### PR TITLE
Fix `subset` by permuting over elements instead of matchers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Change Log
 All notable changes to this project will be documented in this file. This change log follows the conventions of [keepachangelog.com](http://keepachangelog.com/).
 
-## [Unreleased]
+## [0.1.1-SNAPSHOT]
+- fix `subset` issue where order of elements effected behavior
+
+## [0.1.0-SNAPSHOT]
 - Project init

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject nubank/matcher-combinators "0.1.0-SNAPSHOT"
+(defproject nubank/matcher-combinators "0.1.1-SNAPSHOT"
   :description "Library for creating matcher combinator to compare nested data structures"
   :url "https://github.com/nubank/matcher-combinators"
   :license {:name "Apache License, Version 2.0"}

--- a/src/matcher_combinators/core.clj
+++ b/src/matcher_combinators/core.clj
@@ -121,15 +121,22 @@
         (recur (remove #{matching-matcher} matchers) rest-elements subset?)))))
 
 (defn- match-all-permutations [matchers elements subset?]
-  (helpers/find-first (fn [matchers] (matches-in-any-order? matchers elements subset?))
-              (helpers/permutations matchers)))
+  (helpers/find-first
+    (fn [elements] (matches-in-any-order? matchers elements subset?))
+    (helpers/permutations elements)))
+
+(defn- incorrect-matcher->element-count?
+  [subset? matcher-count element-count]
+  (if subset?
+    (> matcher-count element-count)
+    (not (= matcher-count element-count))))
 
 (defn- match-any-order [expected actual subset?]
   (cond
     (not (sequential? actual))
     [:mismatch (model/->Mismatch expected actual)]
 
-    (and (not subset?) (not (= (count expected) (count actual))))
+    (incorrect-matcher->element-count? subset? (count expected) (count actual))
     ;; for size mismatch, is there a more detailed mismatch model to use?
     [:mismatch (model/->Mismatch expected actual)]
 

--- a/test/matcher_combinators/core_test.clj
+++ b/test/matcher_combinators/core_test.clj
@@ -1,6 +1,6 @@
 (ns matcher-combinators.core-test
   (:require [midje.sweet :refer :all :exclude [exactly]]
-            [matcher-combinators.core :refer :all]
+            [matcher-combinators.core :as core :refer :all]
             [matcher-combinators.matchers :refer :all]
             [matcher-combinators.model :as model]))
 
@@ -253,3 +253,14 @@
 
 
 (future-fact "on contains-elements sequence matcher")
+
+(let [matchers [(core/->Predicate odd? 'odd?)
+                (core/->Predicate even? 'even?)]]
+  (fact "subset will recur on matchers"
+    (#'core/matches-in-any-order? matchers [5 4 1 2] true) => truthy
+    (#'core/matches-in-any-order? matchers [5 1 3 2] true) => falsey)
+  (fact "mismatch if there are more matchers than actual elements"
+    (#'core/match-any-order matchers [5] false)
+    => [:mismatch (model/->Mismatch matchers [5])]
+    (#'core/match-any-order matchers [5] true)
+    => [:mismatch (model/->Mismatch matchers [5])]))

--- a/test/matcher_combinators/midje_test.clj
+++ b/test/matcher_combinators/midje_test.clj
@@ -101,3 +101,9 @@
     (f [1 2 3]) => 1
     (provided
       (f short-list) => 1)))
+
+(fact "match-any-order subset"
+  [5 4 1 2 3] => (ch/match (m/subset [odd? even? odd?])))
+
+(fact
+  [5 1 4 2] => (ch/match (m/subset [odd? even?])))

--- a/test/matcher_combinators/midje_test.clj
+++ b/test/matcher_combinators/midje_test.clj
@@ -82,6 +82,7 @@
       [5 1 4 2] => (ch/match (m/subset [1 5]))
       [5 1 4 2] => (ch/match (m/subset [5 1 4 2]))
       [5 1 4 2] => (ch/match (m/subset [1 5 2 4]))
+      [5 1 4 2] => (ch/match (m/subset [odd? even?]))
       [5 1 4 2] =not=> (ch/match (m/subset [5 1 4 2 6])))
 
 (fact "Find optimal in-any-order matching just like midje"
@@ -101,9 +102,3 @@
     (f [1 2 3]) => 1
     (provided
       (f short-list) => 1)))
-
-(fact "match-any-order subset"
-  [5 4 1 2 3] => (ch/match (m/subset [odd? even? odd?])))
-
-(fact
-  [5 1 4 2] => (ch/match (m/subset [odd? even?])))


### PR DESCRIPTION
Fix for https://github.com/nubank/matcher-combinators/issues/2