### PR TITLE
Parse lists as equals-seq, same as we do for vectors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 # Change Log
 All notable changes to this project will be documented in this file. This change log follows the conventions of [keepachangelog.com](http://keepachangelog.com/).
 
+## [0.1.2-SNAPSHOT]
+- update parser to interpret lists as equals-seq matcher-combinators
+
 ## [0.1.1-SNAPSHOT]
 - fix `subset` issue where order of elements effected behavior
 

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject nubank/matcher-combinators "0.1.1-SNAPSHOT"
+(defproject nubank/matcher-combinators "0.1.2-SNAPSHOT"
   :description "Library for creating matcher combinator to compare nested data structures"
   :url "https://github.com/nubank/matcher-combinators"
   :license {:name "Apache License, Version 2.0"}
@@ -12,4 +12,4 @@
   :profiles {:dev {:dependencies [[colorize "0.1.1" :exclusions [org.clojure/clojure]]
                                   [org.clojure/test.check "0.9.0"]
                                   [org.clojure/tools.namespace "0.2.11"]
-                                  [midje "1.9.1" :exclusions [org.clojure/clojure]]]}})
+                                  [midje "1.9.2-alpha1" :exclusions [org.clojure/clojure]]]}})

--- a/src/matcher_combinators/matchers.clj
+++ b/src/matcher_combinators/matchers.clj
@@ -26,7 +26,7 @@
 
   Similar to Midje's `(just expected)`"
   [expected]
-  (assert (vector? expected))
+  (assert (sequential? expected))
   (core/->EqualsSequence expected))
 
 (defn in-any-order

--- a/src/matcher_combinators/parser.clj
+++ b/src/matcher_combinators/parser.clj
@@ -2,7 +2,7 @@
   (:require [matcher-combinators.core :as core]
             [matcher-combinators.matchers :as matchers]
             [matcher-combinators.model :as model])
-  (:import [clojure.lang Keyword Symbol Ratio BigInt IPersistentMap IPersistentVector]
+  (:import [clojure.lang Keyword Symbol Ratio BigInt IPersistentMap IPersistentVector IPersistentList]
            [java.util UUID Date]
            [java.time LocalDate LocalDateTime YearMonth]))
 
@@ -39,3 +39,4 @@
 
 (mimic-matcher matchers/contains-map IPersistentMap)
 (mimic-matcher matchers/equals-seq IPersistentVector)
+(mimic-matcher matchers/equals-seq IPersistentList)

--- a/test/matcher_combinators/core_test.clj
+++ b/test/matcher_combinators/core_test.clj
@@ -265,18 +265,21 @@
     (#'core/match-any-order matchers [5] true)
     => [:mismatch (model/->Mismatch matchers [5])]))
 
-(fact "repro bug"
-  (core/match
-    (in-any-order :a
-                    [{:a {:id 1} :b 42}
-                     {:a {:id 2} :b 1337}])
-    [{:a {:id 1} :b 42}
-     {:a {:id 2} :b 1337}])
-  => [:match [{:a {:id 1} :b 42}
-              {:a {:id 2} :b 1337}]])
+(future-fact "reproducing select? bug"
+  (fact "the bug"
+    (core/match
+      (in-any-order :a [(contains-map {:a (equals-map {:id (equals-value 1)}) :b (equals-value 42)})
+                        (contains-map {:a (equals-map {:id (equals-value 2)}) :b (equals-value 1337)})])
+      [{:a {:id 1} :b 42}
+       {:a {:id 2} :b 1337}])
+    => [:match [{:a {:id 1} :b 42}
+                {:a {:id 2} :b 1337}]])
 
-
-(fact "what about lists?"
-  (matcher-combinators.core/match
-    '(1 2 3)
-    '(1 2 3)))
+  (fact "similar, but works"
+    (core/match
+      (in-any-order :a [(contains-map {:a (equals-value 1) :b (equals-value 42)})
+                        (contains-map {:a (equals-value 2) :b (equals-value 1337)})])
+      [{:a 1 :b 42}
+       {:a 2 :b 1337}])
+    => [:match [{:a 1 :b 42}
+                {:a 2 :b 1337}]]))

--- a/test/matcher_combinators/core_test.clj
+++ b/test/matcher_combinators/core_test.clj
@@ -264,3 +264,19 @@
     => [:mismatch (model/->Mismatch matchers [5])]
     (#'core/match-any-order matchers [5] true)
     => [:mismatch (model/->Mismatch matchers [5])]))
+
+(fact "repro bug"
+  (core/match
+    (in-any-order :a
+                    [{:a {:id 1} :b 42}
+                     {:a {:id 2} :b 1337}])
+    [{:a {:id 1} :b 42}
+     {:a {:id 2} :b 1337}])
+  => [:match [{:a {:id 1} :b 42}
+              {:a {:id 2} :b 1337}]])
+
+
+(fact "what about lists?"
+  (matcher-combinators.core/match
+    '(1 2 3)
+    '(1 2 3)))

--- a/test/matcher_combinators/parser_test.clj
+++ b/test/matcher_combinators/parser_test.clj
@@ -53,3 +53,9 @@
     (= (core/match (equals-seq [10]) [10])
        (core/match (equals-seq [(equals-value 10)]) [10]))
     => truthy))
+
+(fact "lists also act as equals-seq matchers"
+  (fact
+    (= (core/match (equals-seq [(equals-value 10)]) [10])
+       (core/match (equals-seq '(10)) [10])
+       (core/match '(10) [10])) => truthy))

--- a/test/matcher_combinators/parser_test.clj
+++ b/test/matcher_combinators/parser_test.clj
@@ -45,13 +45,15 @@
 (fact "maps act as equals-map matchers"
   (fact
     (= (core/match (equals-map {:a (equals-value 10)}) {:a 10})
-       (core/match (equals-map {:a 10}) {:a 10}))
+       (core/match (equals-map {:a 10}) {:a 10})
+       (core/match {:a 10} {:a 10}))
     => truthy))
 
 (fact "vectors act as equals-seq matchers"
   (fact
-    (= (core/match (equals-seq [10]) [10])
-       (core/match (equals-seq [(equals-value 10)]) [10]))
+    (= (core/match (equals-seq [(equals-value 10)]) [10])
+       (core/match (equals-seq [10]) [10])
+       (core/match [10] [10]))
     => truthy))
 
 (fact "lists also act as equals-seq matchers"


### PR DESCRIPTION
The use case was for checking a function that returned
the result of schema.core/explain.

Something like
```
(fact
  (s/explain {:a (s/enum :foo)}) => (match {:a '(s/enum :foo)}))
```

Felt weird to write
```
(fact
  (s/explain {:a (s/enum :foo)}) => (match {:a [s/enum :foo]}))
```
even though it matches in the same way.

An alternative would be to parse lists as `equals-value`, just like
primitives.