### PR TITLE
Define 'match' checker in terms of defchecker

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 # Change Log
 All notable changes to this project will be documented in this file. This change log follows the conventions of [keepachangelog.com](http://keepachangelog.com/).
 
+## [0.1.4-SNAPSHOT]
+- Don't define `matcher-combinators.midje/matcher` as a macro; it isn't needed
+
 ## [0.1.3-SNAPSHOT]
 - Allow inline use of `match` inside of `midje` `provided` forms
 

--- a/project.clj
+++ b/project.clj
@@ -12,4 +12,4 @@
   :profiles {:dev {:dependencies [[colorize "0.1.1" :exclusions [org.clojure/clojure]]
                                   [org.clojure/test.check "0.9.0"]
                                   [org.clojure/tools.namespace "0.2.11"]
-                                  [midje "1.9.2-alpha1" :exclusions [org.clojure/clojure]]]}})
+                                  [midje "1.9.2-alpha2" :exclusions [org.clojure/clojure]]]}})

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject nubank/matcher-combinators "0.1.3-SNAPSHOT"
+(defproject nubank/matcher-combinators "0.1.4-SNAPSHOT"
   :description "Library for creating matcher combinator to compare nested data structures"
   :url "https://github.com/nubank/matcher-combinators"
   :license {:name "Apache License, Version 2.0"}

--- a/src/matcher_combinators/core.clj
+++ b/src/matcher_combinators/core.clj
@@ -38,13 +38,6 @@
      (= expected actual)  [:match actual]
      :else                [:mismatch (model/->Mismatch expected actual)])))
 
-(defrecord Predicate [func form]
-  Matcher
-  (match [_this actual]
-    (if (func actual)
-      [:match actual]
-      [:mismatch (model/->FailedPredicate form actual)])))
-
 (defn- compare-maps [expected actual unexpected-handler allow-unexpected?]
   (let [entry-results      (map (fn [[key matcher-or-pred]]
                                   [key (match matcher-or-pred

--- a/src/matcher_combinators/midje.clj
+++ b/src/matcher_combinators/midje.clj
@@ -16,11 +16,9 @@
         true
         (checking/as-data-laden-falsehood {:notes [(printer/as-string result)]})))))
 
-(defmacro ^{:midje/checker true} match [matcher-form]
-  `(checkers.defining/as-checker
-     (fn [actual#]
-       (let [matcher# ~matcher-form]
-         (if (core/matcher? matcher#)
-           (check-match matcher# actual#)
-           (ex-info "Input wasn't a matcher" {:input matcher#}))))))
 
+(checkers.defining/defchecker match [matcher]
+  (checkers.defining/checker [actual]
+    (if (core/matcher? matcher)
+      (check-match matcher actual)
+      (ex-info "Input wasn't a matcher" {:input matcher}))))

--- a/test/matcher_combinators/core_test.clj
+++ b/test/matcher_combinators/core_test.clj
@@ -254,8 +254,7 @@
 
 (future-fact "on contains-elements sequence matcher")
 
-(let [matchers [(core/->Predicate odd? 'odd?)
-                (core/->Predicate even? 'even?)]]
+(let [matchers [odd? even?]]
   (fact "subset will recur on matchers"
     (#'core/matches-in-any-order? matchers [5 4 1 2] true) => truthy
     (#'core/matches-in-any-order? matchers [5 1 3 2] true) => falsey)


### PR DESCRIPTION
Follow up to https://github.com/nubank/matcher-combinators/pull/5#discussion_r159091226

I believe I had implemented `matcher-combinators.midje/match` as a macro because I was trying to get it to capture form information about predicate functions. This didn't pan out (seems way too hard to do) so let's make it be a normal function instead of a macro.

When I say 'capture form information about predicate functions', I mean the following:
```clojure
(fact
  1 => (match (fn [x] (= x 2))))
```
would show ` (fn [x] (= x 2))` in the matcher-combinator error message, instead of just 
```
FAIL at (form-init1300508260004661418.clj:1)
Actual result did not agree with the checking function.
Actual result:
1
Checking function: (m/match (fn [x] (= x 2)))
    The checker said this about the reason:
        [:mismatch
 (predicate
  "user$eval11756$fn__11757$fn__11758$fn__11761@2a235fc4"
  1)]
```
Midje luckily shows us the checker code, but we don't get that with `clojure.test`:

```clojure
(deftest basic-matching
  (is (match? (ma/equals-seq [1 (fn [x] (even? x))]) [1 3])))

;; FAIL in (basic-matching) (form-init1300508260004661418.clj:2)
;; mismatch:
;; (1 (predicate "user$fn__11825$fn__11829@193f011a" 3))
```