### PR TITLE
Add Double to parser and make midje checker fail correctly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 # Change Log
 All notable changes to this project will be documented in this file. This change log follows the conventions of [keepachangelog.com](http://keepachangelog.com/).
 
+## [0.1.5-SNAPSHOT]
+- Interpret Double as `matcher-combinators.matchers/equals-value` in parser.
+- Make Midje checker fail correctly when passed a non-matcher
+
 ## [0.1.4-SNAPSHOT]
 - Don't define `matcher-combinators.midje/matcher` as a macro; it isn't needed
 

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject nubank/matcher-combinators "0.1.4-SNAPSHOT"
+(defproject nubank/matcher-combinators "0.1.5-SNAPSHOT"
   :description "Library for creating matcher combinator to compare nested data structures"
   :url "https://github.com/nubank/matcher-combinators"
   :license {:name "Apache License, Version 2.0"}

--- a/src/matcher_combinators/midje.clj
+++ b/src/matcher_combinators/midje.clj
@@ -16,9 +16,9 @@
         true
         (checking/as-data-laden-falsehood {:notes [(printer/as-string result)]})))))
 
-
 (checkers.defining/defchecker match [matcher]
   (checkers.defining/checker [actual]
     (if (core/matcher? matcher)
       (check-match matcher actual)
-      (ex-info "Input wasn't a matcher" {:input matcher}))))
+      (checking/as-data-laden-falsehood
+        {:notes [(str "Input wasn't a matcher: " matcher)]}))))

--- a/src/matcher_combinators/parser.clj
+++ b/src/matcher_combinators/parser.clj
@@ -22,6 +22,7 @@
 
 (mimic-matcher matchers/equals-value
                Long
+               Double
                String
                Symbol
                Keyword

--- a/test/matcher_combinators/midje_test.clj
+++ b/test/matcher_combinators/midje_test.clj
@@ -117,3 +117,45 @@
           (provided
             (f (ch/match (m/equals-seq [int? int? int?]))) => 1)))
       => falsey)))
+
+
+(def now (java.time.LocalDateTime/now))
+(def an-id-string "67b22046-7e9f-46b2-a3b9-e68618242864")
+(def an-id (java.util.UUID/fromString an-id-string))
+(def another-id (java.util.UUID/fromString "8f488446-374e-4975-9670-35ca0a633da1"))
+(def response-time (java.time.LocalDateTime/now))
+
+(def nested-map
+ {:id {:type :user-id
+       :value an-id-string}
+ :input {:id {:type :user-id
+              :value an-id-string}
+         :timestamp now
+         :trigger "blabla"}
+ :model "sampa_v3"
+ :output {:sampa-score 123.4M
+          :user-id another-id
+          :w-alpha -0.123}
+ :response-time response-time
+ :version "1.33.7"})
+
+(fact "match nested maps with UUID, LocalDateTime, BigDecimal, and Double values"
+  nested-map
+  => (ch/match {:id {:type :user-id
+                     :value an-id-string}
+                :input {:id {:type keyword?
+                             :value an-id-string}
+                        :timestamp now}
+                :model "sampa_v3"
+                :output {:sampa-score 123.4M
+                         :user-id another-id
+                         :w-alpha -0.123}
+                :response-time response-time
+                :version string?}))
+
+(def an-object (Object.))
+(fact "Objects aren't matchers, so matching on them shouldn't work and produce
+       an informative error"
+  an-object => (ch/match (m/equals-value an-object))
+  an-object =not=> (ch/match an-object)
+  (Object.) =not=> (ch/match (Object.)))


### PR DESCRIPTION
Matching wasn't working with `Double`s. Fix was to add it to the parser to be interpreted as `matcher-combinators.matchers/equals-value`

Also, when midje `match` checker was passed a non-matcher, it wasn't failing correctly. Now it prints the failure message correctly