### PR TITLE
Fix in-any-order to work with identical matchers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 # Change Log
 All notable changes to this project will be documented in this file. This change log follows the conventions of [keepachangelog.com](http://keepachangelog.com/).
 
+## [0.1.6-SNAPSHOT]
+- Fix issue where `in-any-order` operating over a list with several identical matchers failed
+
 ## [0.1.5-SNAPSHOT]
 - Interpret Double as `matcher-combinators.matchers/equals-value` in parser.
 - Make Midje checker fail correctly when passed a non-matcher
@@ -12,10 +15,10 @@ All notable changes to this project will be documented in this file. This change
 - Allow inline use of `match` inside of `midje` `provided` forms
 
 ## [0.1.2-SNAPSHOT]
-- update parser to interpret lists as equals-seq matcher-combinators
+- Update parser to interpret lists as equals-seq matcher-combinators
 
 ## [0.1.1-SNAPSHOT]
-- fix `subset` issue where order of elements effected behavior
+- Fix `subset` issue where order of elements effected behavior
 
 ## [0.1.0-SNAPSHOT]
 - Project init

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject nubank/matcher-combinators "0.1.5-SNAPSHOT"
+(defproject nubank/matcher-combinators "0.1.6-SNAPSHOT"
   :description "Library for creating matcher combinator to compare nested data structures"
   :url "https://github.com/nubank/matcher-combinators"
   :license {:name "Apache License, Version 2.0"}

--- a/src/matcher_combinators/core.clj
+++ b/src/matcher_combinators/core.clj
@@ -111,7 +111,9 @@
                              matchers)]
       (if (nil? matching-matcher)
         false
-        (recur (remove #{matching-matcher} matchers) rest-elements subset?)))))
+        (recur (helpers/remove-first #{matching-matcher} matchers)
+               rest-elements
+               subset?)))))
 
 (defn- match-all-permutations [matchers elements subset?]
   (helpers/find-first

--- a/src/matcher_combinators/helpers.clj
+++ b/src/matcher_combinators/helpers.clj
@@ -12,8 +12,5 @@
 (defn remove-first
   "Similar to `remove` but stops after removing 1 element"
   [pred coll]
-  (letfn [(remover [[no-removes? & acc] elem]
-            (if (and no-removes? (pred elem))
-              (cons false acc)
-              (cons no-removes? (cons elem acc))))]
-    (reverse (rest (reduce remover [true] coll)))))
+  (let [[x [y & z]] (split-with (complement pred) coll)]
+    (concat x z)))

--- a/src/matcher_combinators/helpers.clj
+++ b/src/matcher_combinators/helpers.clj
@@ -8,3 +8,12 @@
   [coll]
   (for [i (range 0 (count coll))]
     (lazy-cat (drop i coll) (take i coll))))
+
+(defn remove-first
+  "Similar to `remove` but stops after removing 1 element"
+  [pred coll]
+  (letfn [(remover [[no-removes? & acc] elem]
+            (if (and no-removes? (pred elem))
+              (cons false acc)
+              (cons no-removes? (cons elem acc))))]
+    (reverse (rest (reduce remover [true] coll)))))

--- a/test/matcher_combinators/core_test.clj
+++ b/test/matcher_combinators/core_test.clj
@@ -148,6 +148,10 @@
         (match (in-any-order [(equals-value 1) (equals-value 2)]) [1 2 3])
         => [:mismatch (model/->Mismatch [(equals-value 1) (equals-value 2)] [1 2 3])])
 
+      (facts "in-any-order for list of same value/matchers"
+        (match (in-any-order [(equals-value 2) (equals-value 2)]) [2 2])
+        => [:match [2 2]])
+
       (facts "when the given sequence contains elements not matched by any
              matcher, marks the whole sequence as a mismatch"
         (match (in-any-order [(equals-value 1) (equals-value 2)]) [1 2 3])
@@ -258,6 +262,9 @@
   (fact "subset will recur on matchers"
     (#'core/matches-in-any-order? matchers [5 4 1 2] true) => truthy
     (#'core/matches-in-any-order? matchers [5 1 3 2] true) => falsey)
+  (fact "works well with identical matchers"
+    (#'core/matches-in-any-order? [(equals-value 2) (equals-value 2)] [2 2] false)
+    => truthy)
   (fact "mismatch if there are more matchers than actual elements"
     (#'core/match-any-order matchers [5] false)
     => [:mismatch (model/->Mismatch matchers [5])]

--- a/test/matcher_combinators/helpers_test.clj
+++ b/test/matcher_combinators/helpers_test.clj
@@ -1,0 +1,12 @@
+(ns matcher-combinators.helpers-test
+  (:require [midje.sweet :refer :all]
+            [matcher-combinators.helpers :as helpers]))
+
+(fact "remove-first impl"
+  (helpers/remove-first #{1} [3 2 1 1 0]) => [3 2 1 0]
+  (helpers/remove-first #{2} [3 2 1 1 0]) => [3 1 1 0]
+  (helpers/remove-first #{1 2} [3 2 1 1 0]) => [3 1 1 0]
+  (helpers/remove-first (constantly false) [3 2 1 1 0]) => [3 2 1 1 0]
+  (helpers/remove-first (constantly true) [3 2 1 1 0]) => [2 1 1 0]
+  (helpers/remove-first (constantly true) []) => []
+  (helpers/remove-first (constantly false) []) => [])

--- a/test/matcher_combinators/parser_test.clj
+++ b/test/matcher_combinators/parser_test.clj
@@ -18,6 +18,7 @@
 (def gen-scalar (gen/one-of [gen/int
                              gen/string
                              gen/symbol
+                             gen/double
                              gen/symbol-ns
                              gen/keyword
                              gen/boolean


### PR DESCRIPTION
The following would fail because the code used `clojure.core/remove` when removing tested matchers in the in-any-order matcher permutation recursion step. `remove` will take out all entries, so both `2` matchers were incorrectly removed.

 ```clojure
(match (in-any-order [2 2]) [2 2])
```