### PR TITLE
Move dependencies out of `:dev` profile and into main profile

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ All notable changes to this project will be documented in this file. This change
 ## [0.1.6-SNAPSHOT]
 - Fix issue where `in-any-order` operating over a list with several identical matchers failed
 - Extend `nil` to be interpreted as `equals-value` by parser
+- Include needed dependencies outside of `:dev` profile
 
 ## [0.1.5-SNAPSHOT]
 - Interpret Double as `matcher-combinators.matchers/equals-value` in parser.

--- a/project.clj
+++ b/project.clj
@@ -8,8 +8,9 @@
 
   :plugins [[lein-midje "3.2.1"]
             [lein-ancient "0.6.14"]]
-  :dependencies [[org.clojure/clojure "1.9.0"]]
-  :profiles {:dev {:dependencies [[colorize "0.1.1" :exclusions [org.clojure/clojure]]
-                                  [org.clojure/test.check "0.9.0"]
-                                  [org.clojure/tools.namespace "0.2.11"]
-                                  [midje "1.9.2-alpha2" :exclusions [org.clojure/clojure]]]}})
+
+  :dependencies [[org.clojure/clojure "1.9.0"]
+                 [colorize "0.1.1" :exclusions [org.clojure/clojure]]
+                 [midje "1.9.2-alpha2" :exclusions [org.clojure/clojure]]]
+
+  :profiles {:dev {:dependencies [[org.clojure/test.check "0.9.0"]]}})


### PR DESCRIPTION
Was trying to pull `matcher-combinators` into a repository that didn't depend on `midje` and `colorize` failed to be found. This made me realized that we weren't correctly setting up the project dependencies because everything was in the `:dev` profile.

Also removed the ` [org.clojure/tools.namespace "0.2.11"] ` dependency