### PR TITLE
Preserve sequence type in mismatch output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ All notable changes to this project will be documented in this file. This change
 - Fix issue where `in-any-order` operating over a list with several identical matchers failed
 - Extend `nil` to be interpreted as `equals-value` by parser
 - Include needed dependencies outside of `:dev` profile
+- Make mismatch output preserve sequence type
 
 ## [0.1.5-SNAPSHOT]
 - Interpret Double as `matcher-combinators.matchers/equals-value` in parser.

--- a/src/matcher_combinators/core.clj
+++ b/src/matcher_combinators/core.clj
@@ -97,7 +97,7 @@
                               (max (count actual) (count expected)))
             match-results   (take match-size match-results')]
         (if (some mismatch? match-results)
-          [:mismatch (map value match-results)]
+          [:mismatch (into (empty actual) (map value match-results))]
           [:match actual]))))
 
 (defrecord EqualsSequence [expected]

--- a/test/matcher_combinators/core_test.clj
+++ b/test/matcher_combinators/core_test.clj
@@ -198,6 +198,17 @@
       [[1 5] 21])
     => [:mismatch [[1 (model/->Mismatch 2 5)] (model/->Mismatch 20 21)]])
 
+  (fact "sequence type is preserved in mismatch output"
+    (-> (equals-seq [(equals-seq [(equals-value 1)])])
+        (match [[2]])
+        second)
+    => #(instance? (class (vector)) %)
+
+    (-> (equals-seq [(equals-seq [(equals-value 1)])])
+        (match (list [2]))
+        second)
+    => #(instance? (class (list 'placeholder)) %))
+
   (fact "nesting in-any-order matchers"
     (match
       (in-any-order [(equals-map {:id (equals-value 1) :a (equals-value 1)})


### PR DESCRIPTION
Mismatched sequences would always print using parenthesis, so it was hard to tell when you were actually dealing with vectors.

Before
```
Actual result:
[[[1]]]
Checking function: (ch/match [[[even?]]])
    The checker said this about the reason:
        [:mismatch
 ((((predicate
     "clojure.core$even_QMARK_@7d3bfe75"
     1))))]
```

After
```
Actual result:
[[[1]]]
Checking function: (ch/match [[[even?]]])
    The checker said this about the reason:
        [:mismatch
 [[[(predicate
     "clojure.core$even_QMARK_@7d3bfe75"
     1)]]]]
```