### PR TITLE
When matcher has invalid input, fail matching without throwing exception

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 # Change Log
 All notable changes to this project will be documented in this file. This change log follows the conventions of [keepachangelog.com](http://keepachangelog.com/).
 
+## [0.1.7]
+- When matcher is provided with incorrect input, cause matcher to fail, but don't raise exception
+
 ## [0.1.6-SNAPSHOT]
 - Fix issue where `in-any-order` operating over a list with several identical matchers failed
 - Extend `nil` to be interpreted as `equals-value` by parser

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject nubank/matcher-combinators "0.1.6-SNAPSHOT"
+(defproject nubank/matcher-combinators "0.1.7"
   :description "Library for creating matcher combinator to compare nested data structures"
   :url "https://github.com/nubank/matcher-combinators"
   :license {:name "Apache License, Version 2.0"}

--- a/src/matcher_combinators/core.clj
+++ b/src/matcher_combinators/core.clj
@@ -42,6 +42,22 @@
      (= expected actual)  [:match actual]
      :else                [:mismatch (model/->Mismatch expected actual)])))
 
+(defn- validate-input
+  [expected actual pred matcher-name type]
+    (cond
+      (not (pred expected))
+      [:mismatch (model/->InvalidMatcherType
+                   (str "provided: " expected)
+                   (str matcher-name
+                        " should be called with 'expected' argument of type: "
+                        type))]
+
+      (not (pred actual))
+      [:mismatch (model/->Mismatch expected actual)]
+
+      :else
+      nil))
+
 (defn- compare-maps [expected actual unexpected-handler allow-unexpected?]
   (let [entry-results      (map (fn [[key matcher]]
                                   [key (match matcher (get actual key ::missing))])
@@ -58,11 +74,6 @@
                       (concat unexpected-entries)
                       (into actual))])))
 
-(defn- match-map [expected actual unexpected-handler matcher-type]
-  (if-not (map? actual)
-    [:mismatch (model/->Mismatch expected actual)]
-    (compare-maps expected actual unexpected-handler matcher-type)))
-
 (defrecord ContainsMap [expected]
   Matcher
   (select? [this select-fn candidate]
@@ -70,7 +81,9 @@
           selected-value   (select-fn candidate)]
       (select? selected-matcher select-fn selected-value)))
   (match [_this actual]
-    (match-map expected actual identity true)))
+    (if-let [validation-issue (validate-input expected actual map? 'contains-map 'map)]
+      validation-issue
+      (compare-maps expected actual identity true))))
 
 (defrecord EqualsMap [expected]
   Matcher
@@ -79,7 +92,9 @@
           selected-value   (select-fn candidate)]
       (select? selected-matcher select-fn selected-value)))
   (match [_this actual]
-    (match-map expected actual model/->Unexpected false)))
+    (if-let [validation-issue (validate-input expected actual map? 'equals-map 'map)]
+      validation-issue
+      (compare-maps expected actual model/->Unexpected false))))
 
 (defn- sequence-match [expected actual subseq?]
   (if-not (sequential? actual)
@@ -103,7 +118,9 @@
 (defrecord EqualsSequence [expected]
   Matcher
   (match [_this actual]
-    (sequence-match expected actual false)))
+    (if-let [validation-issue (validate-input expected actual sequential? 'equals-seq 'sequential)]
+      validation-issue
+      (sequence-match expected actual false))))
 
 (defn- matches-in-any-order? [matchers elements subset?]
   (if (empty? matchers)
@@ -147,7 +164,9 @@
 (defrecord InAnyOrder [expected]
   Matcher
   (match [_this actual]
-    (match-any-order expected actual false)))
+    (if-let [validation-issue (validate-input expected actual sequential? 'in-any-order 'sequential)]
+      validation-issue
+      (match-any-order expected actual false))))
 
 (defn- base-selecting-match [matchers matching? matched-elements]
   (if (empty? matchers)
@@ -175,16 +194,20 @@
 (defrecord SelectingInAnyOrder [select-fn expected]
   Matcher
   (match [_this actual]
-    (if-not (sequential? actual)
-      [:mismatch (model/->Mismatch expected actual)]
+    (if-let [validation-issue (validate-input expected actual sequential? 'in-any-order 'sequential)]
+      validation-issue
       (selecting-match select-fn expected actual))))
 
 (defrecord SubSeq [expected]
   Matcher
   (match [_this actual]
-    (sequence-match expected actual true)))
+    (if-let [validation-issue (validate-input expected actual sequential? 'sublist 'sequential)]
+      validation-issue
+      (sequence-match expected actual true))))
 
 (defrecord SubSet [expected]
   Matcher
   (match [_this actual]
-    (match-any-order expected actual true)))
+    (if-let [validation-issue (validate-input expected actual sequential? 'subset 'sequential)]
+      validation-issue
+      (match-any-order expected actual true))))

--- a/src/matcher_combinators/matchers.clj
+++ b/src/matcher_combinators/matchers.clj
@@ -18,7 +18,6 @@
     1. the keys of the `expected` map are equal to the given map's keys
     2. the value matchers of `expected` map matches the given map's values"
   [expected]
-  (assert (map? expected))
   (core/->EqualsMap expected))
 
 (defn equals-seq
@@ -26,7 +25,6 @@
 
   Similar to Midje's `(just expected)`"
   [expected]
-  (assert (sequential? expected))
   (core/->EqualsSequence expected))
 
 (defn in-any-order
@@ -48,7 +46,6 @@
 
   Similar to Midje's `(contains expected)`"
   [expected]
-  (assert (vector? expected))
   (core/->SubSeq expected))
 
 (defn subset
@@ -57,5 +54,4 @@
 
   Similar to Midje's `(contains expected :in-any-order :gaps-ok)`"
   [expected]
-  (assert (vector? expected))
   (core/->SubSet expected))

--- a/src/matcher_combinators/model.clj
+++ b/src/matcher_combinators/model.clj
@@ -3,4 +3,5 @@
 (defrecord Mismatch [expected actual])
 (defrecord Missing  [expected])
 (defrecord Unexpected [actual])
+(defrecord InvalidMatcherType [provided expected-type-msg])
 (defrecord FailedPredicate [form actual])

--- a/src/matcher_combinators/printer.clj
+++ b/src/matcher_combinators/printer.clj
@@ -3,14 +3,16 @@
   (:require [clojure.pprint :as pprint]
             [matcher-combinators.model :as model]
             [colorize.core :as colorize])
-  (:import [matcher_combinators.model Mismatch Missing Unexpected FailedPredicate]))
+  (:import [matcher_combinators.model Mismatch Missing Unexpected FailedPredicate InvalidMatcherType]))
 
 (defrecord ColorTag [color expression])
 
 (defmulti markup-expression class)
 
 (defmethod markup-expression Mismatch [mismatch]
-  (list 'mismatch (->ColorTag :yellow (:expected mismatch)) (->ColorTag :red (:actual mismatch))))
+  (list 'mismatch
+        (->ColorTag :yellow (:expected mismatch))
+        (->ColorTag :red (:actual mismatch))))
 
 (defmethod markup-expression Missing [missing]
   (list 'missing (->ColorTag :red (:expected missing))))
@@ -19,7 +21,14 @@
   (list 'unexpected (->ColorTag :red (:actual unexpected))))
 
 (defmethod markup-expression FailedPredicate [failed-predicate]
-  (list 'predicate (->ColorTag :yellow (:form failed-predicate)) (->ColorTag :red (:actual failed-predicate))))
+  (list 'predicate
+        (->ColorTag :yellow (:form failed-predicate))
+        (->ColorTag :red (:actual failed-predicate))))
+
+(defmethod markup-expression InvalidMatcherType [invalid-type]
+  (list 'invalid-matcher-input
+        (->ColorTag :yellow (:expected-type-msg invalid-type))
+        (->ColorTag :red (:provided invalid-type))))
 
 (defmethod markup-expression :default [expression]
   expression)

--- a/test/matcher_combinators/core_test.clj
+++ b/test/matcher_combinators/core_test.clj
@@ -309,3 +309,19 @@
        {:a 2 :b 1337}])
     => [:match [{:a 1 :b 42}
                 {:a 2 :b 1337}]]))
+
+(tabular
+  (fact "Providing seq/map matcher with incorrect input leads to automatic mismatch"
+    (core/match (?matcher 1) 1)
+    => (just [:mismatch
+              (contains {:expected-type-msg
+                         #(clojure.string/starts-with? % (-> ?matcher var meta :name str))
+
+                         :provided
+                         "provided: 1"})]))
+  ?matcher
+  equals-seq
+  sublist
+  subset
+  equals-map
+  contains-map)


### PR DESCRIPTION
| before | after |
| ---- | ---- |
| ![before](https://user-images.githubusercontent.com/94817/36028172-4f893228-0d9e-11e8-9641-6b9713309f2c.png) | ![after](https://user-images.githubusercontent.com/94817/36028174-51847240-0d9e-11e8-94e7-d7d995ad2af7.png) |

