### PR TITLE
Remove select? from Matcher protocol

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ All notable changes to this project will be documented in this file. This change
 ## [0.1.6-SNAPSHOT]
 - Fix issue where `in-any-order` operating over a list with several identical matchers failed
 - Extend `nil` to be interpreted as `equals-value` by parser
+- Include needed dependencies outside of `:dev` profile
 
 ## [0.1.5-SNAPSHOT]
 - Interpret Double as `matcher-combinators.matchers/equals-value` in parser.

--- a/project.clj
+++ b/project.clj
@@ -8,8 +8,9 @@
 
   :plugins [[lein-midje "3.2.1"]
             [lein-ancient "0.6.14"]]
-  :dependencies [[org.clojure/clojure "1.9.0"]]
-  :profiles {:dev {:dependencies [[colorize "0.1.1" :exclusions [org.clojure/clojure]]
-                                  [org.clojure/test.check "0.9.0"]
-                                  [org.clojure/tools.namespace "0.2.11"]
-                                  [midje "1.9.2-alpha2" :exclusions [org.clojure/clojure]]]}})
+
+  :dependencies [[org.clojure/clojure "1.9.0"]
+                 [colorize "0.1.1" :exclusions [org.clojure/clojure]]
+                 [midje "1.9.2-alpha2" :exclusions [org.clojure/clojure]]]
+
+  :profiles {:dev {:dependencies [[org.clojure/test.check "0.9.0"]]}})

--- a/src/matcher_combinators/core.clj
+++ b/src/matcher_combinators/core.clj
@@ -24,8 +24,6 @@
   Matcher
   (match [_this actual]
    (cond
-     (and (nil? expected)
-          (nil? actual))  [:match nil]
      (= ::missing actual) [:mismatch (model/->Missing expected)]
      (= expected actual)  [:match actual]
      :else                [:mismatch (model/->Mismatch expected actual)])))
@@ -38,7 +36,7 @@
                                    (when-not (find expected key)
                                      [key (unexpected-handler val)]))
                                  actual)]
-    (if (and (every? (comp match? value) entry-results)
+    (if (and (every? (comp match? second) entry-results)
              (or allow-unexpected? (empty? unexpected-entries)))
       [:match actual]
       [:mismatch (->> entry-results

--- a/src/matcher_combinators/matchers.clj
+++ b/src/matcher_combinators/matchers.clj
@@ -33,14 +33,8 @@
   "Matcher that will match when the given a list that is the same as the
   `expected` list but with elements in a different order.
 
-  `select-fn`: optional argument used to anchoring specific substructures to
-               clarify mismatch output
-
   Similar to Midje's `(just expected :in-any-order)`"
-  ([expected]
-   (core/->InAnyOrder expected))
-  ([select-fn expected]
-   (core/->SelectingInAnyOrder select-fn expected)))
+  [expected] (core/->InAnyOrder expected))
 
 (defn sublist
   "Matcher that will match when provided a (ordered) prefix of the `expected`


### PR DESCRIPTION
I don't think `select?` is needed with the changes in https://github.com/nubank/matcher-combinators/pull/10