### PR TITLE
Rename matchers and implement set matchers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,11 +5,11 @@ All notable changes to this project will be documented in this file. This change
 - _BREAKING_:
   - rename `equals-map`, `equals-seq`, and `equals-value` to all be `equals`
     and do dispatch based on type
-  - rename `sublist` to `prefix-seq`
+  - rename `sublist` to `prefix`
   - rename `subset` sequence matcher to be `embeds`
   - rename `contains-map` to `embeds` and make it do dispatch based on type
-- implement matchers for sets: `equals` and `embeds` as well as `equals-set`
-  and `embeds-set` which allow one to use sequences to match sets, skirting the
+- implement matchers for sets: `equals` and `embeds` as well as `set-equals`
+  and `set-embeds` which allow one to use sequences to match sets, skirting the
   issue that a set matcher of form `#{odd? odd?}` will reduce to `#{odd?}`.
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,18 @@
 # Change Log
 All notable changes to this project will be documented in this file. This change log follows the conventions of [keepachangelog.com](http://keepachangelog.com/).
 
+## [0.2.0]
+- _BREAKING_:
+  - rename `equals-map`, `equals-seq`, and `equals-value` to all be `equals`
+    and do dispatch based on type
+  - rename `sublist` to `prefix-seq`
+  - rename `subset` sequence matcher to be `embeds`
+  - rename `contains-map` to `embeds` and make it do dispatch based on type
+- implement matchers for sets: `equals` and `embeds` as well as `equals-set`
+  and `embeds-set` which allow one to use sequences to match sets, skirting the
+  issue that a set matcher of form `#{odd? odd?}` will reduce to `#{odd?}`.
+
+
 ## [0.1.7]
 - Adapt `in-any-order` to print diff for element ordering that leads to most direct matches
 - When matcher is provided with incorrect input, cause matcher to fail, but don't raise exception

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ For example:
          '[matcher-combinators.matchers :as m]
          '[matcher-combinators.midje :refer [match]])
 (fact "matching a map exactly"
-  {:a {:bb 1} :c 2} => (match (m/equals-map {:a {:bb 1} :c 2})))
+  {:a {:bb 1} :c 2} => (match (m/equals {:a {:bb 1} :c 2})))
 
 (fact "loosely matching a map"
   ;; by default a map is interpreted as a `contains-map` matcher

--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ For example:
 (deftest basic-sequence-matching
   ;; by default a vector is interpreted as a `equals-seq` matcher
   (is (match? [1 odd?] [1 3]))
-  (is (match? (m/sublist [1 odd?]) [1 1 2 3])))
+  (is (match? (m/prefix [1 odd?]) [1 1 2 3])))
 ```
 
 ## Matchers
@@ -71,21 +71,32 @@ For example:
 ### default matchers
 
 If a data-structure isn't wrapped in a specific matcher-combinator the default interpretation is:
-- map: `embds`
+- map: `embeds`
 - vector: `equals`
 - number, date, and other base data-structure: `equals`
 
 ### built-in matchers
 
-- `equals-value`: matches when the given value is exactly the same as the `expected`.
-- `equals-map`: matches when:
+- `equals` operates over base values, maps, sequences, and sets
+
+  - base values (string, int, function, etc.): matches when the given value is exactly the same as the `expected`.
+  - map: matches when
       1. the keys of the `expected` map are equal to the given map's keys
       2. the value matchers of `expected` map matches the given map's values
-- `equals-seq`: matches when the `expected` list's matchers match the given list. Similar to midje's `(just expected)`
-- `subset`: order-agnostic matcher that will match when provided a subset of the `expected` list. Similar to midje's `(contains expected :in-any-order :gaps-ok)`
-- `sublist`: matches when provided a (ordered) prefix of the `expected` list.  Similar to midje's `(contains expected)`
-- `in-any-order`: matches when the given a list that is the same as the `expected` list but with elements in a different order.  Similar to midje's `(just expected :in-any-order)`
-- `contains-map`: matches when the map contains some of the same key/values as the `expected` map.
+  - sequence: matches when the `expected` sequences's matchers match the given sequence. Similar to midje's `(just expected)`
+  - set: matches when all the elements in the given set can be matched with a matcher in `expected` set and each matcher is used exactly once.
+- `embeds` operates over maps, sequences, and sets
+  - map: matches when the map contains some of the same key/values as the `expected` map.
+  - sequence: order-agnostic matcher that will match when provided a subset of the `expected` sequence. Similar to midje's `(contains expected :in-any-order :gaps-ok)`
+  - set: matches when all the matchers in the `expected` set can be matched with an element in the provided set. There may be more elements in the provided set than there are matchers.
+- `prefix` operates over sequences
+
+  matches when provided a (ordered) prefix of the `expected` sequence. Similar to midje's `(contains expected)`
+- `in-any-order` operates over sequences
+
+  matches when the given a sequence that is the same as the `expected` sequence but with elements in a different order.  Similar to midje's `(just expected :in-any-order)`
+
+- `set-equals`/`set-embeds` similar behavior to `equals`/`embeds` for sets, but allows one to specify the matchers using a sequence so that duplicate matchers are not removed. For example, `(equals #{odd? odd?})` becomes `(equals #{odd})`, so to get arround this one should use `(set-equals [odd? odd])`.
 
 ## Running tests
 

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ For example:
   {:a {:bb 1} :c 2} => (match (m/equals {:a {:bb 1} :c 2})))
 
 (fact "loosely matching a map"
-  ;; by default a map is interpreted as a `contains-map` matcher
+  ;; by default a map is interpreted as a `embeds` matcher
   {:headers {:type "txt"} :body "hello world!"} => (match {:body string?}))
 ```
 
@@ -71,9 +71,9 @@ For example:
 ### default matchers
 
 If a data-structure isn't wrapped in a specific matcher-combinator the default interpretation is:
-- map: `contains-map`
-- vector: `equals-seq`
-- number, date, and other base data-structure: `equals-value`
+- map: `embds`
+- vector: `equals`
+- number, date, and other base data-structure: `equals`
 
 ### built-in matchers
 

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject nubank/matcher-combinators "0.1.7"
+(defproject nubank/matcher-combinators "0.2.0"
   :description "Library for creating matcher combinator to compare nested data structures"
   :url "https://github.com/nubank/matcher-combinators"
   :license {:name "Apache License, Version 2.0"}

--- a/src/matcher_combinators/core.clj
+++ b/src/matcher_combinators/core.clj
@@ -85,14 +85,14 @@
                       (concat unexpected-entries)
                       (into actual))])))
 
-(defrecord ContainsMap [expected]
+(defrecord EmbedsMap [expected]
   Matcher
   (select? [this select-fn candidate]
     (let [selected-matcher (select-fn expected)
           selected-value   (select-fn candidate)]
       (select? selected-matcher select-fn selected-value)))
   (match [_this actual]
-    (if-let [issue (validate-input expected actual map? 'contains "map")]
+    (if-let [issue (validate-input expected actual map? 'embeds "map")]
       issue
       (compare-maps expected actual identity true))))
 
@@ -263,15 +263,15 @@
       issue
       (sequence-match expected actual true))))
 
-(defrecord ContainsSeq [expected]
+(defrecord EmbedsSeq [expected]
   Matcher
   (match [_this actual]
     (if-let [issue (validate-input
-                     expected actual sequential? 'contains "sequential")]
+                     expected actual sequential? 'embeds "sequential")]
       issue
       (match-any-order expected actual true))))
 
-(defrecord ContainsSet [expected accept-seq?]
+(defrecord EmbedsSet [expected accept-seq?]
   Matcher
   (match [_this actual]
     (if-let [issue (if accept-seq?
@@ -279,12 +279,12 @@
                                      actual
                                      #(or (set? %) (sequential? %))
                                      set?
-                                     'contains-set
+                                     'embeds-set
                                      "set or sequential")
                      (validate-input expected
                                      actual
                                      set?
-                                     'contains
+                                     'embeds
                                      "set"))]
       issue
       (let [[matching? result-payload] (match-any-order

--- a/src/matcher_combinators/core.clj
+++ b/src/matcher_combinators/core.clj
@@ -203,7 +203,7 @@
       issue
       (match-any-order expected actual false))))
 
-(defrecord EqualsSet [expected accept-seq?]
+(defrecord SetEquals [expected accept-seq?]
   Matcher
   (match [_this actual]
     (if-let [issue (if accept-seq?
@@ -211,7 +211,7 @@
                                      actual
                                      #(or (set? %) (sequential? %))
                                      set?
-                                     'equals-set
+                                     'set-equals
                                      "set or sequential")
                      (validate-input expected
                                      actual
@@ -255,11 +255,11 @@
       issue
       (selecting-match select-fn expected actual))))
 
-(defrecord PrefixSeq [expected]
+(defrecord Prefix [expected]
   Matcher
   (match [_this actual]
     (if-let [issue (validate-input
-                     expected actual sequential? 'prefix-seq  "sequential")]
+                     expected actual sequential? 'prefix "sequential")]
       issue
       (sequence-match expected actual true))))
 
@@ -271,7 +271,7 @@
       issue
       (match-any-order expected actual true))))
 
-(defrecord EmbedsSet [expected accept-seq?]
+(defrecord SetEmbeds [expected accept-seq?]
   Matcher
   (match [_this actual]
     (if-let [issue (if accept-seq?
@@ -279,7 +279,7 @@
                                      actual
                                      #(or (set? %) (sequential? %))
                                      set?
-                                     'embeds-set
+                                     'set-embeds
                                      "set or sequential")
                      (validate-input expected
                                      actual

--- a/src/matcher_combinators/matchers.clj
+++ b/src/matcher_combinators/matchers.clj
@@ -7,14 +7,16 @@
   [expected]
   (cond
     (sequential? expected) (core/->EqualsSeq expected)
-    (set? expected)        (core/->EqualsSet expected)
+    (set? expected)        (core/->EqualsSet expected false)
     (map? expected)        (core/->EqualsMap expected)
     :else                  (core/->Value expected)))
 
 (defn equals-set
-  ""
+  "Matches a set in the way `(equals some-set)` would, but accepts sequences as
+  the expected matcher argument, allowing one to use matchers with the same
+  submatcher appearing more than once."
   [expected]
-  (core/->EqualsSet expected))
+  (core/->EqualsSet expected true))
 
 (defn contains
   "Matcher that will match when the map contains some of the same key/values as
@@ -22,14 +24,16 @@
   [expected]
   (cond
     (sequential? expected) (core/->ContainsSeq expected)
-    (set? expected)        (core/->ContainsSet expected)
+    (set? expected)        (core/->ContainsSet expected false)
     (map? expected)        (core/->ContainsMap expected)
     :else                  (core/->InvalidType expected "contains" "seq, set, map")))
 
 (defn contains-set
-  ""
+  "Matches a set in the way `(contains some-set)` would, but accepts sequences
+  as the expected matcher argument, allowing one to use matchers with the same
+  submatcher appearing more than once."
   [expected]
-  (core/->ContainsSet expected))
+  (core/->ContainsSet expected true))
 
 (defn in-any-order
   "Matcher that will match when the given a list that is the same as the

--- a/src/matcher_combinators/matchers.clj
+++ b/src/matcher_combinators/matchers.clj
@@ -1,31 +1,35 @@
 (ns matcher-combinators.matchers
   (:require [matcher-combinators.core :as core]))
 
-(defn equals-value
+(defn equals
   "Matcher that will match when the given value is exactly the same as the
   `expected`."
   [expected]
-  (core/->Value expected))
+  (cond
+    (sequential? expected) (core/->EqualsSeq expected)
+    (set? expected)        (core/->EqualsSet expected)
+    (map? expected)        (core/->EqualsMap expected)
+    :else                  (core/->Value expected)))
 
-(defn contains-map
+(defn equals-set
+  ""
+  [expected]
+  (core/->EqualsSet expected))
+
+(defn contains
   "Matcher that will match when the map contains some of the same key/values as
   the `expected` map."
   [expected]
-  (core/->ContainsMap expected))
+  (cond
+    (sequential? expected) (core/->ContainsSeq expected)
+    (set? expected)        (core/->ContainsSet expected)
+    (map? expected)        (core/->ContainsMap expected)
+    :else                  (core/->InvalidType expected "contains" "seq, set, map")))
 
-(defn equals-map
-  "Matcher that will match when:
-    1. the keys of the `expected` map are equal to the given map's keys
-    2. the value matchers of `expected` map matches the given map's values"
+(defn contains-set
+  ""
   [expected]
-  (core/->EqualsMap expected))
-
-(defn equals-seq
-  "Matcher that will match when the `expected` list's matchers match the given list.
-
-  Similar to Midje's `(just expected)`"
-  [expected]
-  (core/->EqualsSequence expected))
+  (core/->ContainsSet expected))
 
 (defn in-any-order
   "Matcher that will match when the given a list that is the same as the
@@ -40,18 +44,10 @@
   ([select-fn expected]
    (core/->SelectingInAnyOrder select-fn expected)))
 
-(defn sublist
+(defn prefix-seq
   "Matcher that will match when provided a (ordered) prefix of the `expected`
   list.
 
   Similar to Midje's `(contains expected)`"
   [expected]
-  (core/->SubSeq expected))
-
-(defn subset
-  "Order-agnostic matcher that will match when provided a subset of the
-  `expected` list.
-
-  Similar to Midje's `(contains expected :in-any-order :gaps-ok)`"
-  [expected]
-  (core/->SubSet expected))
+  (core/->PrefixSeq expected))

--- a/src/matcher_combinators/matchers.clj
+++ b/src/matcher_combinators/matchers.clj
@@ -18,22 +18,22 @@
   [expected]
   (core/->EqualsSet expected true))
 
-(defn contains
+(defn embeds
   "Matcher that will match when the map contains some of the same key/values as
   the `expected` map."
   [expected]
   (cond
-    (sequential? expected) (core/->ContainsSeq expected)
-    (set? expected)        (core/->ContainsSet expected false)
-    (map? expected)        (core/->ContainsMap expected)
-    :else                  (core/->InvalidType expected "contains" "seq, set, map")))
+    (sequential? expected) (core/->EmbedsSeq expected)
+    (set? expected)        (core/->EmbedsSet expected false)
+    (map? expected)        (core/->EmbedsMap expected)
+    :else                  (core/->InvalidType expected "embeds" "seq, set, map")))
 
-(defn contains-set
-  "Matches a set in the way `(contains some-set)` would, but accepts sequences
+(defn embeds-set
+  "Matches a set in the way `(embeds some-set)` would, but accepts sequences
   as the expected matcher argument, allowing one to use matchers with the same
   submatcher appearing more than once."
   [expected]
-  (core/->ContainsSet expected true))
+  (core/->EmbedsSet expected true))
 
 (defn in-any-order
   "Matcher that will match when the given a list that is the same as the
@@ -52,6 +52,6 @@
   "Matcher that will match when provided a (ordered) prefix of the `expected`
   list.
 
-  Similar to Midje's `(contains expected)`"
+  Similar to Midje's `(embeds expected)`"
   [expected]
   (core/->PrefixSeq expected))

--- a/src/matcher_combinators/matchers.clj
+++ b/src/matcher_combinators/matchers.clj
@@ -7,16 +7,16 @@
   [expected]
   (cond
     (sequential? expected) (core/->EqualsSeq expected)
-    (set? expected)        (core/->EqualsSet expected false)
+    (set? expected)        (core/->SetEquals expected false)
     (map? expected)        (core/->EqualsMap expected)
     :else                  (core/->Value expected)))
 
-(defn equals-set
+(defn set-equals
   "Matches a set in the way `(equals some-set)` would, but accepts sequences as
   the expected matcher argument, allowing one to use matchers with the same
   submatcher appearing more than once."
   [expected]
-  (core/->EqualsSet expected true))
+  (core/->SetEquals expected true))
 
 (defn embeds
   "Matcher that will match when the map contains some of the same key/values as
@@ -24,16 +24,16 @@
   [expected]
   (cond
     (sequential? expected) (core/->EmbedsSeq expected)
-    (set? expected)        (core/->EmbedsSet expected false)
+    (set? expected)        (core/->SetEmbeds expected false)
     (map? expected)        (core/->EmbedsMap expected)
     :else                  (core/->InvalidType expected "embeds" "seq, set, map")))
 
-(defn embeds-set
+(defn set-embeds
   "Matches a set in the way `(embeds some-set)` would, but accepts sequences
   as the expected matcher argument, allowing one to use matchers with the same
   submatcher appearing more than once."
   [expected]
-  (core/->EmbedsSet expected true))
+  (core/->SetEmbeds expected true))
 
 (defn in-any-order
   "Matcher that will match when the given a list that is the same as the
@@ -48,10 +48,10 @@
   ([select-fn expected]
    (core/->SelectingInAnyOrder select-fn expected)))
 
-(defn prefix-seq
+(defn prefix
   "Matcher that will match when provided a (ordered) prefix of the `expected`
   list.
 
   Similar to Midje's `(embeds expected)`"
   [expected]
-  (core/->PrefixSeq expected))
+  (core/->Prefix expected))

--- a/src/matcher_combinators/parser.clj
+++ b/src/matcher_combinators/parser.clj
@@ -20,7 +20,7 @@
       [:match actual]
       [:mismatch (model/->FailedPredicate (str this) actual)])))
 
-(mimic-matcher matchers/equals-value
+(mimic-matcher matchers/equals
                Long
                Double
                String
@@ -38,6 +38,6 @@
                BigInt
                Character)
 
-(mimic-matcher matchers/contains-map IPersistentMap)
-(mimic-matcher matchers/equals-seq IPersistentVector)
-(mimic-matcher matchers/equals-seq IPersistentList)
+(mimic-matcher matchers/contains IPersistentMap)
+(mimic-matcher matchers/equals IPersistentVector)
+(mimic-matcher matchers/equals IPersistentList)

--- a/src/matcher_combinators/parser.clj
+++ b/src/matcher_combinators/parser.clj
@@ -38,6 +38,6 @@
                BigInt
                Character)
 
-(mimic-matcher matchers/contains IPersistentMap)
+(mimic-matcher matchers/embeds IPersistentMap)
 (mimic-matcher matchers/equals IPersistentVector)
 (mimic-matcher matchers/equals IPersistentList)

--- a/test/matcher_combinators/core_test.clj
+++ b/test/matcher_combinators/core_test.clj
@@ -44,7 +44,7 @@
         "a1"
         [[:a 1]]))
     ?map-matcher
-    contains
+    embeds
     equals)
 
   (facts "on the equals matcher for maps"
@@ -216,22 +216,22 @@
       [{:id 1 :a 1} {:id 2 :a 2}])
     => [:match [{:id 1 :a 1} {:id 2 :a 2}]])
 
-  (facts "nesting contains for maps"
+  (facts "nesting embeds for maps"
     (match
-      (contains {:a (equals 42) :m (contains {:x (equals "foo")})})
+      (embeds {:a (equals 42) :m (embeds {:x (equals "foo")})})
       {:a 42 :m {:x "foo"}})
     => [:match {:a 42 :m {:x "foo"}}]
 
 
-    (match (contains {:a (equals 42)
-                      :m (contains {:x (equals "foo")})})
+    (match (embeds {:a (equals 42)
+                    :m (embeds {:x (equals "foo")})})
            {:a 42
             :m {:x "bar"}})
     => [:mismatch {:a 42
                    :m {:x (model/->Mismatch "foo" "bar")}}]
 
-    (match (contains {:a (equals 42)
-                      :m (contains {:x (equals "foo")})})
+    (match (embeds {:a (equals 42)
+                    :m (embeds {:x (equals "foo")})})
            {:a 43
             :m {:x "bar"}})
     => [:mismatch {:a (model/->Mismatch 42 43)
@@ -306,8 +306,8 @@
 (future-fact "reproducing select? bug"
   (fact "the bug"
     (core/match
-      (in-any-order :a [(contains {:a (equals {:id (equals 1)}) :b (equals 42)})
-                        (contains {:a (equals {:id (equals 2)}) :b (equals 1337)})])
+      (in-any-order :a [(embeds {:a (equals {:id (equals 1)}) :b (equals 42)})
+                        (embeds {:a (equals {:id (equals 2)}) :b (equals 1337)})])
       [{:a {:id 1} :b 42}
        {:a {:id 2} :b 1337}])
     => [:match [{:a {:id 1} :b 42}
@@ -315,8 +315,8 @@
 
   (fact "similar, but works"
     (core/match
-      (in-any-order :a [(contains {:a (equals 1) :b (equals 42)})
-                        (contains {:a (equals 2) :b (equals 1337)})])
+      (in-any-order :a [(embeds {:a (equals 1) :b (equals 42)})
+                        (embeds {:a (equals 2) :b (equals 1337)})])
       [{:a 1 :b 42}
        {:a 2 :b 1337}])
     => [:match [{:a 1 :b 42}
@@ -333,54 +333,54 @@
                                "provided: 1"})]))
   ?matcher
   prefix-seq
-  contains)
+  embeds )
 
 (def pred-set #{(pred-matcher odd?) (pred-matcher pos?)})
 (def pred-seq [(pred-matcher odd?) (pred-matcher pos?)])
 
-(fact "contains/equals-set matches"
-  (core/match (contains pred-set) #{1 3}) => (just [:match (just #{1 3})])
-  (core/match (contains-set pred-seq) #{1 3}) => (just [:match (just #{1 3})])
+(fact "embeds /equals-set matches"
+  (core/match (embeds pred-set) #{1 3}) => (just [:match (just #{1 3})])
+  (core/match (embeds-set pred-seq) #{1 3}) => (just [:match (just #{1 3})])
   (core/match (equals pred-set) #{1 3}) => (just [:match (just #{1 3})])
   (core/match (equals-set pred-seq) #{1 3}) => (just [:match (just #{1 3})]))
 
-(fact "contains/equals mismatches due to type"
+(fact "embeds /equals mismatches due to type"
   (core/match (equals pred-seq) #{1 3})
   => (just [:mismatch (just {:actual   #{1 3}
                              :expected anything})])
   (core/match (equals pred-set) [1 3])
   => (just [:mismatch (just {:actual   [1 3]
                              :expected anything})])
-  (core/match (contains pred-seq) #{1 3})
+  (core/match (embeds pred-seq) #{1 3})
   => (just [:mismatch (just {:actual   #{1 3}
                              :expected anything})])
-  (core/match (contains pred-set) [1 3])
+  (core/match (embeds pred-set) [1 3])
   => (just [:mismatch (just {:actual   [1 3]
                              :expected anything})])
-  (core/match (contains 1) [1])
-  => (just [:mismatch (just {:expected-type-msg #"^contains*"
+  (core/match (embeds 1) [1])
+  => (just [:mismatch (just {:expected-type-msg #"^embeds *"
                              :provided          #"^provided: 1"})]))
 
-(fact "contains/equals-set mismatches due to type"
-  (core/match (contains-set pred-seq) [1 3])
+(fact "embeds /equals-set mismatches due to type"
+  (core/match (embeds-set pred-seq) [1 3])
   => (just [:mismatch (just {:actual   [1 3]
                              :expected anything})])
   (core/match (equals-set pred-seq) [1 3])
   => (just [:mismatch (just {:actual   [1 3]
                              :expected anything})])
-  (core/match (contains-set 1) [1 3])
-  => (just [:mismatch (just {:expected-type-msg #"^contains-set*"
+  (core/match (embeds-set 1) [1 3])
+  => (just [:mismatch (just {:expected-type-msg #"^embeds-set*"
                              :provided          #"^provided: 1"})])
   (core/match (equals-set 1) [1 3])
   => (just [:mismatch (just {:expected-type-msg #"^equals-set*"
                              :provided          #"^provided: 1"})]))
 
-(fact "contains/equals-set mismatches due to content"
-  (core/match (contains-set pred-set) #{1 -2})
+(fact "embeds /equals-set mismatches due to content"
+  (core/match (embeds-set pred-set) #{1 -2})
   => (just [:mismatch (just #{1 (just {:actual -2
                                        :form   anything})})])
 
-  (core/match (contains-set pred-seq) #{1 -2})
+  (core/match (embeds-set pred-seq) #{1 -2})
   => (just [:mismatch (just #{1 (just {:actual -2
                                        :form   anything})})])
 

--- a/test/matcher_combinators/core_test.clj
+++ b/test/matcher_combinators/core_test.clj
@@ -332,17 +332,17 @@
                                :provided
                                "provided: 1"})]))
   ?matcher
-  prefix-seq
+  prefix
   embeds )
 
 (def pred-set #{(pred-matcher odd?) (pred-matcher pos?)})
 (def pred-seq [(pred-matcher odd?) (pred-matcher pos?)])
 
-(fact "embeds /equals-set matches"
+(fact "embeds /set-equals matches"
   (core/match (embeds pred-set) #{1 3}) => (just [:match (just #{1 3})])
-  (core/match (embeds-set pred-seq) #{1 3}) => (just [:match (just #{1 3})])
+  (core/match (set-embeds pred-seq) #{1 3}) => (just [:match (just #{1 3})])
   (core/match (equals pred-set) #{1 3}) => (just [:match (just #{1 3})])
-  (core/match (equals-set pred-seq) #{1 3}) => (just [:match (just #{1 3})]))
+  (core/match (set-equals pred-seq) #{1 3}) => (just [:match (just #{1 3})]))
 
 (fact "embeds /equals mismatches due to type"
   (core/match (equals pred-seq) #{1 3})
@@ -361,26 +361,26 @@
   => (just [:mismatch (just {:expected-type-msg #"^embeds *"
                              :provided          #"^provided: 1"})]))
 
-(fact "embeds /equals-set mismatches due to type"
-  (core/match (embeds-set pred-seq) [1 3])
+(fact "embeds /set-equals mismatches due to type"
+  (core/match (set-embeds pred-seq) [1 3])
   => (just [:mismatch (just {:actual   [1 3]
                              :expected anything})])
-  (core/match (equals-set pred-seq) [1 3])
+  (core/match (set-equals pred-seq) [1 3])
   => (just [:mismatch (just {:actual   [1 3]
                              :expected anything})])
-  (core/match (embeds-set 1) [1 3])
-  => (just [:mismatch (just {:expected-type-msg #"^embeds-set*"
+  (core/match (set-embeds 1) [1 3])
+  => (just [:mismatch (just {:expected-type-msg #"^set-embeds*"
                              :provided          #"^provided: 1"})])
-  (core/match (equals-set 1) [1 3])
-  => (just [:mismatch (just {:expected-type-msg #"^equals-set*"
+  (core/match (set-equals 1) [1 3])
+  => (just [:mismatch (just {:expected-type-msg #"^set-equals*"
                              :provided          #"^provided: 1"})]))
 
-(fact "embeds /equals-set mismatches due to content"
-  (core/match (embeds-set pred-set) #{1 -2})
+(fact "embeds /set-equals mismatches due to content"
+  (core/match (set-embeds pred-set) #{1 -2})
   => (just [:mismatch (just #{1 (just {:actual -2
                                        :form   anything})})])
 
-  (core/match (embeds-set pred-seq) #{1 -2})
+  (core/match (set-embeds pred-seq) #{1 -2})
   => (just [:mismatch (just #{1 (just {:actual -2
                                        :form   anything})})])
 
@@ -388,6 +388,6 @@
   => (just [:mismatch (just #{1 (just {:actual -2
                                        :form   anything})})])
 
-  (core/match (equals-set pred-seq) #{1 -2})
+  (core/match (set-equals pred-seq) #{1 -2})
   => (just [:mismatch (just #{1 (just {:actual -2
                                        :form   anything})})]))

--- a/test/matcher_combinators/midje_test.clj
+++ b/test/matcher_combinators/midje_test.clj
@@ -74,10 +74,10 @@
   (seq #{3 8 1}) => (ch/match (m/in-any-order [(midje/as-checker odd?) 3 (midje/as-checker even?)]))))
 
 (fact [5 1 4 2] => (midje/contains [1 2 5] :gaps-ok :in-any-order))
-(fact [5 1 4 2] => (ch/match (m/prefix-seq [5 1]))
-      [5 1 4 2] => (ch/match (m/prefix-seq [5 1 4 2]))
-      [5 1 4 2] =not=> (ch/match (m/prefix-seq [5 1 4 2 6]))
-      [5 1 4 2] =not=> (ch/match (m/prefix-seq [1 5])))
+(fact [5 1 4 2] => (ch/match (m/prefix [5 1]))
+      [5 1 4 2] => (ch/match (m/prefix [5 1 4 2]))
+      [5 1 4 2] =not=> (ch/match (m/prefix [5 1 4 2 6]))
+      [5 1 4 2] =not=> (ch/match (m/prefix [1 5])))
 
 (fact [5 1 4 2] => (ch/match (m/embeds [5 1]))
       [5 1 4 2] => (ch/match (m/embeds [1 5]))

--- a/test/matcher_combinators/midje_test.clj
+++ b/test/matcher_combinators/midje_test.clj
@@ -79,12 +79,12 @@
       [5 1 4 2] =not=> (ch/match (m/prefix-seq [5 1 4 2 6]))
       [5 1 4 2] =not=> (ch/match (m/prefix-seq [1 5])))
 
-(fact [5 1 4 2] => (ch/match (m/contains [5 1]))
-      [5 1 4 2] => (ch/match (m/contains [1 5]))
-      [5 1 4 2] => (ch/match (m/contains [5 1 4 2]))
-      [5 1 4 2] => (ch/match (m/contains [1 5 2 4]))
-      [5 1 4 2] => (ch/match (m/contains [odd? even?]))
-      [5 1 4 2] =not=> (ch/match (m/contains [5 1 4 2 6])))
+(fact [5 1 4 2] => (ch/match (m/embeds [5 1]))
+      [5 1 4 2] => (ch/match (m/embeds [1 5]))
+      [5 1 4 2] => (ch/match (m/embeds [5 1 4 2]))
+      [5 1 4 2] => (ch/match (m/embeds [1 5 2 4]))
+      [5 1 4 2] => (ch/match (m/embeds [odd? even?]))
+      [5 1 4 2] =not=> (ch/match (m/embeds [5 1 4 2 6])))
 
 (fact "Find optimal in-any-order matching just like midje"
   [1 3] => (midje/just [odd? 1] :in-any-order)

--- a/test/matcher_combinators/midje_test.clj
+++ b/test/matcher_combinators/midje_test.clj
@@ -13,8 +13,8 @@
   [[[1]]] => (ch/match [[[odd?]]]))
 
 (fact "map matching"
-  {:a {:bb 1} :c 2} => (ch/match (m/equals-map {:a {:bb 1} :c 2}))
-  {:a {:bb 1} :c 2} => (ch/match (m/equals-map {:a {:bb odd?} :c 2})))
+  {:a {:bb 1} :c 2} => (ch/match (m/equals {:a {:bb 1} :c 2}))
+  {:a {:bb 1} :c 2} => (ch/match (m/equals {:a {:bb odd?} :c 2})))
 
 (fact "map embeds"
   {:a {:aa 11 :bb {:aaa 111}} :b 2} => (ch/match {:a {:bb {:aaa 111}}})
@@ -23,28 +23,28 @@
 
 (fact "map in a sequence in a map"
   {:a [{:bb 1} {:cc 2 :dd 3}] :b 4} => (ch/match {:a [{:bb 1} {:cc 2 :dd 3}] :b 4})
-  {:a [{:bb 1} {:cc 2 :dd 3}] :b 4} => (ch/match (m/equals-map {:a [{:bb 1} {:cc 2 :dd 3}] :b 4})))
+  {:a [{:bb 1} {:cc 2 :dd 3}] :b 4} => (ch/match (m/equals {:a [{:bb 1} {:cc 2 :dd 3}] :b 4})))
 
 (fact "use midje checkers inside matchers"
-  {:a {:bb 1} :c 2} => (ch/match (m/equals-map {:a {:bb midje/anything} :c 2}))
-  {:a {:bb 1} :c 2} => (ch/match (m/equals-map {:a {:bb (midje/roughly 1)} :c 2}))
+  {:a {:bb 1} :c 2} => (ch/match (m/equals {:a {:bb midje/anything} :c 2}))
+  {:a {:bb 1} :c 2} => (ch/match (m/equals {:a {:bb (midje/roughly 1)} :c 2}))
   {:a {:bb 1} :c 2} => (ch/match {:a {:bb midje/anything}})
   {:a {:bb 1} :c 2} => (ch/match {:a {:bb (midje/roughly 1)}}))
 
 (facts "predicates in matchers"
   (fact "you can use a plain predicate inside matchers"
-    {:a {:bb 1} :c 2} => (ch/match (m/equals-map {:a {:bb odd?} :c 2}))
+    {:a {:bb 1} :c 2} => (ch/match (m/equals {:a {:bb odd?} :c 2}))
     {:a {:bb 1} :c 2} => (ch/match {:a {:bb odd?}}))
-  (fact "but if you want to check exact functions use `equals-value` which
+  (fact "but if you want to check exact functions use `equals` which
         works like midje's 'exactly'"
-    {:a {:bb odd?} :c 2} =not=> (ch/match (m/equals-map {:a {:bb odd?} :c 2}))
-    {:a {:bb odd?} :c 2} => (ch/match (m/equals-map {:a {:bb (m/equals-value odd?)} :c 2}))
-    {:a {:bb odd?} :c 2} => (ch/match (m/equals-map {:a {:bb (midje/exactly odd?)} :c 2}))))
+    {:a {:bb odd?} :c 2} =not=> (ch/match (m/equals {:a {:bb odd?} :c 2}))
+    {:a {:bb odd?} :c 2} => (ch/match (m/equals {:a {:bb (m/equals odd?)} :c 2}))
+    {:a {:bb odd?} :c 2} => (ch/match (m/equals {:a {:bb (midje/exactly odd?)} :c 2}))))
 
 (defrecord Point [x y])
 
 (fact "matching records with maps"
-  (->Point 1 2) => (ch/match (m/equals-map {:x 1 :y 2}))
+  (->Point 1 2) => (ch/match (m/equals {:x 1 :y 2}))
   {:a (->Point 1 2) :b 2} => (ch/match {:a (->Point 1 2)})
   {:a (->Point 1 2) :b 2} => (ch/match {:a {:x 1 :y 2}})
   (->Point {:a 1} {:b 2}) => (ch/match {:x {:a 1}})
@@ -53,52 +53,52 @@
 
 ;; TODO PLM: do we want to allow this?:
 (fact "matching maps with records"
-  {:x 1 :y 2} => (ch/match (m/equals-map (->Point 1 2)))
+  {:x 1 :y 2} => (ch/match (m/equals (->Point 1 2)))
   {:a {:x 1 :y 2}} => (ch/match {:a (->Point 1 2)})
-  {:x 1 :y 3} =not=> (ch/match (m/equals-map (->Point 1 2)))
-  {:x 1 :z 2} =not=> (ch/match (m/equals-map (->Point 1 2))))
+  {:x 1 :y 3} =not=> (ch/match (m/equals (->Point 1 2)))
+  {:x 1 :z 2} =not=> (ch/match (m/equals (->Point 1 2))))
 
 (fact "matching records with records"
-  (->Point 1 2) => (ch/match (m/equals-map (->Point 1 2)))
+  (->Point 1 2) => (ch/match (m/equals (->Point 1 2)))
   (->Point 1 2) => (ch/match (->Point 1 2)))
 
-(fact "equals-map doesn't coerce like midje `just`"
+(fact "equals doesn't coerce like midje `just`"
   {:a 1 :b 2} => (midje/just [[:a 1] [:b 2]])
-  {:a 1 :b 2} =not=> (ch/match (m/equals-seq [[:a 1] [:b 2]])))
+  {:a 1 :b 2} =not=> (ch/match (m/equals [[:a 1] [:b 2]])))
 
 (facts "dealing with sets"
  (fact "midje set checker example"
     #{3 8 1} => (midje/just [odd? 3 even?]))
  (fact "to match sets, you need to turn it into a list"
-  #{3 8 1} =not=> (ch/match (m/equals-seq [(midje/as-checker odd?) 3 (midje/as-checker even?)]))
+  #{3 8 1} =not=> (ch/match (m/equals [(midje/as-checker odd?) 3 (midje/as-checker even?)]))
   (seq #{3 8 1}) => (ch/match (m/in-any-order [(midje/as-checker odd?) 3 (midje/as-checker even?)]))))
 
 (fact [5 1 4 2] => (midje/contains [1 2 5] :gaps-ok :in-any-order))
-(fact [5 1 4 2] => (ch/match (m/sublist [5 1]))
-      [5 1 4 2] => (ch/match (m/sublist [5 1 4 2]))
-      [5 1 4 2] =not=> (ch/match (m/sublist [5 1 4 2 6]))
-      [5 1 4 2] =not=> (ch/match (m/sublist [1 5])))
+(fact [5 1 4 2] => (ch/match (m/prefix-seq [5 1]))
+      [5 1 4 2] => (ch/match (m/prefix-seq [5 1 4 2]))
+      [5 1 4 2] =not=> (ch/match (m/prefix-seq [5 1 4 2 6]))
+      [5 1 4 2] =not=> (ch/match (m/prefix-seq [1 5])))
 
-(fact [5 1 4 2] => (ch/match (m/subset [5 1]))
-      [5 1 4 2] => (ch/match (m/subset [1 5]))
-      [5 1 4 2] => (ch/match (m/subset [5 1 4 2]))
-      [5 1 4 2] => (ch/match (m/subset [1 5 2 4]))
-      [5 1 4 2] => (ch/match (m/subset [odd? even?]))
-      [5 1 4 2] =not=> (ch/match (m/subset [5 1 4 2 6])))
+(fact [5 1 4 2] => (ch/match (m/contains [5 1]))
+      [5 1 4 2] => (ch/match (m/contains [1 5]))
+      [5 1 4 2] => (ch/match (m/contains [5 1 4 2]))
+      [5 1 4 2] => (ch/match (m/contains [1 5 2 4]))
+      [5 1 4 2] => (ch/match (m/contains [odd? even?]))
+      [5 1 4 2] =not=> (ch/match (m/contains [5 1 4 2 6])))
 
 (fact "Find optimal in-any-order matching just like midje"
   [1 3] => (midje/just [odd? 1] :in-any-order)
 
-  {:a [1 3]} => (ch/match (m/equals-map {:a (m/in-any-order [odd? 1])}))
-  {:a [1 3]} => (ch/match (m/equals-map {:a (m/in-any-order [1 odd?])}))
+  {:a [1 3]} => (ch/match (m/equals {:a (m/in-any-order [odd? 1])}))
+  {:a [1 3]} => (ch/match (m/equals {:a (m/in-any-order [1 odd?])}))
 
-  {:a [1 3]} => (ch/match (m/equals-map {:a (m/in-any-order [(midje/as-checker odd?) 1])}))
-  {:a [1]} =not=> (ch/match (m/equals-map {:a (m/in-any-order [(midje/as-checker odd?) 1])}))
+  {:a [1 3]} => (ch/match (m/equals {:a (m/in-any-order [(midje/as-checker odd?) 1])}))
+  {:a [1]} =not=> (ch/match (m/equals {:a (m/in-any-order [(midje/as-checker odd?) 1])}))
   [1 2] => (ch/match (m/in-any-order [(midje/as-checker even?)
                                       (midje/as-checker odd?)])))
 
 (midje/unfinished f)
-(let [short-list (ch/match (m/equals-seq [int? int? int?]))]
+(let [short-list (ch/match (m/equals [int? int? int?]))]
   (fact "using defined matchers in provided statements"
     (f [1 2 3]) => 1
     (provided
@@ -108,14 +108,14 @@
     (fact "succeeding"
       (f [1 2 3]) => 1
       (provided
-        (f (ch/match (m/equals-seq [int? int? int?]))) => 1))
+        (f (ch/match (m/equals [int? int? int?]))) => 1))
 
     (fact "a match failure will fail the test"
       (emission/silently
         (fact "will fail"
           (f [1 2 :not-this]) => 1
           (provided
-            (f (ch/match (m/equals-seq [int? int? int?]))) => 1)))
+            (f (ch/match (m/equals [int? int? int?]))) => 1)))
       => falsey)))
 
 
@@ -160,6 +160,6 @@
 (def an-object (Object.))
 (fact "Objects aren't matchers, so matching on them shouldn't work and produce
        an informative error"
-  an-object => (ch/match (m/equals-value an-object))
+  an-object => (ch/match (m/equals an-object))
   an-object =not=> (ch/match an-object)
   (Object.) =not=> (ch/match (Object.)))

--- a/test/matcher_combinators/parser_test.clj
+++ b/test/matcher_combinators/parser_test.clj
@@ -1,5 +1,5 @@
 (ns matcher-combinators.parser-test
-  (:require [midje.sweet :refer :all :exclude [exactly]]
+  (:require [midje.sweet :refer :all :exclude [exactly contains]]
             [midje.experimental :refer [for-all]]
             [matcher-combinators.parser]
             [matcher-combinators.matchers :refer :all]
@@ -34,36 +34,36 @@
   (gen-distinct-pair gen-scalar))
 
 
-(facts "scalar values act as equals-value matchers"
+(facts "scalar values act as equals matchers"
   (for-all [i gen-scalar]
     {:num-tests 50}
-    (core/match i i) => (core/match (equals-value i) i))
+    (core/match i i) => (core/match (equals i) i))
 
   (for-all [[i j] gen-scalar-pair]
     {:num-tests 50}
-    (core/match i j) => (core/match (equals-value i) j)))
+    (core/match i j) => (core/match (equals i) j)))
 
-(fact "maps act as equals-map matchers"
+(fact "maps act as equals matcher"
   (fact
-    (= (core/match (equals-map {:a (equals-value 10)}) {:a 10})
-       (core/match (equals-map {:a 10}) {:a 10})
+    (= (core/match (equals {:a (equals 10)}) {:a 10})
+       (core/match (equals {:a 10}) {:a 10})
        (core/match {:a 10} {:a 10}))
     => truthy))
 
-(fact "vectors act as equals-seq matchers"
+(fact "vectors act as equals matchers"
   (fact
-    (= (core/match (equals-seq [(equals-value 10)]) [10])
-       (core/match (equals-seq [10]) [10])
+    (= (core/match (equals [(equals 10)]) [10])
+       (core/match (equals [10]) [10])
        (core/match [10] [10]))
     => truthy))
 
-(fact "lists also act as equals-seq matchers"
+(fact "lists also act as equals matchers"
   (fact
-    (= (core/match (equals-seq [(equals-value 10)]) [10])
-       (core/match (equals-seq '(10)) [10])
+    (= (core/match (equals [(equals 10)]) [10])
+       (core/match (equals '(10)) [10])
        (core/match '(10) [10])) => truthy))
 
-(fact "`nil` is parsed as an equals-value"
+(fact "`nil` is parsed as an equals"
   (fact
-    (= (core/match (equals-value nil) nil)
+    (= (core/match (equals nil) nil)
        (core/match nil nil)) => truthy))

--- a/test/matcher_combinators/test_test.clj
+++ b/test/matcher_combinators/test_test.clj
@@ -17,12 +17,12 @@
 (deftest basic-matching
   (is (match? example-matcher example-actual)
       "In 'match?', the matcher argument comes first")
-  (is (match? (m/equals-map example-matcher)
+  (is (match? (m/equals example-matcher)
               (dissoc example-actual :device))
-      "wrapping the matcher in 'equals-map' means the top level of 'actual'
+      "wrapping the matcher in 'equals' means the top level of 'actual'
       must have the exact same key/values")
   (is (match? 1 1))
-  (is (match? (m/equals-seq [1 odd?]) [1 3]))
+  (is (match? (m/equals [1 odd?]) [1 3]))
   (is (match? {:a {:b odd?}}
               {:a {:b 1}})
       "Predicates can be used in matchers")


### PR DESCRIPTION
We currently have unique matcher names for maps, sequences, and values.
This potentially introduces overhead for the user to remember the unique names in every context (I say potentially because I'm undecided if it is better to overload names or have unique names for every specific matcher).

This PR explores the idea of renaming
 - `equals-map`, `equals-seq`, and `equals-value` to `equals` 
 - `contains-map` and `subset` to `embeds`
- `subseq` to `prefix-seq`
and dispatch to the correct matcher logic based on the shape of the `expected` argument

Also introduced are matchers for sets
 - `equals` and `embeds` work for sets
 - `set-equals` and `set-embeds` allow one to use the same submatcher more than once by accepting a sequence instead of a set as the `expected` argument. That is `(match (equals #{odd? odd?}) #{1 3})` will fail because `#{odd? odd?}` evaluates to `#{odd?}`. So one can use `(match (set-equals [odd? odd?]) #{1 3})` 