### PR TITLE
Set `equals` as default matcher for set

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 # Change Log
 All notable changes to this project will be documented in this file. This change log follows the conventions of [keepachangelog.com](http://keepachangelog.com/).
 
+## [0.2.2]
+- implement default matcher parser for sets
+
 ## [0.2.1]
 - stop using `boolean?` which is only in clojure 1.9
 

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject nubank/matcher-combinators "0.2.1"
+(defproject nubank/matcher-combinators "0.2.2"
   :description "Library for creating matcher combinator to compare nested data structures"
   :url "https://github.com/nubank/matcher-combinators"
   :license {:name "Apache License, Version 2.0"}

--- a/src/matcher_combinators/parser.clj
+++ b/src/matcher_combinators/parser.clj
@@ -2,7 +2,7 @@
   (:require [matcher-combinators.core :as core]
             [matcher-combinators.matchers :as matchers]
             [matcher-combinators.model :as model])
-  (:import [clojure.lang Keyword Symbol Ratio BigInt IPersistentMap IPersistentVector IPersistentList]
+  (:import [clojure.lang Keyword Symbol Ratio BigInt IPersistentMap IPersistentVector IPersistentList IPersistentSet]
            [java.util UUID Date]
            [java.time LocalDate LocalDateTime YearMonth]))
 
@@ -42,3 +42,4 @@
 (mimic-matcher matchers/embeds IPersistentMap)
 (mimic-matcher matchers/equals IPersistentVector)
 (mimic-matcher matchers/equals IPersistentList)
+(mimic-matcher matchers/equals IPersistentSet)

--- a/test/matcher_combinators/midje_test.clj
+++ b/test/matcher_combinators/midje_test.clj
@@ -97,6 +97,20 @@
   [1 2] => (ch/match (m/in-any-order [(midje/as-checker even?)
                                       (midje/as-checker odd?)])))
 
+(facts "match sets"
+  (fact "simple cases"
+    #{1 2 3} => (ch/match #{1 2 3})
+    #{1 2 3} => (ch/match (m/equals #{1 2 3}))
+    #{1 2 3} =not=> (ch/match (m/equals #{1 2}))
+    #{1 2 3} => (ch/match (m/embeds #{1 2})))
+
+  (fact "why `equals` isn't always sufficient with sets"
+    #{1 3} =not=> (ch/match (set [odd? odd?]))
+    #{1} => (ch/match (m/equals (set [odd? odd?])))
+
+    #{1 3} => (ch/match (m/set-equals [odd? odd?]))
+    #{1 2} =not=> (ch/match (m/set-equals [odd? odd?]))))
+
 ;; for clojure 1.8 support
 (defn is-int? [x]
   (or (instance? Long x)


### PR DESCRIPTION
Forgot to add this in https://github.com/nubank/matcher-combinators/pull/20