### PR TITLE
WIP: `match-with` to allow for matching with default overrides (i.e. `match-roughly`, `match-equals`)

### DIFF
--- a/src/matcher_combinators/core.clj
+++ b/src/matcher_combinators/core.clj
@@ -28,6 +28,19 @@
      (= expected actual)  [:match actual]
      :else                [:mismatch (model/->Mismatch expected actual)])))
 
+(defn- roughly? [expected actual delta]
+ (and (number? actual)
+      (>= expected (-' actual delta))
+      (<= expected (+' actual delta))))
+
+(defrecord Roughly [expected delta]
+  Matcher
+  (match [_this actual]
+   (cond
+     (= ::missing actual)             [:mismatch (model/->Missing expected)]
+     (roughly? expected actual delta) [:match actual]
+     :else                            [:mismatch (model/->Mismatch expected actual)])))
+
 (defn- validate-input
   ([expected actual pred matcher-name type]
    (validate-input expected actual pred pred matcher-name type))

--- a/src/matcher_combinators/midje.clj
+++ b/src/matcher_combinators/midje.clj
@@ -1,6 +1,6 @@
 (ns matcher-combinators.midje
   (:require [matcher-combinators.core :as core]
-            [matcher-combinators.parser]
+            [matcher-combinators.parser :as parser]
             [matcher-combinators.printer :as printer]
             [midje.checking.core :as checking]
             [midje.util.exceptions :as exception]
@@ -22,3 +22,11 @@
       (check-match matcher actual)
       (checking/as-data-laden-falsehood
         {:notes [(str "Input wasn't a matcher: " matcher)]}))))
+
+(checkers.defining/defchecker equals-match [matcher]
+  (checkers.defining/checker [actual]
+    (with-redefs [parser/map-dispatch (fn [exp] (core/->EqualsMap exp))]
+      (if (core/matcher? matcher)
+        (check-match matcher actual)
+        (checking/as-data-laden-falsehood
+          {:notes [(str "Input wasn't a matcher: " matcher)]})))))

--- a/src/matcher_combinators/parser.clj
+++ b/src/matcher_combinators/parser.clj
@@ -39,7 +39,10 @@
                BigInt
                Character)
 
-(mimic-matcher matchers/embeds IPersistentMap)
+(defn- map-dispatch [expected]
+  (core/->EmbedsMap expected))
+
+(mimic-matcher map-dispatch IPersistentMap)
 (mimic-matcher matchers/equals IPersistentVector)
 (mimic-matcher matchers/equals IPersistentList)
 (mimic-matcher matchers/equals IPersistentSet)

--- a/src/matcher_combinators/parser.clj
+++ b/src/matcher_combinators/parser.clj
@@ -20,10 +20,33 @@
       [:match actual]
       [:mismatch (model/->FailedPredicate (str this) actual)])))
 
-(mimic-matcher matchers/equals
-               nil
+(defn- map-dispatch [expected]
+  (core/->EmbedsMap expected))
+
+(defn- number-dispatch [expected]
+  (core/->Value expected))
+
+(defn- seq-dispatch [expected]
+  (core/->EqualsSeq expected))
+
+(defn- set-dispatch [expected]
+  (core/->SetEquals expected false))
+
+(def type-map
+  {:number #'number-dispatch
+   :map    #'map-dispatch
+   :seq    #'seq-dispatch
+   :set    #'set-dispatch})
+
+(mimic-matcher number-dispatch
                Long
                Double
+               BigDecimal
+               BigInteger
+               BigInt)
+
+(mimic-matcher matchers/equals
+               nil
                String
                Symbol
                Keyword
@@ -34,15 +57,9 @@
                LocalDateTime
                YearMonth
                Ratio
-               BigDecimal
-               BigInteger
-               BigInt
                Character)
 
-(defn- map-dispatch [expected]
-  (core/->EmbedsMap expected))
-
 (mimic-matcher map-dispatch IPersistentMap)
-(mimic-matcher matchers/equals IPersistentVector)
-(mimic-matcher matchers/equals IPersistentList)
-(mimic-matcher matchers/equals IPersistentSet)
+(mimic-matcher seq-dispatch IPersistentVector)
+(mimic-matcher seq-dispatch IPersistentList)
+(mimic-matcher set-dispatch IPersistentSet)

--- a/test/matcher_combinators/midje_test.clj
+++ b/test/matcher_combinators/midje_test.clj
@@ -71,8 +71,11 @@
  (fact "midje set checker example"
     #{3 8 1} => (midje/just [odd? 3 even?]))
  (fact "to match sets, you need to turn it into a list"
-  #{3 8 1} =not=> (ch/match (m/equals [(midje/as-checker odd?) 3 (midje/as-checker even?)]))
-  (seq #{3 8 1}) => (ch/match (m/in-any-order [(midje/as-checker odd?) 3 (midje/as-checker even?)]))))
+  #{3 8 1} =not=> (ch/match
+                    (m/equals [(midje/as-checker odd?) 3 (midje/as-checker even?)]))
+  (seq #{3 8 1}) => (ch/match
+                      (m/in-any-order
+                        [(midje/as-checker odd?) 3 (midje/as-checker even?)]))))
 
 (fact [5 1 4 2] => (midje/contains [1 2 5] :gaps-ok :in-any-order))
 (fact [5 1 4 2] => (ch/match (m/prefix [5 1]))
@@ -208,4 +211,9 @@
     (x ..a..) => {:a ..b..}))
 
 (fact
-  {:a 1 :b 2} =not=> (ch/equals-match {:a 1}))
+  {:a 1 :b 2} =not=> (ch/match-equals {:a 1})
+  {:a 1 :b 2} => (ch/match-equals {:a 1 :b 2}))
+
+(fact
+  1 => (ch/match-roughly 0.1 0.95)
+  1 =not=> (ch/match-roughly 0.1 0.89))

--- a/test/matcher_combinators/midje_test.clj
+++ b/test/matcher_combinators/midje_test.clj
@@ -186,3 +186,6 @@
   an-object => (ch/match (m/equals an-object))
   an-object =not=> (ch/match an-object)
   (Object.) =not=> (ch/match (Object.)))
+
+(fact
+  {:a 1 :b 2} =not=> (ch/equals-match {:a 1}))

--- a/test/matcher_combinators/test_test.clj
+++ b/test/matcher_combinators/test_test.clj
@@ -28,7 +28,7 @@
       "Predicates can be used in matchers")
   (is (match? {:a {:b 1}} {:a {:b 1 :c 2}})))
 
-(deftest equals-matching
-  (is (equals-match? {:a 1}
+#_(deftest equals-matching
+  (is (match-equals? {:a 1}
                      {:a 1 :b 2})
       "matcher where every default parser is `equals`"))

--- a/test/matcher_combinators/test_test.clj
+++ b/test/matcher_combinators/test_test.clj
@@ -27,3 +27,8 @@
               {:a {:b 1}})
       "Predicates can be used in matchers")
   (is (match? {:a {:b 1}} {:a {:b 1 :c 2}})))
+
+(deftest equals-matching
+  (is (equals-match? {:a 1}
+                     {:a 1 :b 2})
+      "matcher where every default parser is `equals`"))


### PR DESCRIPTION
Currently to do exact map matches you have to do
```clojure
(fact "maps: every level contains _exactly_ these key/value pairs"
  {:a {:b {:c 1}}} => (match (equals {:a (equals {:b (equals {:c odd?})})})))
```

To cut down on writing, we should introduce a new midje/clojure.test checker, called something like `match-equals`, that uses `equals` instead of `embeds` for the map parser default.

With this, the same check would be:

```clojure
(fact
  {:a {:b {:c 1}}} => (match-equals {:a {:b {:c odd?}}}))
```

Also implements `match-roughly` to address `B)` in https://github.com/nubank/matcher-combinators/issues/28

```clojure
(fact
  1 => (matcher-combinators.midje/match-roughly 0.1 0.95)
```

TODO:
 - [ ] write tests
 - [ ] implement `clojure.test` version
 - [ ] double-check that `match-with` can only feasibly be defined as a macro