### PR TITLE
Improve mismatch output for differing counts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 # Change Log
 All notable changes to this project will be documented in this file. This change log follows the conventions of [keepachangelog.com](http://keepachangelog.com/).
 
+## [0.2.5]
+- add default parser for Integer and Float
+- namespace the custom `:mismatch` directive for `clojure.test` reporting
+- make mismatches for sets and the `prefix` matcher more informative
+
 ## [0.2.4]
 - fix issue when matching in the presence of midje metaconstants
 

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject nubank/matcher-combinators "0.2.4"
+(defproject nubank/matcher-combinators "0.2.5"
   :description "Library for creating matcher combinator to compare nested data structures"
   :url "https://github.com/nubank/matcher-combinators"
   :license {:name "Apache License, Version 2.0"}
@@ -7,7 +7,7 @@
                  ["clojars" {:url "https://clojars.org/repo/"}]]
 
   :plugins [[lein-midje "3.2.1"]
-            [lein-ancient "0.6.14"]]
+            [lein-ancient "0.6.15"]]
 
   :dependencies [[org.clojure/clojure "1.9.0"]
                  [colorize "0.1.1" :exclusions [org.clojure/clojure]]

--- a/src/matcher_combinators/core.clj
+++ b/src/matcher_combinators/core.clj
@@ -159,24 +159,9 @@
                                   (:unmatched result)))
              (:elements result)))))
 
-(defn- incorrect-matcher->element-count?
-  [subset? matcher-count element-count]
-  (if subset?
-    (> matcher-count element-count)
-    (not (= matcher-count element-count))))
-
 (defn- match-any-order [expected actual subset?]
-  (cond
-    (not (sequential? actual))
+  (if (not (sequential? actual))
     [:mismatch (model/->Mismatch expected actual)]
-
-    (and (not subset?) (not (= (count expected) (count actual))))
-    (match-all-permutations expected actual subset?)
-
-    (incorrect-matcher->element-count? subset? (count expected) (count actual))
-    [:mismatch (model/->Mismatch expected actual)]
-
-    :else
     (match-all-permutations expected actual subset?)))
 
 (defrecord InAnyOrder [expected]

--- a/src/matcher_combinators/parser.clj
+++ b/src/matcher_combinators/parser.clj
@@ -16,9 +16,7 @@
 (extend-type clojure.lang.Fn
   core/Matcher
   (match [this actual]
-    (if (this actual)
-      [:match actual]
-      [:mismatch (model/->FailedPredicate (str this) actual)])))
+    (core/match-pred this actual)))
 
 (mimic-matcher matchers/equals
                nil

--- a/test/matcher_combinators/core_test.clj
+++ b/test/matcher_combinators/core_test.clj
@@ -279,7 +279,9 @@
     => (just [:mismatch (just [(just (model/->Missing anything)) 5]
                               :in-any-order)])
     (#'core/match-any-order matchers [5] true)
-    => [:mismatch (model/->Mismatch matchers [5])]))
+    => (just [:mismatch (just [5 (just (model/->Missing anything))]
+                              :in-any-order)])))
+
 
 (tabular
   (fact "Providing seq/map matcher with incorrect input leads to automatic mismatch"

--- a/test/matcher_combinators/core_test.clj
+++ b/test/matcher_combinators/core_test.clj
@@ -150,13 +150,14 @@
         (match (in-any-order [(equals 2) (equals 2)]) [2 2])
         => [:match [2 2]])
 
-      (fact "when there the matcher and list count differ, mark everything as mismatch"
+      (fact "when there the matcher and list count differ, mark specific mismatches"
         (match (in-any-order [(equals 1) (equals 2)]) [1 2 3])
-        => [:mismatch (model/->Mismatch [(equals 1) (equals 2)] [1 2 3])]
+        => (just [:mismatch (just [1 2 (model/->Unexpected 3)]
+                                  :in-any-order)])
 
         (match (in-any-order [(equals 1) (equals 2) (equals 3)]) [1 2])
-        => [:mismatch (model/->Mismatch [(equals 1) (equals 2) (equals 3)]
-                                        [1 2])]))))
+        => (just [:mismatch (just [1 2 (model/->Missing 3)]
+                                  :in-any-order)])))))
 
 (facts "on nesting multiple matchers"
   (facts "on nesting equals matchers for sequences"
@@ -233,15 +234,32 @@
 (defrecord PredMatcher [expected]
   core/Matcher
   (match [this actual]
-    (if (expected actual)
-      [:match actual]
-      [:mismatch (model/->FailedPredicate (str this) actual)])))
+    (core/match-pred expected actual)))
 
 (defn- pred-matcher [expected]
   (assert ifn? expected)
   (->PredMatcher expected))
 
+(fact
+  (match (equals [(pred-matcher odd?) (pred-matcher even?)]) [1 2])
+  => [:match [1 2]]
+  (match (equals [(pred-matcher odd?) (pred-matcher even?)]) [1])
+  => (just [:mismatch (just [1 anything])]))
+
 (let [matchers [(pred-matcher odd?) (pred-matcher even?)]]
+  (fact "no matching when there are more matchers than elements"
+    (#'core/matches-in-any-order? matchers [] true [])
+    => (sweet/contains {:matched?  false
+                        :unmatched (just [anything anything])
+                        :matched   empty?})
+    (#'core/matches-in-any-order? matchers [1] false [])
+    => (sweet/contains {:matched?  false
+                        :unmatched (just [anything])
+                        :matched   (just [anything])})
+    (#'core/matches-in-any-order? matchers [1] true [])
+    => (sweet/contains {:matched?  false
+                        :unmatched (just [anything])
+                        :matched   (just [anything])}))
   (fact "subset will recur on matchers"
     (#'core/matches-in-any-order? matchers [5 4 1 2] true [])
     => (sweet/contains {:matched?  true
@@ -258,7 +276,8 @@
                         :matched   (just [anything anything])}))
   (fact "mismatch if there are more matchers than actual elements"
     (#'core/match-any-order matchers [5] false)
-    => [:mismatch (model/->Mismatch matchers [5])]
+    => (just [:mismatch (just [(just (model/->Missing anything)) 5]
+                              :in-any-order)])
     (#'core/match-any-order matchers [5] true)
     => [:mismatch (model/->Mismatch matchers [5])]))
 
@@ -273,7 +292,7 @@
                                "provided: 1"})]))
   ?matcher
   prefix
-  embeds )
+  embeds)
 
 (def pred-set #{(pred-matcher odd?) (pred-matcher pos?)})
 (def pred-seq [(pred-matcher odd?) (pred-matcher pos?)])

--- a/test/matcher_combinators/core_test.clj
+++ b/test/matcher_combinators/core_test.clj
@@ -350,3 +350,23 @@
   (core/match (set-equals pred-seq) #{1 -2})
   => (just [:mismatch (just #{1 (just {:actual -2
                                        :form   anything})})]))
+
+(def even-odd-set #{(pred-matcher #(and (odd? %) (pos? %)))
+                    (pred-matcher even?)})
+(def even-odd-seq (into [] even-odd-set))
+(fact "Order agnostic checks show fine-grained mismatch details"
+  (core/match (equals even-odd-set) #{1 2 -3})
+  => (just [:mismatch #{1 2 (model/->Unexpected -3)}])
+
+  (core/match (in-any-order even-odd-seq) [1 2 -3])
+  => (just [:mismatch (just [1 2 (model/->Unexpected -3)]
+                            :in-any-order)])
+
+  (core/match (in-any-order even-odd-seq) [1])
+  => (just [:mismatch (just [1 (just (model/->Missing anything))]
+                            :in-any-order)])
+
+  (core/match (equals even-odd-set) #{1})
+  => (just [:mismatch (just #{1 (just (model/->Missing anything))}
+                            :in-any-order)]))
+

--- a/test/matcher_combinators/parser_test.clj
+++ b/test/matcher_combinators/parser_test.clj
@@ -19,7 +19,7 @@
   (gen/fmap #(Integer. %) gen/int))
 
 (def gen-float
-  (gen/fmap #(float %) gen/double))
+  (gen/fmap #(float %) gen/int))
 
 (def gen-scalar (gen/one-of [gen-java-integer
                              gen/int ;; really a Long


### PR DESCRIPTION
`set` and `in-any-order` mismatches that came up due to differing matcher/actual element counts weren't showing very fine-grained diffs. This fixes that by showing what elements or matchers were left unmatched.

Also fixes issue where predicate matchers were getting called with `:matcher-combinators.core/missing` keys. In these cases, the predicate call should be short-circuited to generate a mismatch.