### PR TITLE
Add support for java.lang.Integer and java.lang.Float

### DIFF
--- a/src/matcher_combinators/parser.clj
+++ b/src/matcher_combinators/parser.clj
@@ -22,7 +22,9 @@
 
 (mimic-matcher matchers/equals
                nil
+               Integer
                Long
+               Float
                Double
                String
                Symbol

--- a/test/matcher_combinators/parser_test.clj
+++ b/test/matcher_combinators/parser_test.clj
@@ -15,9 +15,17 @@
 (def gen-big-int
   (gen/fmap #(* 1N %) gen/int))
 
-(def gen-scalar (gen/one-of [gen/int
+(def gen-java-integer
+  (gen/fmap #(Integer. %) gen/int))
+
+(def gen-float
+  (gen/fmap #(float %) gen/double))
+
+(def gen-scalar (gen/one-of [gen-java-integer
+                             gen/int ;; really a Long
                              gen/string
                              gen/symbol
+                             gen-float
                              gen/double
                              gen/symbol-ns
                              gen/keyword


### PR DESCRIPTION
Currently when comparing numbers of these types an exception will be raised,
since they don't implement the Matcher protocol.