### PR TITLE
Fix issue where missing was showing as mismatch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 # Change Log
 All notable changes to this project will be documented in this file. This change log follows the conventions of [keepachangelog.com](http://keepachangelog.com/).
 
+## [0.2.7]
+- fix issue where a 'missing' was showing as a 'mismatch'
+
 ## [0.2.6]
 - namespace the custom `:mismatch` directive for `clojure.test` reporting
 

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject nubank/matcher-combinators "0.2.6"
+(defproject nubank/matcher-combinators "0.2.7"
   :description "Library for creating matcher combinator to compare nested data structures"
   :url "https://github.com/nubank/matcher-combinators"
   :license {:name "Apache License, Version 2.0"}

--- a/src/matcher_combinators/core.clj
+++ b/src/matcher_combinators/core.clj
@@ -33,6 +33,9 @@
    (validate-input expected actual pred pred matcher-name type))
   ([expected actual expected-pred actual-pred matcher-name type]
    (cond
+     (= actual ::missing)
+     [:mismatch (model/->Missing expected)]
+
      (not (expected-pred expected))
      [:mismatch (model/->InvalidMatcherType
                   (str "provided: " expected)

--- a/test/matcher_combinators/core_test.clj
+++ b/test/matcher_combinators/core_test.clj
@@ -124,7 +124,10 @@
 
     (fact "when there are more matchers then actual elements, append the expected values marked as Missing"
       (match (equals [(equals 1) (equals 2) (equals 3)]) [1 2])
-      => [:mismatch [1 2 (model/->Missing 3)]]))
+      => [:mismatch [1 2 (model/->Missing 3)]]
+
+      (match (equals [(equals {:a (equals 1)}) (equals {:b (equals 2)})]) [{:a 1}])
+      => [:mismatch [{:a 1} (model/->Missing {:b (equals 2)})]]))
 
   (facts "on the in-any-order sequence matcher"
     (tabular


### PR DESCRIPTION
map related matchers that matched against missing values would return `[:mismatch (Mismatch {:whatever 'foo} :matcher-combinators.core/missing)]` instead of `[:mismatch (Missing {:whatever 'foo})]`