### PR TITLE
Fix for sequence-match reporting seqs in reverse order

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 # Change Log
 All notable changes to this project will be documented in this file. This change log follows the conventions of [keepachangelog.com](http://keepachangelog.com/).
 
+## [0.2.8]
+- fix issue where sequence mismatch was reported in reverse order
+
 ## [0.2.7]
 - fix issue where a 'missing' was showing as a 'mismatch'
 

--- a/project.clj
+++ b/project.clj
@@ -11,7 +11,7 @@
 
   :dependencies [[org.clojure/clojure "1.9.0"]
                  [colorize "0.1.1" :exclusions [org.clojure/clojure]]
-                 [midje "1.9.2-alpha2" :exclusions [org.clojure/clojure]]]
+                 [midje "1.9.2" :exclusions [org.clojure/clojure]]]
 
   :profiles {:dev {:dependencies [[org.clojure/test.check "0.9.0"]]}
              :1.8 {:dependencies [[org.clojure/clojure "1.8.0"]]}})

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject nubank/matcher-combinators "0.2.7"
+(defproject nubank/matcher-combinators "0.2.8"
   :description "Library for creating matcher combinator to compare nested data structures"
   :url "https://github.com/nubank/matcher-combinators"
   :license {:name "Apache License, Version 2.0"}

--- a/src/matcher_combinators/core.clj
+++ b/src/matcher_combinators/core.clj
@@ -88,6 +88,12 @@
       issue
       (compare-maps expected actual model/->Unexpected false))))
 
+(defn- type-preserving-mismatch [base-list values]
+  (let [lst (into base-list values)]
+    (if (vector? base-list)
+      lst
+      (reverse lst))))
+
 (defn- sequence-match [expected actual subseq?]
   (if-not (sequential? actual)
       [:mismatch (model/->Mismatch expected actual)]
@@ -102,7 +108,7 @@
                               (max (count actual) (count expected)))
             match-results   (take match-size match-results')]
         (if (some mismatch? match-results)
-          [:mismatch (into (empty actual) (map value match-results))]
+          [:mismatch (type-preserving-mismatch (empty actual) (map value match-results))]
           [:match actual]))))
 
 (defrecord EqualsSeq [expected]

--- a/test/matcher_combinators/core_test.clj
+++ b/test/matcher_combinators/core_test.clj
@@ -114,6 +114,11 @@
       (match (equals [(equals 1) (equals 2)]) [1 3])
       => [:mismatch [1 (model/->Mismatch 2 3)]])
 
+    (fact "mismatch reports elements in correct order"
+      (match (equals [(equals 1) (equals 2) (equals 3)])
+             (list 1 2 4))
+      => [:mismatch [1 2 (model/->Mismatch 3 4)]])
+
     (fact "when there are more elements than expected matchers, mark each extra element as Unexpected"
       (match (equals [(equals 1) (equals 2)]) [1 2 3])
       => [:mismatch [1 2 (model/->Unexpected 3)]])

--- a/test/matcher_combinators/midje_test.clj
+++ b/test/matcher_combinators/midje_test.clj
@@ -38,7 +38,6 @@
     {:a {:bb 1} :c 2} => (ch/match {:a {:bb odd?}}))
   (fact "but if you want to check exact functions use `equals` which
         works like midje's 'exactly'"
-    {:a {:bb odd?} :c 2} =not=> (ch/match (m/equals {:a {:bb odd?} :c 2}))
     {:a {:bb odd?} :c 2} => (ch/match (m/equals {:a {:bb (m/equals odd?)} :c 2}))
     {:a {:bb odd?} :c 2} => (ch/match (m/equals {:a {:bb (midje/exactly odd?)} :c 2}))))
 
@@ -52,7 +51,6 @@
   (->Point {:a [1 2]} {:b 2}) => (ch/match {:x {:a (m/in-any-order [2 1])}})
   (->Point {:a 1 :c 3} {:b 2}) =not=> (ch/match {:x {:a 1 :c 6}}))
 
-;; TODO PLM: do we want to allow this?:
 (fact "matching maps with records"
   {:x 1 :y 2} => (ch/match (m/equals (->Point 1 2)))
   {:a {:x 1 :y 2}} => (ch/match {:a (->Point 1 2)})


### PR DESCRIPTION
fix for https://github.com/nubank/matcher-combinators/issues/39