### PR TITLE
Add regex matcher

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 All notable changes to this project will be documented in this file. This change log follows the conventions of [keepachangelog.com](http://keepachangelog.com/).
 
 ## [0.3.0]
-- regexes are now interpreted as mastchers
+- regexes are now interpreted as matchers
 
 ## [0.2.8]
 - fix issue where sequence mismatch was reported in reverse order (#39)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 # Change Log
 All notable changes to this project will be documented in this file. This change log follows the conventions of [keepachangelog.com](http://keepachangelog.com/).
 
+## [0.3.0]
+- regexes are now interpreted as mastchers
+
 ## [0.2.8]
 - fix issue where sequence mismatch was reported in reverse order (#39)
 - fix issue matching core clojure sequence types like Repeat (#26)

--- a/README.md
+++ b/README.md
@@ -80,6 +80,7 @@ If a data-structure isn't wrapped in a specific matcher-combinator the default i
 - sequential: `equals`
 - set: `equals`
 - number, date, and other base data-structure: `equals`
+- regex: `regex`
 
 ### built-in matchers
 
@@ -103,6 +104,8 @@ If a data-structure isn't wrapped in a specific matcher-combinator the default i
   matches when the given a sequence that is the same as the `expected` sequence but with elements in a different order.  Similar to midje's `(just expected :in-any-order)`
 
 - `set-equals`/`set-embeds` similar behavior to `equals`/`embeds` for sets, but allows one to specify the matchers using a sequence so that duplicate matchers are not removed. For example, `(equals #{odd? odd?})` becomes `(equals #{odd})`, so to get arround this one should use `(set-equals [odd? odd])`.
+
+- `regex`: matches the `actual-value-found` when provided an `expected-regex` using `(re-find expected-regex actual-value-found)`
 
 ### building new matchers
 

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject nubank/matcher-combinators "0.2.8"
+(defproject nubank/matcher-combinators "0.3.0"
   :description "Library for creating matcher combinator to compare nested data structures"
   :url "https://github.com/nubank/matcher-combinators"
   :license {:name "Apache License, Version 2.0"}

--- a/src/matcher_combinators/core.clj
+++ b/src/matcher_combinators/core.clj
@@ -49,6 +49,22 @@
      :else
      nil)))
 
+(defn- regex? [value] (instance? java.util.regex.Pattern value))
+(defrecord Regex [expected]
+  Matcher
+  (match [_this actual]
+   (if-let [issue (validate-input expected actual regex? (constantly true) 'regex "java.util.regex.Pattern")]
+     issue
+     (try
+       (if (re-find expected actual)
+         [:match actual]
+         [:mismatch (model/->Mismatch expected actual)])
+       (catch ClassCastException ex
+         [:mismatch (model/->InvalidMatcherType
+                      (str "provided: " actual)
+                      (str "regex " (print-str expected) " can't match 'expected' argument of type: "
+                           (type actual)))])))))
+
 (defrecord InvalidType [provided matcher-name type-msg]
   Matcher
   (match [_this _actual]

--- a/src/matcher_combinators/core.clj
+++ b/src/matcher_combinators/core.clj
@@ -56,8 +56,8 @@
    (if-let [issue (validate-input expected actual regex? (constantly true) 'regex "java.util.regex.Pattern")]
      issue
      (try
-       (if (re-find expected actual)
-         [:match actual]
+       (if-let [match (re-find expected actual)]
+         [:match match]
          [:mismatch (model/->Mismatch expected actual)])
        (catch ClassCastException ex
          [:mismatch (model/->InvalidMatcherType

--- a/src/matcher_combinators/matchers.clj
+++ b/src/matcher_combinators/matchers.clj
@@ -49,3 +49,8 @@
   Similar to Midje's `(embeds expected)`"
   [expected]
   (core/->Prefix expected))
+
+(defn regex
+  "Matcher that will match when given value matches the `expected` regular expression."
+  [expected]
+  (core/->Regex expected))

--- a/src/matcher_combinators/parser.clj
+++ b/src/matcher_combinators/parser.clj
@@ -6,6 +6,7 @@
             IPersistentVector IPersistentList IPersistentSet
             LazySeq Repeat Cons]
            [java.util UUID Date]
+           [java.util.regex Pattern]
            [java.time LocalDate LocalDateTime YearMonth]))
 
 (defmacro mimic-matcher [matcher-builder & types]
@@ -48,3 +49,4 @@
 (mimic-matcher matchers/equals Cons)
 (mimic-matcher matchers/equals Repeat)
 (mimic-matcher matchers/equals LazySeq)
+(mimic-matcher matchers/regex Pattern)

--- a/test/matcher_combinators/matchers_test.clj
+++ b/test/matcher_combinators/matchers_test.clj
@@ -76,6 +76,12 @@ false(ns matcher-combinators.matchers-test
            {:one "1"})
   => (just [:match (just {:one "1"})])
 
+  (c/match #"^pref" "prefix")
+  => [:match "pref"]
+
+  (c/match #"hello, (.*)" "hello, world")
+  => (just [:match (just ["hello, world" "world"])])
+
   (c/match (m/equals {:one (m/regex #"1")})
            {:one "2"})
   => (just [:mismatch (just {:one mismatch?})])
@@ -87,3 +93,11 @@ false(ns matcher-combinators.matchers-test
   (c/match (m/equals {:one (m/regex #"1")})
            {:one 2})
   => (just [:mismatch (just {:one invalid-type?})]))
+
+(fact "mismatch that includes a matching regex shows the match data"
+  (c/match (m/equals {:two 2
+                      :one (m/regex #"hello, (.*)")})
+           {:two 1
+            :one "hello, world"})
+   => (just [:mismatch (just {:two mismatch?
+                              :one (just ["hello, world" "world"])})]))

--- a/test/matcher_combinators/matchers_test.clj
+++ b/test/matcher_combinators/matchers_test.clj
@@ -5,7 +5,7 @@ false(ns matcher-combinators.matchers-test
             [matcher-combinators.matchers :as m]
             [matcher-combinators.model :as model]
             [matcher-combinators.core :as c])
-  (:import [matcher_combinators.model Mismatch Missing]))
+  (:import [matcher_combinators.model Mismatch Missing InvalidMatcherType]))
 
 (def now (java.time.LocalDateTime/now))
 (def an-id-string "67b22046-7e9f-46b2-a3b9-e68618242864")
@@ -34,6 +34,8 @@ false(ns matcher-combinators.matchers-test
   (instance? Mismatch actual))
 (defn missing? [actual]
   (instance? Missing actual))
+(defn invalid-type? [actual]
+  (instance? InvalidMatcherType actual))
 
 (fact "in-any-order using matcher ordering with maximum matchings for diff"
   (c/match (m/in-any-order [a-nested-map b-nested-map])
@@ -68,3 +70,20 @@ false(ns matcher-combinators.matchers-test
          second
          (map vals))
     => (has every? one-mismatch?)))
+
+(fact "Regex matching and mismatching"
+  (c/match (m/equals {:one (m/regex #"1")})
+           {:one "1"})
+  => (just [:match (just {:one "1"})])
+
+  (c/match (m/equals {:one (m/regex #"1")})
+           {:one "2"})
+  => (just [:mismatch (just {:one mismatch?})])
+
+  (c/match (m/equals {:one (m/regex "1")})
+           {:one "1"})
+  => (just [:mismatch (just {:one invalid-type?})])
+
+  (c/match (m/equals {:one (m/regex #"1")})
+           {:one 2})
+  => (just [:mismatch (just {:one invalid-type?})]))

--- a/test/matcher_combinators/midje_test.clj
+++ b/test/matcher_combinators/midje_test.clj
@@ -213,3 +213,6 @@
   (f ..a..) => (ch/match {:a ..b..})
   (provided
     (x ..a..) => {:a ..b..}))
+
+(fact "treat regex as predicate in match"
+  {:one "1"} => (ch/match {:one #"1"}))

--- a/test/matcher_combinators/midje_test.clj
+++ b/test/matcher_combinators/midje_test.clj
@@ -215,4 +215,5 @@
     (x ..a..) => {:a ..b..}))
 
 (fact "treat regex as predicate in match"
-  {:one "1"} => (ch/match {:one #"1"}))
+  {:one "1"} => (ch/match {:one #"1"})
+  {:one "hello, world"} => (ch/match {:one #"hello, (.*)"}))


### PR DESCRIPTION
In Midje checkers you can write a regex and it uses it as a checking predicate.
The same would be nice for matcher-combinators

For example:
```clojure
(fact "treat regex as predicate in match"
  {:one "1"} => (match {:one #"1"}))
```

example mismatch output

```clojure
(fact "when a regex doesn't match"
  {:one "1"} => (ch/match {:one #"2"}))
```
results in:
```
FAIL "treat regex as predicate in match" at (midje_test.clj:220)
Actual result did not agree with the checking function.
Actual result:
{:one "1"}
Checking function: (ch/match {:one #"2"})
    The checker said this about the reason:
        [:mismatch {:one (mismatch #"2" "1")}]
```

and

```clojure
(fact "trying to apply regex to wrong type"
  {:one 1} => (ch/match {:one #"2"}))
```
results in:
```
Actual result did not agree with the checking function.
Actual result:
{:one 1}
Checking function: (ch/match {:one #"2"})
    The checker said this about the reason:
        [:mismatch
 {:one
  (invalid-matcher-input
   "regex #\"2\" can't match 'expected' argument of type: class java.lang.Long"
   "provided: 1")}]
```
