### PR TITLE
Add regex matcher

### DIFF
--- a/src/matcher_combinators/parser.clj
+++ b/src/matcher_combinators/parser.clj
@@ -48,3 +48,10 @@
 (mimic-matcher matchers/equals Cons)
 (mimic-matcher matchers/equals Repeat)
 (mimic-matcher matchers/equals LazySeq)
+
+(extend-type java.util.regex.Pattern
+  core/Matcher
+  (match [this actual]
+    (if-let [match (re-find this actual)]
+      [:match match]
+      [:mismatch (model/->Mismatch this actual)])))

--- a/test/matcher_combinators/parser_test.clj
+++ b/test/matcher_combinators/parser_test.clj
@@ -75,3 +75,12 @@
   (fact
     (= (core/match (equals nil) nil)
        (core/match nil nil)) => truthy))
+
+(fact "regex patterns can be used as matchers"
+  (fact
+    (core/match #"^pref" "prefix") => [:match "pref"])
+
+  (future-fact
+      (core/match #"^ref" "prefix")
+    => [:mismatch {:expected #"^ref"
+                   :actual   "prefix"}]))


### PR DESCRIPTION
I couldn't test the mismatch case for some reason. What I get:

```
Diffs: in [1 :expected] expected #"^ref", was #"^ref"
```

Trying to use `exactly` also fails