### PR TITLE
ensure metaconstant ns is loaded before Java classes from it are loaded

### DIFF
--- a/src/matcher_combinators/midje.clj
+++ b/src/matcher_combinators/midje.clj
@@ -2,6 +2,7 @@
   (:require [matcher-combinators.core :as core]
             [matcher-combinators.model :as model]
             [matcher-combinators.parser]
+            [midje.data.metaconstant] ; otherwise Metaconstant class cannot be found
             [matcher-combinators.printer :as printer]
             [midje.checking.core :as checking]
             [midje.util.exceptions :as exception]


### PR DESCRIPTION
Hey :wave: `import` doesn't load Clojure code but just loads Java classes. In order for Java classes based on Clojure code to be available those namespaces have to be loaded. 

You probably never ran into this because `midje.sweet` and other API namespaces transitively load the metaconstant namespace. 

Thanks to @hiredman for pointing me in the right direction to fix this on the Clojurians slack.

EDIT: After you publish a release with this change it should work on cljdoc. You may also want to consider deleting `doc/intro.md` before cutting the release since it doesn't have any content but will be included in the documentation via cljdoc's [article inference](https://github.com/cljdoc/cljdoc/blob/master/doc/userguide/for-library-authors.adoc#auto-inferred-articles).