### PR TITLE
Fix for seq embeds matching due to not all permutations being computed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 # Change Log
 All notable changes to this project will be documented in this file. This change log follows the conventions of [keepachangelog.com](http://keepachangelog.com/).
 
+## [0.3.2]
+- fix for `embeds` sequence matching where some matches weren't found
+
 ## [0.3.1]
 - fix to get project working with cljdoc
 

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject nubank/matcher-combinators "0.3.1"
+(defproject nubank/matcher-combinators "0.3.2"
   :description "Library for creating matcher combinator to compare nested data structures"
   :url "https://github.com/nubank/matcher-combinators"
   :license {:name "Apache License, Version 2.0"}
@@ -11,6 +11,7 @@
 
   :dependencies [[org.clojure/clojure "1.9.0"]
                  [colorize "0.1.1" :exclusions [org.clojure/clojure]]
+                 [org.clojure/math.combinatorics "0.1.4"]
                  [midje "1.9.2" :exclusions [org.clojure/clojure]]]
 
   :profiles {:dev {:dependencies [[org.clojure/test.check "0.9.0"]]}

--- a/src/matcher_combinators/core.clj
+++ b/src/matcher_combinators/core.clj
@@ -1,5 +1,6 @@
 (ns matcher-combinators.core
-  (:require [matcher-combinators.helpers :as helpers]
+  (:require [clojure.math.combinatorics :as combo]
+            [matcher-combinators.helpers :as helpers]
             [matcher-combinators.model :as model]))
 
 (defprotocol Matcher
@@ -171,7 +172,7 @@
         :else                       best))))
 
 (defn- match-all-permutations [matchers elements subset?]
-  (let [elem-permutations (helpers/permutations elements)
+  (let [elem-permutations (combo/permutations elements)
         find-best-match   (matched-or-best-matchers matchers subset?)
         result            (reduce find-best-match
                                   {:matched   []

--- a/src/matcher_combinators/helpers.clj
+++ b/src/matcher_combinators/helpers.clj
@@ -3,12 +3,6 @@
 (defn find-first [pred coll]
   (->> coll (filter pred) first))
 
-(defn permutations
-  "Lazy seq of all permutations of a seq"
-  [coll]
-  (for [i (range 0 (count coll))]
-    (lazy-cat (drop i coll) (take i coll))))
-
 (defn remove-first
   "Similar to `remove` but stops after removing 1 element"
   [pred coll]

--- a/test/matcher_combinators/core_test.clj
+++ b/test/matcher_combinators/core_test.clj
@@ -290,7 +290,6 @@
     => (just [:mismatch (just [5 (just (model/->Missing anything))]
                               :in-any-order)])))
 
-
 (tabular
   (fact "Providing seq/map matcher with incorrect input leads to automatic mismatch"
     (core/match (?matcher 1) 1)
@@ -306,6 +305,12 @@
 
 (def pred-set #{(pred-matcher odd?) (pred-matcher pos?)})
 (def pred-seq [(pred-matcher odd?) (pred-matcher pos?)])
+
+(def short-equals-seq (map equals [1 3]))
+
+(fact "embeds for sequences"
+  (core/match (embeds short-equals-seq) [3 4 1]) => (just [:match (just [3 4 1])])
+  (core/match (embeds short-equals-seq) [3 4 1 5]) => (just [:match (just [3 4 1 5])]))
 
 (fact "embeds /set-equals matches"
   (core/match (embeds pred-set) #{1 3}) => (just [:match (just #{1 3})])

--- a/test/matcher_combinators/matchers_test.clj
+++ b/test/matcher_combinators/matchers_test.clj
@@ -1,5 +1,6 @@
 false(ns matcher-combinators.matchers-test
-  (:require [midje.sweet :as midje :refer [fact facts => falsey contains just anything future-fact has]]
+  (:require [clojure.math.combinatorics :as combo]
+            [midje.sweet :as midje :refer [fact facts => falsey contains just anything future-fact has]]
             [matcher-combinators.midje :refer [match]]
             [matcher-combinators.helpers :as helpers]
             [matcher-combinators.matchers :as m]
@@ -51,7 +52,7 @@ false(ns matcher-combinators.matchers-test
   (map #(->> %
              (c/match (m/in-any-order [1 2 3 4]))
              second)
-       (helpers/permutations [1 2 3 500]))
+       (combo/permutations [1 2 3 500]))
   => (has every? one-mismatch?))
 
 (facts "Show how input ordering affects diff size (when it ideally shouldn't)"


### PR DESCRIPTION
Fix for https://github.com/nubank/matcher-combinators/issues/47

Was caused because the permutation helper I had defined wasn't computing all permutations, only computing permutations created by rotating the sequence.

Calculating all permutations might be heavy handed, but prefer to refactor it once it proves to be a bottleneck