### PR TITLE
Added matcher for ByteArray

### DIFF
--- a/src/matcher_combinators/core.clj
+++ b/src/matcher_combinators/core.clj
@@ -330,3 +330,19 @@
     {::result/type  :mismatch
      ::result/value (model/->FailedPredicate (str func) actual)
      ::result/weight 1}))
+
+(defrecord ByteArray [expected]
+  Matcher
+  (match [_this actual]
+    (cond
+      (= actual ::missing) {::result/type  :mismatch
+                            ::result/value (model/->Missing expected)
+                            ::result/weight 1}
+
+      (= (set expected) (set actual)) {::result/type   :match
+                                       ::result/value  actual
+                                       ::result/weight 0}
+
+      :else {::result/type   :mismatch
+             ::result/value  (model/->Mismatch expected actual)
+             ::result/weight 1})))

--- a/src/matcher_combinators/matchers.clj
+++ b/src/matcher_combinators/matchers.clj
@@ -9,6 +9,7 @@
     (sequential? expected) (core/->EqualsSeq expected)
     (set? expected)        (core/->SetEquals expected false)
     (map? expected)        (core/->EqualsMap expected)
+    (bytes? expected)      (core/->ByteArray expected)
     :else                  (core/->Value expected)))
 
 (defn set-equals
@@ -26,6 +27,7 @@
     (sequential? expected) (core/->EmbedsSeq expected)
     (set? expected)        (core/->SetEmbeds expected false)
     (map? expected)        (core/->EmbedsMap expected)
+    (bytes? expected)      (core/->ByteArray expected)
     :else                  (core/->InvalidType expected "embeds" "seq, set, map")))
 
 (defn set-embeds
@@ -54,3 +56,8 @@
   "Matcher that will match when given value matches the `expected` regular expression."
   [expected]
   (core/->Regex expected))
+
+(defn byte-array
+  "Matcher that will compare ByteArrays contents."
+  [expected]
+  (core/->ByteArray expected))

--- a/test/matcher_combinators/core_test.clj
+++ b/test/matcher_combinators/core_test.clj
@@ -536,4 +536,14 @@
                        {:a "1" :x (model/->Mismatch "12" "12=")}]
       ::result/weight 2})
 
+(facts "on ByteArray values"
+  (let [x (clojure.core/byte-array [(byte 0x43) (byte 0x6c) (byte 0x6f)])
+        y (clojure.core/byte-array [(byte 0x21)])]
+    (match (byte-array x) x) => {::result/type   :match
+                                 ::result/value  x
+                                 ::result/weight 0}
+    (match (byte-array x) y) => {::result/type   :mismatch
+                                 ::result/value  (model/->Mismatch x y)
+                                 ::result/weight 1}))
+
 (spec.test/unstrument)


### PR DESCRIPTION
The idea of this matcher is to allow matching ByteArrays. Currently, using `matcher-combinators` with ByteArrays returns the following error:

```
No implementation of method: :match of protocol: #'matcher-combinators.core/Matcher found for class: [B>
```