### PR TITLE
Add declare to stop linters from erasing require

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject nubank/matcher-combinators "0.8.0"
+(defproject nubank/matcher-combinators "0.8.1"
   :description "Library for creating matcher combinator to compare nested data structures"
   :url "https://github.com/nubank/matcher-combinators"
   :license {:name "Apache License, Version 2.0"}

--- a/src/cljc/matcher_combinators/test.cljc
+++ b/src/cljc/matcher_combinators/test.cljc
@@ -4,3 +4,5 @@
        :clj  [clojure.test :as t :refer        [is are deftest testing]])
     #?(:cljs [matcher-combinators.cljs-test]
        :clj  [matcher-combinators.clj-test])))
+
+(declare match?)


### PR DESCRIPTION
As it's not being directly used by the code that requires it, linters keep complaining of unused import when requiring `matcher-combinators.test`.

Now clients can write `[matcher-combinators.test :refer [match?]]` and stop linters from deleting this line. And, as it's not declared outside from clojure test's checks, so it still works as intended.