### PR TITLE
add `value` matcher

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 # Change Log
 All notable changes to this project will be documented in this file. This change log follows the conventions of [keepachangelog.com](http://keepachangelog.com/).
 
+## [0.9.0]
+- add `value` matcher for forcing map like structures to be compared using equality
+
 ## [0.8.1]
 - declare `match?` to help avoid linters removing require
 

--- a/README.md
+++ b/README.md
@@ -128,6 +128,8 @@ If a data-structure isn't wrapped in a specific matcher-combinator the default i
 
 - `set-equals`/`set-embeds` similar behavior to `equals`/`embeds` for sets, but allows one to specify the matchers using a sequence so that duplicate matchers are not removed. For example, `(equals #{odd? odd?})` becomes `(equals #{odd})`, so to get arround this one should use `(set-equals [odd? odd])`.
 
+- `value` uses `=` to compares `expected` with `actual`. Same behavior as `equals` except in the case of maps and sequences, where `value` continues to use `=` but `equals` recursively applies matching logic. Useful for asserting equality for special maps such as prismatic schemas.
+
 - `regex`: matches the `actual-value-found` when provided an `expected-regex` using `(re-find expected-regex actual-value-found)`
 
 ### building new matchers

--- a/src/cljc/matcher_combinators/matchers.cljc
+++ b/src/cljc/matcher_combinators/matchers.cljc
@@ -1,6 +1,11 @@
 (ns matcher-combinators.matchers
   (:require [matcher-combinators.core :as core]))
 
+(defn value
+  "Matcher that uses underlying language-level equality"
+  [expected]
+  (core/->Value expected))
+
 (defn equals
   "Matcher that will match when the given value is exactly the same as the
   `expected`."

--- a/test/clj/matcher_combinators/matchers_test.clj
+++ b/test/clj/matcher_combinators/matchers_test.clj
@@ -1,7 +1,6 @@
 (ns matcher-combinators.matchers-test
   (:require [clojure.math.combinatorics :as combo]
             [midje.sweet :as midje :refer [fact facts => falsey contains just anything future-fact has]]
-            [matcher-combinators.midje :refer [match]]
             [matcher-combinators.helpers :as helpers]
             [matcher-combinators.matchers :as m]
             [matcher-combinators.model :as model]
@@ -148,3 +147,30 @@
                 ::result/value {:actual   b
                                 :expected a}
                 ::result/weight 1}))))
+
+(def a-map {:a (constantly false)})
+(def b-map {:a (constantly false)})
+(def a-seq [(constantly false)])
+(def b-seq [(constantly false)])
+
+(facts "value matcher"
+  (fact "for maps"
+    (c/match (m/value a-map) a-map)
+    => (just {::result/type :match
+              ::result/value a-map
+              ::result/weight 0})
+    (c/match (m/value a-map) b-map)
+    => (just {::result/type :mismatch
+              ::result/value {:actual   b-map
+                              :expected a-map}
+              ::result/weight 1}))
+  (fact "for seqs"
+    (c/match (m/value a-seq) a-seq)
+    => (just {::result/type :match
+              ::result/value a-seq
+              ::result/weight 0})
+    (c/match (m/value a-seq) b-seq)
+    => (just {::result/type :mismatch
+              ::result/value {:actual   b-seq
+                              :expected a-seq}
+              ::result/weight 1})))

--- a/test/clj/matcher_combinators/midje_test.clj
+++ b/test/clj/matcher_combinators/midje_test.clj
@@ -239,4 +239,18 @@
   (throw (ex-info "foo" {:foo 1 :bar 2})) =not=> (throws-match {:foo 2} ExceptionInfo)
   (throw (ex-info "foo" {:foo 1 :bar 2})) =not=> (throws-match {:foo 1} clojure.lang.ArityException))
 
+(def a-map {:a (constantly false)})
+(def b-map {:a (constantly false)})
+
+(facts "match maps using clojure `=`"
+  (fact "functions that are equavalent aren't referentially equal"
+    (:a a-map) =not=> (:a b-map))
+
+  (fact "using default map matching fails because functions are called as predicates"
+    a-map =not=> (match b-map))
+
+  (fact "using `value` maps are compared using `=`"
+    a-map => (match (m/value a-map))
+    a-map =not=> (match (m/value b-map))))
+
 (spec.test/unstrument)


### PR DESCRIPTION
I was trying to compare references to prismatic schemas using matcher-combinators and running into issues. This is because schemas are in the end maps, but they contain predicate functions. When you try to use matcher-combinators with these predicate functions, they actually get applied, resulting in undesirable behavior.

Thus I'm introducing a way to force using `=` to compare maps via the `value` matcher