### PR TITLE
Treat nil value in map as expecting the key/value to be absent

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,19 @@
 # Change Log
 All notable changes to this project will be documented in this file. This change log follows the conventions of [keepachangelog.com](http://keepachangelog.com/).
 
+## [1.0.0]
+- Using `nil` as the matcher for value at a key in a map now only matches if the key is absent.
+
+For example:
+```clojure
+(testing "will match because `:b` points to `nil` in the matcher and the `actual` doesn't have `:b`"
+  (is (match? {:a 1 :b nil}
+              {:a 1})))
+(testing 'won't match because `:b` is present in the `actual` when the `nil` signifies it should be absent"
+  (is (match? {:a 1 :b nil}
+              {:a 1 :b 2})))
+```
+
 ## [0.8.1]
 - declare `match?` to help avoid linters removing require
 

--- a/README.md
+++ b/README.md
@@ -130,6 +130,26 @@ If a data-structure isn't wrapped in a specific matcher-combinator the default i
 
 - `regex`: matches the `actual-value-found` when provided an `expected-regex` using `(re-find expected-regex actual-value-found)`
 
+#### Asserting the absence of a key/value in a map using built-in matchers
+
+Usually with matcher-combinators you specify the data you expect to be present in the datastructure.
+At times it is useful to be able to additionally assert in a concise manner the absence of certain data.
+
+To assert the absence of a key/value entry in a map, point they key to `nil` in the matcher.
+For example:
+
+```clojure
+(testing "will match because `:b` points to `nil` in the matcher and the `actual` doesn't have `:b`"
+  (is (match? {:a 1 :b nil}
+              {:a 1})))
+
+(testing 'won't match because `:b` is present in the `actual` when the `nil` signifies it should be absent"
+  (is (match? {:a 1 :b nil}
+              {:a 1 :b 2})))
+```
+
+If you would like to actually assert that the key is present and points to `nil`, use `nil?` instead.
+
 ### building new matchers
 
 You can extend your data-types to work with `matcher-combinators` by implemented the [`Matcher` protocol](https://github.com/nubank/matcher-combinators/blob/066da1a07ab620a6c63bbb0ce8e1b6b3a4ccd956/src/matcher_combinators/core.clj#L5-L9).

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject nubank/matcher-combinators "0.8.1"
+(defproject nubank/matcher-combinators "1.0.0"
   :description "Library for creating matcher combinator to compare nested data structures"
   :url "https://github.com/nubank/matcher-combinators"
   :license {:name "Apache License, Version 2.0"}

--- a/test/clj/matcher_combinators/core_test.clj
+++ b/test/clj/matcher_combinators/core_test.clj
@@ -55,6 +55,17 @@
             ::result/value  {:b 42, :a (model/->Missing 42)}
             ::result/weight 1})
 
+      (fact "when key points to `nil` in matcher, expect the key to be missing in actual"
+        (match (?map-matcher {:a (equals 42) :b nil}) {:a 42})
+        => {::result/type   :match
+            ::result/value  {:a 42}
+            ::result/weight 0}
+
+        (match (?map-matcher {:a (equals 42) :b nil}) {:a 42 :b 42})
+        => {::result/type   :mismatch
+            ::result/value  {:a 42, :b (model/->Unexpected 42)}
+            ::result/weight 1})
+
       (tabular
         (fact "mismatch when given an actual input that is not a map"
           (match (?map-matcher {:a (equals 1)}) ?actual)

--- a/test/clj/matcher_combinators/midje_test.clj
+++ b/test/clj/matcher_combinators/midje_test.clj
@@ -191,9 +191,15 @@
              :response-time response-time
              :version string?}))
 
-(fact "matchers can use `nil` inside them"
-  {:a nil} => (match {:a nil})
-  {:a 1} =not=> (match {:a nil}))
+(facts "matchers can use `nil` inside them"
+  [1 nil] => (match (m/in-any-order [nil 1]))
+
+  (fact "but when you use `nil` in a map, it indicates absence"
+    {} => (match (m/equals {:a nil}))
+    {:a nil} =not=> (match {:a nil}))
+
+  (fact "to match `nil` in a map, use `nil?`"
+    {:a nil} => (match (m/equals {:a nil?}))))
 
 (def an-object (Object.))
 (fact "Objects aren't matchers, so matching on them shouldn't work and produce


### PR DESCRIPTION
an alternative approach to https://github.com/nubank/matcher-combinators/pull/66

currently
```clojure
;; matches
(is
  (match? {:a number? :b nil}
          {:a 1 :b nil}))
;; mismatches with `:b should have been nil`
(is
  (match? {:a number? :b nil}
          {:a 1}))
```
which can be useful because `nil` is a base value and usually in matcher-combinators base values match using `=`.

but in many cases it is nice to not have to write an additional test checking the absence of keys in a map.

Hence, this PR changes the behavior of `nil` in the value position of a map to assert that the key isn't present in the map

```clojure
;; matches because `:b` is missing from the actual
(is
  (match? {:a number? :b nil}
          {:a 1}))
;; doesn't match because `:b` is present
(is
  (match? {:a number? :b nil}
          {:a 1 :b nil}))
```

if you'd like to assert that the value at a key is `nil` you should use the predicate `nil?`

```clojure
;; matching a nil value
(is
  (match? {:a number? :b nil?}
          {:a 1 :b nil}))
```