### PR TITLE
Create a timeout test case for in-any-order

### DIFF
--- a/test/clj/matcher_combinators/matchers_test.clj
+++ b/test/clj/matcher_combinators/matchers_test.clj
@@ -46,6 +46,20 @@
                                   :in-any-order)
             ::result/weight number?}))
 
+(facts "in-any-order process time grows exponentially by the number of items"
+  (fact "7 items: around miliseconds"
+    ["G" "A" "B" "C" "D" "E" "F"]
+    => (match (m/in-any-order ["A" "B" "C" "D" "E" "F" "G"])))
+  (fact "8 items: almost a second"
+    ["H" "A" "B" "C" "D" "E" "F" "G"]
+    => (match (m/in-any-order ["A" "B" "C" "D" "E" "F" "G" "H"])))
+  (fact "9 items: around 5 seconds"
+    ["I" "A" "B" "C" "D" "E" "F" "G" "H"]
+    => (match (m/in-any-order ["A" "B" "C" "D" "E" "F" "G" "H" "I"])))
+  (fact "10 items timeouts"
+    ["J" "A" "B" "C" "D" "E" "F" "G" "H" "I"]
+    => (match (m/in-any-order ["A" "B" "C" "D" "E" "F" "G" "H" "I" "J"]))))
+
 (defn one-mismatch? [mismatch-list]
   (= 1 (count (filter #(or (mismatch? %) (missing? %)) mismatch-list))))
 


### PR DESCRIPTION
After https://github.com/nubank/matcher-combinators/pull/72 (`0.8.2`), one of our test cases using `in-any-order` timeouted. Before `0.8.2`, it worked. The test case was comparing two lists of 50 items each using `in-any-order`.

It seems `in-any-order` process time grows exponentially by the number of items it's comparing. By 10 items it'll definitely timeout any CI.

I've opened this PR with the minimum reproducible test case of this behavior.