### PR TITLE
Use `:fail` for mismatch test reporting; improve CIDER / Cursive integration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@ All notable changes to this project will be documented in this file. This
 change log follows the conventions of
 [keepachangelog.com](http://keepachangelog.com/).
 
+## [1.1.0]
+- Improve cider + cursive integration by using `:fail`, which is the standard in `clojure.test`
+  for reporting mismatches. Thanks to Arne Brasseur (@plexus) for implementation
+
 ## [1.0.1]
 - Provide clearer message on incorrect arg count to `match?` and `thrown-match?`
 

--- a/project.clj
+++ b/project.clj
@@ -23,15 +23,14 @@
   :profiles {:dev {:plugins [[lein-midje "3.2.1"]
                              [lein-cljfmt "0.5.7"]
                              [lein-cljsbuild "1.1.7"]
-                             [lein-kibit "0.1.6"]
                              [lein-ancient "0.6.15"]
                              [lein-doo "0.1.11"]]
                    :dependencies [[org.clojure/test.check "0.10.0-alpha3"]
                                   [org.clojure/clojurescript "1.10.520"]]}
              :1.8 {:dependencies [[org.clojure/clojure "1.8.0"]]}}
 
-  :aliases {"lint"     ["do" "cljfmt" "check," "kibit"]
-            "lint-fix" ["do" "cljfmt" "fix," "kibit" "--replace"]
+  :aliases {"lint"     ["do" "cljfmt"]
+            "lint-fix" ["do" "cljfmt" "fix,"]
             "test-clj" ["all" "do" ["test"] ["check"]]
             "test-phantom" ["doo" "phantom" "test"]
             "test-advanced" ["doo" "phantom" "advanced-test"]

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject nubank/matcher-combinators "1.0.1"
+(defproject nubank/matcher-combinators "1.1.0"
   :description "Library for creating matcher combinator to compare nested data structures"
   :url "https://github.com/nubank/matcher-combinators"
   :license {:name "Apache License, Version 2.0"}

--- a/src/clj/matcher_combinators/clj_test.clj
+++ b/src/clj/matcher_combinators/clj_test.clj
@@ -29,7 +29,7 @@
 (defn tagged-for-pretty-printing [actual-summary result]
   (with-meta {:summary      actual-summary
               :match-result result}
-             {:type ::mismatch}))
+    {:type ::mismatch}))
 
 (defmethod clojure.test/assert-expr 'match? [msg form]
   `(let [args#              (list ~@(rest form))
@@ -79,10 +79,10 @@
                 :message  ~msg
                 :expected (symbol "`thrown-match?` expects 3 arguments: an exception class, a `matcher`, and the `actual`")
                 :actual   (symbol (str (count args#) " were provided: " '~form))})
-            (clojure.test/do-report {:type     :fail
-                                     :message  ~msg
-                                     :expected '~form
-                                     :actual   (symbol "the expected exception wasn't thrown")})))
+              (clojure.test/do-report {:type     :fail
+                                       :message  ~msg
+                                       :expected '~form
+                                       :actual   (symbol "the expected exception wasn't thrown")})))
           (catch ~klass e#
             (let [result# (core/match ~matcher (ex-data e#))]
               (clojure.test/do-report

--- a/test/clj/matcher_combinators/core_test.clj
+++ b/test/clj/matcher_combinators/core_test.clj
@@ -397,8 +397,8 @@
 (fact "`absent` interaction with keys pointing to `nil` values"
   (core/match (equals {:a (equals 42)
                        :b absent})
-              {:a 42
-               :b nil})
+    {:a 42
+     :b nil})
   => (just {::result/type   :mismatch
             ::result/value  (just {:a 42
                                    :b {:actual nil}})


### PR DESCRIPTION
Redo of https://github.com/nubank/matcher-combinators/pull/49 to fix resolve merge conflicts (don't know how to do that on other people's PRs)