### PR TITLE
introduce match-with, match-equals, match-roughly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,18 @@ All notable changes to this project will be documented in this file. This
 change log follows the conventions of
 [keepachangelog.com](http://keepachangelog.com/).
 
+## [1.2.0]
+Add new matching contexts:
+For Midje:
+- `match-with`: takes a class->matcher map and an expected matcher. The map defines what matcher will be used by default when a particular class instance is found.
+- `match-equals`: Allows for exact matching of datastructures by using the `equals` matcher instead of `embeds` for maps.
+- `match-roughly`: Matches all numerics as long as they are within a given delta of the expected.
+
+For `clojure.test`:
+- `match-with?`: same as the midje version above
+- `match-equals?`: same as the midje version above
+As well as `matcher-combinator.test/build-match-assert` to help build new matcher contexts
+
 ## [1.1.0]
 - Improve cider + cursive integration by using `:fail`, which is the standard in `clojure.test`
   for reporting mismatches. Thanks to Arne Brasseur (@plexus) for implementation

--- a/README.md
+++ b/README.md
@@ -202,6 +202,14 @@ Or if you want a one-off override of defaults, it can be done `match-with?`:
 - `match-roughly`
 - `match-equals`
 
+Or you can build your own, for example:
+
+```clojure
+(def match-equals
+  "match but using strict `equals` matching behavior for maps, even nested ones."
+  (match-with {clojure.lang.IPersistentMap matchers/equals}))
+```
+
 ## Running tests
 
 The project contains `midje`, `clojure.test`, and `cljs.test` tests.

--- a/README.md
+++ b/README.md
@@ -150,5 +150,5 @@ lein midje
 To run Clojurescript tests:
 
 ```
-lein node-test
+lein test-node
 ```

--- a/README.md
+++ b/README.md
@@ -137,6 +137,71 @@ You can extend your data-types to work with `matcher-combinators` by implemented
 
 An example of this in the wild can be seen in the `abracad` library [here](https://github.com/nubank/abracad/blob/b52e6a7114461f50bdacc2cf09a1de08f707b9f3/test/abracad/custom_types_test.clj#L15-L20).
 
+## Overriding default matchers
+
+Inside the context of `match?` (clojure.test) / `match` (midje), data-structures are assigned default matchers, which eliminates the need to wrap data-structures with matcher-combinators when your desired matching behavior matches the defaults.
+
+But what if your desired matching behavior deviates from the defaults?
+
+For example, if you want to do exact map matching you need to use a log of `m/equals`:
+
+```clojure
+(deftest exact-map-matching-by-hand
+  (is (match? (m/equals {:a (m/equals {:b (m/equals {:c odd?})})}))
+              {:a {:b {:c 1}}})
+  ;; without m/equals, the system defaults to m/embeds for maps,
+  ;; which has looser matching properties
+  (is (match? {:a {:b {:c odd?}}}
+              {:a {:b {:c 1 :extra-c 0} :extra-b 0} :extra-a 0})))
+```
+
+This verbosity can be avoided by redefining the matcher data-type defaults
+
+### clojure.test
+
+You can register a custom `clojure.test` match assert expression if you are going to use it a few times:
+
+```clojure
+(defmethod clojure.test/assert-expr 'match-equals? [msg form]
+  (matcher-combinators.test/build-match-assert 'match-equals? {clojure.lang.IPersistentMap m/equals} msg form))
+
+(deftest match-equals-test
+  (is (match-equals? {:a {:b {:c odd?}}}
+                     {:a {:b {:c 1}}})))
+```
+
+Or if you want a one-off override of defaults, it can be done `match-with?`:
+
+```
+(deftest one-off-match-equals
+  (is (match-with? {clojure.lang.IPersistentMap m/equals}
+                   {:a {:b {:c odd?}}}
+                   {:a {:b {:c 1}}})))
+```
+
+#### built-in matching context
+
+- `match?`
+- `match-with?`
+- `match-equals?`
+
+### midje
+
+```clojure
+(fact "match-with example"
+  {:a {:b {:c odd?}}} => (match-with {clojure.lang.IPersistentMap m/equals}
+                                     {:a {:b {:c odd?}}}))
+(fact "match-equals example"
+  {:a {:b {:c odd?}}} => (match-equals {:a {:b {:c odd?}}}))
+```
+
+#### built-in matching context
+
+- `match`
+- `match-with`
+- `match-roughly`
+- `match-equals`
+
 ## Running tests
 
 The project contains `midje`, `clojure.test`, and `cljs.test` tests.

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject nubank/matcher-combinators "1.1.0"
+(defproject nubank/matcher-combinators "1.2.0"
   :description "Library for creating matcher combinator to compare nested data structures"
   :url "https://github.com/nubank/matcher-combinators"
   :license {:name "Apache License, Version 2.0"}
@@ -25,7 +25,7 @@
                              [lein-cljsbuild "1.1.7"]
                              [lein-ancient "0.6.15"]
                              [lein-doo "0.1.11"]]
-                   :dependencies [[org.clojure/test.check "0.10.0-alpha3"]
+                   :dependencies [[org.clojure/test.check "0.10.0"]
                                   [org.clojure/clojurescript "1.10.520"]]}
              :1.8 {:dependencies [[org.clojure/clojure "1.8.0"]]}}
 

--- a/project.clj
+++ b/project.clj
@@ -14,8 +14,8 @@
 
   :dependencies [[org.clojure/clojure "1.10.1"]
                  [org.clojure/spec.alpha "0.2.176"]
-                 [org.clojure/math.combinatorics "0.1.5"]
-                 [midje "1.9.8" :exclusions [org.clojure/clojure]]]
+                 [org.clojure/math.combinatorics "0.1.6"]
+                 [midje "1.9.9" :exclusions [org.clojure/clojure]]]
 
   :test-paths ["test/clj"]
   :source-paths ["src/cljc" "src/cljs" "src/clj"]

--- a/src/clj/matcher_combinators/clj_test.clj
+++ b/src/clj/matcher_combinators/clj_test.clj
@@ -71,36 +71,36 @@
          matcher
          actual]       args]
     (dispatch/match-with-inner
-      type->matcher
+     type->matcher
      `(cond
-       (not (= 3 (count '~args)))
-       (clojure.test/do-report
+        (not (= 3 (count '~args)))
+        (clojure.test/do-report
          {:type     :fail
           :message  ~msg
           :expected (symbol "`match-with?` expects 3 arguments: a `type->matcher` map, a `matcher`, and the `actual`")
           :actual   (symbol (str (count '~args) " were provided: " '~form))})
 
-       (core/matcher? ~matcher)
-       (let [result# (core/match ~matcher ~actual)]
-         (clojure.test/do-report
-          (if (core/match? result#)
-            {:type     :pass
-             :message  ~msg
-             :expected '~form
-             :actual   (list 'match? ~matcher ~actual)}
-            (with-file+line-info
-              {:type     :fail
-               :message  ~msg
-               :expected '~form
-               :actual   (tagged-for-pretty-printing (list '~'not (list 'match? ~matcher ~actual))
-                                                     result#)}))))
+        (core/matcher? ~matcher)
+        (let [result# (core/match ~matcher ~actual)]
+          (clojure.test/do-report
+           (if (core/match? result#)
+             {:type     :pass
+              :message  ~msg
+              :expected '~form
+              :actual   (list 'match? ~matcher ~actual)}
+             (with-file+line-info
+               {:type     :fail
+                :message  ~msg
+                :expected '~form
+                :actual   (tagged-for-pretty-printing (list '~'not (list 'match? ~matcher ~actual))
+                                                      result#)}))))
 
-       :else
-       (clojure.test/do-report
-        {:type     :fail
-         :message  ~msg
-         :expected (str "The first argument of match? needs to be a matcher (implement the match protocol)")
-         :actual   '~form})))))
+        :else
+        (clojure.test/do-report
+         {:type     :fail
+          :message  ~msg
+          :expected (str "The first argument of match? needs to be a matcher (implement the match protocol)")
+          :actual   '~form})))))
 
 (defmethod clojure.test/assert-expr 'thrown-match? [msg form]
   ;; (is (thrown-with-match? exception-class matcher expr))

--- a/src/clj/matcher_combinators/clj_test.clj
+++ b/src/clj/matcher_combinators/clj_test.clj
@@ -66,20 +66,19 @@
          :actual   '~form}))))
 
 (defmethod clojure.test/assert-expr 'match-with? [msg form]
-  (let [a              (rest form)
+  (let [args           (rest form)
         [type->matcher
          matcher
-         actual]       a]
-    (println a)
-    (dispatch/match-with-inner 
+         actual]       args]
+    (dispatch/match-with-inner
       type->matcher
      `(cond
-       (not (= 3 (do (println (list ~a)) (count (list ~a)))))
+       (not (= 3 (count '~args)))
        (clojure.test/do-report
-        {:type     :fail
-         :message  ~msg
-         :expected (symbol "`match-with?` expects 3 arguments: a `type->matcher` map, a `matcher`, and the `actual`")
-         :actual   (symbol (str (count ~a) " were provided: " '~form))})
+         {:type     :fail
+          :message  ~msg
+          :expected (symbol "`match-with?` expects 3 arguments: a `type->matcher` map, a `matcher`, and the `actual`")
+          :actual   (symbol (str (count '~args) " were provided: " '~form))})
 
        (core/matcher? ~matcher)
        (let [result# (core/match ~matcher ~actual)]

--- a/src/clj/matcher_combinators/midje.clj
+++ b/src/clj/matcher_combinators/midje.clj
@@ -64,19 +64,19 @@
           `(fn [~matcher-var]
              (fn [~actual-var]
                ~(dispatch/match-with-inner
-                  type->default-matcher
-                  `(if (core/matcher? ~matcher-var)
-                     (check-match ~matcher-var ~actual-var)
-                     (checking/as-data-laden-falsehood
-                       {:notes [(str "Input wasn't a matcher: " ~matcher-var)]}))))))
+                 type->default-matcher
+                 `(if (core/matcher? ~matcher-var)
+                    (check-match ~matcher-var ~actual-var)
+                    (checking/as-data-laden-falsehood
+                     {:notes [(str "Input wasn't a matcher: " ~matcher-var)]}))))))
       2 (let [[type->default-matcher matcher] args]
           `(fn [~actual-var]
              ~(dispatch/match-with-inner
-                type->default-matcher
-                `(if (core/matcher? ~matcher)
-                   (check-match ~matcher ~actual-var)
-                   (checking/as-data-laden-falsehood
-                     {:notes [(str "Input wasn't a matcher: " ~matcher)]})))))
+               type->default-matcher
+               `(if (core/matcher? ~matcher)
+                  (check-match ~matcher ~actual-var)
+                  (checking/as-data-laden-falsehood
+                   {:notes [(str "Input wasn't a matcher: " ~matcher)]})))))
       (throw (ArityException. arg-count "expected 1 or 2 arguments")))))
 
 (defn- parse-throws-args! [args]
@@ -144,12 +144,12 @@
     (let [func (fn [expected] (core/->PredMatcher (fn [actual]
                                                     (core/roughly? expected actual delta))))]
       (match-with
-        {java.lang.Integer    func
-         java.lang.Short      func
-         java.lang.Long       func
-         java.lang.Float      func
-         java.lang.Double     func
-         java.math.BigDecimal func
-         java.math.BigInteger func
-         clojure.lang.BigInt  func}
-        matcher))))
+       {java.lang.Integer    func
+        java.lang.Short      func
+        java.lang.Long       func
+        java.lang.Float      func
+        java.lang.Double     func
+        java.math.BigDecimal func
+        java.math.BigInteger func
+        clojure.lang.BigInt  func}
+       matcher))))

--- a/src/clj/matcher_combinators/midje.clj
+++ b/src/clj/matcher_combinators/midje.clj
@@ -5,6 +5,7 @@
             [matcher-combinators.model :as model]
             [matcher-combinators.parser]
             [matcher-combinators.result :as result]
+            [matcher-combinators.utils :as utils]
             [midje.data.metaconstant] ; otherwise Metaconstant class cannot be found
             [matcher-combinators.printer :as printer]
             [midje.checking.core :as checking]
@@ -142,7 +143,7 @@
   "match where all numbers match if they are within the delta of their expected value"
   (fn [delta matcher]
     (let [func (fn [expected] (core/->PredMatcher (fn [actual]
-                                                    (core/roughly? expected actual delta))))]
+                                                    (utils/roughly? expected actual delta))))]
       (match-with
        {java.lang.Integer    func
         java.lang.Short      func

--- a/src/cljc/matcher_combinators/cljs_test.cljc
+++ b/src/cljc/matcher_combinators/cljs_test.cljc
@@ -57,41 +57,11 @@
           :actual   '~form}))))
 
 (defmethod t/assert-expr 'match-with? [_ msg form]
-  (let [args           (rest form)
-        [type->matcher
-         matcher
-         actual]       args]
-    (dispatch/match-with-inner
-      type->matcher
-     `(cond
-       (not (= 3 (count '~args)))
-       (clojure.test/do-report
-         {:type     :fail
-          :message  ~msg
-          :expected (symbol "`match-with?` expects 3 arguments: a `type->matcher` map, a `matcher`, and the `actual`")
-          :actual   (symbol (str (count '~args) " were provided: " '~form))})
-
-       (core/matcher? ~matcher)
-       (let [result# (core/match ~matcher ~actual)]
-         (clojure.test/do-report
-          (if (core/match? result#)
-            {:type     :pass
-             :message  ~msg
-             :expected '~form
-             :actual   (list 'match? ~matcher ~actual)}
-            (with-file+line-info
-              {:type     :fail
-               :message  ~msg
-               :expected '~form
-               :actual   (tagged-for-pretty-printing (list '~'not (list 'match? ~matcher ~actual))
-                                                     result#)}))))
-
-       :else
-       (clojure.test/do-report
-        {:type     :fail
-         :message  ~msg
-         :expected (str "The first argument of match? needs to be a matcher (implement the match protocol)")
-         :actual   '~form})))))
+  `(clojure.test/do-report
+     {:type     :fail
+      :message  ~msg
+      :expected (symbol "`match-with?` not yet implemented for cljs")
+      :actual   '~form}))
 
 (defmethod t/assert-expr 'thrown-match? [_ msg form]
   ;; (is (thrown-with-match? exception-class matcher expr))

--- a/src/cljc/matcher_combinators/core.cljc
+++ b/src/cljc/matcher_combinators/core.cljc
@@ -396,3 +396,13 @@
     {::result/type  :mismatch
      ::result/value (model/->FailedPredicate (str func) actual)
      ::result/weight 1}))
+
+(defn roughly? [expected actual delta]
+  (and (number? actual)
+       (>= expected (-' actual delta))
+       (<= expected (+' actual delta))))
+
+(defrecord PredMatcher [pred-fn]
+  Matcher
+  (match [this actual]
+    (match-pred pred-fn actual)))

--- a/src/cljc/matcher_combinators/core.cljc
+++ b/src/cljc/matcher_combinators/core.cljc
@@ -397,11 +397,6 @@
      ::result/value (model/->FailedPredicate (str func) actual)
      ::result/weight 1}))
 
-(defn roughly? [expected actual delta]
-  (and (number? actual)
-       (>= expected (-' actual delta))
-       (<= expected (+' actual delta))))
-
 (defrecord PredMatcher [pred-fn]
   Matcher
   (match [this actual]

--- a/src/cljc/matcher_combinators/dispatch.cljc
+++ b/src/cljc/matcher_combinators/dispatch.cljc
@@ -50,39 +50,53 @@
 (defn function-dispatch [expected] (partial core/match-pred expected))
 
 (def type->dispatch
-  {nil                            #'nil-dispatch
-   java.lang.Class                #'class-dispatch
-   java.lang.Integer              #'integer-dispatch
-   java.lang.Short                #'short-dispatch
-   java.lang.Long                 #'long-dispatch
-   java.lang.Float                #'float-dispatch
-   java.lang.Double               #'double-dispatch
-   java.lang.String               #'string-dispatch
-   clojure.lang.Symbol            #'symbol-dispatch
-   clojure.lang.Keyword           #'keyword-dispatch
-   java.lang.Boolean              #'boolean-dispatch
-   java.util.UUID                 #'uuid-dispatch
-   java.util.Date                 #'date-dispatch
-   java.time.LocalDate            #'local-date-dispatch
-   java.time.LocalDateTime        #'local-date-time-dispatch
-   java.time.LocalTime            #'local-time-dispatch
-   java.time.YearMonth            #'year-month-dispatch
-   clojure.lang.Ratio             #'ratio-dispatch
-   java.math.BigDecimal           #'big-decimal-dispatch
-   java.math.BigInteger           #'big-integer-dispatch
-   clojure.lang.BigInt            #'big-int-dispatch
-   java.lang.Character            #'character-dispatch
-   clojure.lang.Var               #'var-dispatch
+  #?(:cljs {nil                  #'nil-dispatch
+            number               #'integer-dispatch
+            string               #'string-dispatch
+            clojure.lang.Keyword #'keyword-dispatch
+            boolean              #'boolean-dispatch
+            java.util.UUID       #'uuid-dispatch
+            js/Date              #'date-dispatch
+            Var                  #'var-dispatch
 
-   clojure.lang.IPersistentMap    #'i-persistent-map-dispatch
-   clojure.lang.IPersistentVector #'i-persistent-vector-dispatch
-   clojure.lang.IPersistentList   #'i-persistent-list-dispatch
-   clojure.lang.IPersistentSet    #'i-persistent-list-dispatch
-   clojure.lang.Cons              #'cons-dispatch
-   clojure.lang.Repeat            #'repeat-dispatch
-   clojure.lang.LazySeq           #'lazy-seq-dispatch
-   java.util.regex.Pattern        #'pattern-dispatch})
+            ;; since there is no cljs map/vectore type, use a symbol stand-in
+            'map                 #'i-persistent-map-dispatch
+            'vector              #'i-persistent-vector-dispatch
+            clojure.lang.Cons    #'cons-dispatch
+            clojure.lang.Repeat  #'repeat-dispatch
+            js/RegExp            #'pattern-dispatch}
+     :clj {nil                            #'nil-dispatch
+           java.lang.Class                #'class-dispatch
+           java.lang.Integer              #'integer-dispatch
+           java.lang.Short                #'short-dispatch
+           java.lang.Long                 #'long-dispatch
+           java.lang.Float                #'float-dispatch
+           java.lang.Double               #'double-dispatch
+           java.lang.String               #'string-dispatch
+           clojure.lang.Symbol            #'symbol-dispatch
+           clojure.lang.Keyword           #'keyword-dispatch
+           java.lang.Boolean              #'boolean-dispatch
+           java.util.UUID                 #'uuid-dispatch
+           java.util.Date                 #'date-dispatch
+           java.time.LocalDate            #'local-date-dispatch
+           java.time.LocalDateTime        #'local-date-time-dispatch
+           java.time.LocalTime            #'local-time-dispatch
+           java.time.YearMonth            #'year-month-dispatch
+           clojure.lang.Ratio             #'ratio-dispatch
+           java.math.BigDecimal           #'big-decimal-dispatch
+           java.math.BigInteger           #'big-integer-dispatch
+           clojure.lang.BigInt            #'big-int-dispatch
+           java.lang.Character            #'character-dispatch
+           clojure.lang.Var               #'var-dispatch
 
+           clojure.lang.IPersistentMap    #'i-persistent-map-dispatch
+           clojure.lang.IPersistentVector #'i-persistent-vector-dispatch
+           clojure.lang.IPersistentList   #'i-persistent-list-dispatch
+           clojure.lang.IPersistentSet    #'i-persistent-list-dispatch
+           clojure.lang.Cons              #'cons-dispatch
+           clojure.lang.Repeat            #'repeat-dispatch
+           clojure.lang.LazySeq           #'lazy-seq-dispatch
+           java.util.regex.Pattern        #'pattern-dispatch}))
 
 (def type-symbol->dispatch
   (->> type->dispatch

--- a/src/cljc/matcher_combinators/dispatch.cljc
+++ b/src/cljc/matcher_combinators/dispatch.cljc
@@ -50,21 +50,7 @@
 (defn function-dispatch [expected] (partial core/match-pred expected))
 
 (def type->dispatch
-  #?(:cljs {nil                  #'nil-dispatch
-            number               #'integer-dispatch
-            string               #'string-dispatch
-            clojure.lang.Keyword #'keyword-dispatch
-            boolean              #'boolean-dispatch
-            java.util.UUID       #'uuid-dispatch
-            js/Date              #'date-dispatch
-            Var                  #'var-dispatch
-
-            ;; since there is no cljs map/vectore type, use a symbol stand-in
-            'map                 #'i-persistent-map-dispatch
-            'vector              #'i-persistent-vector-dispatch
-            clojure.lang.Cons    #'cons-dispatch
-            clojure.lang.Repeat  #'repeat-dispatch
-            js/RegExp            #'pattern-dispatch}
+  #?(:cljs {}
      :clj {nil                            #'nil-dispatch
            java.lang.Class                #'class-dispatch
            java.lang.Integer              #'integer-dispatch

--- a/src/cljc/matcher_combinators/dispatch.cljc
+++ b/src/cljc/matcher_combinators/dispatch.cljc
@@ -1,0 +1,103 @@
+(ns matcher-combinators.dispatch
+  (:require [matcher-combinators.matchers :as matchers]
+            [matcher-combinators.core :as core])
+  #?(:clj
+     (:import [clojure.lang Keyword Symbol Ratio BigInt IPersistentMap
+               IPersistentVector IPersistentList IPersistentSet
+               LazySeq Repeat Cons Var]
+              [java.util UUID Date]
+              [java.util.regex Pattern]
+              [java.time LocalDate LocalDateTime LocalTime YearMonth])))
+
+;; equals base types
+(defn nil-dispatch [expected] (matchers/equals expected))
+(defn class-dispatch [expected] (matchers/equals expected))
+(defn integer-dispatch [expected] (matchers/equals expected))
+(defn short-dispatch [expected] (matchers/equals expected))
+(defn long-dispatch [expected] (matchers/equals expected))
+(defn float-dispatch [expected] (matchers/equals expected))
+(defn double-dispatch [expected] (matchers/equals expected))
+(defn string-dispatch [expected] (matchers/equals expected))
+(defn symbol-dispatch [expected] (matchers/equals expected))
+(defn keyword-dispatch [expected] (matchers/equals expected))
+(defn boolean-dispatch [expected] (matchers/equals expected))
+(defn uuid-dispatch [expected] (matchers/equals expected))
+(defn date-dispatch [expected] (matchers/equals expected))
+(defn local-date-dispatch [expected] (matchers/equals expected))
+(defn local-date-time-dispatch [expected] (matchers/equals expected))
+(defn local-time-dispatch [expected] (matchers/equals expected))
+(defn year-month-dispatch [expected] (matchers/equals expected))
+(defn ratio-dispatch [expected] (matchers/equals expected))
+(defn big-decimal-dispatch [expected] (matchers/equals expected))
+(defn big-integer-dispatch [expected] (matchers/equals expected))
+(defn big-int-dispatch [expected] (matchers/equals expected))
+(defn character-dispatch [expected] (matchers/equals expected))
+(defn var-dispatch [expected] (matchers/equals expected))
+
+;; equals compound types
+(defn i-persistent-vector-dispatch [expected] (matchers/equals expected))
+(defn i-persistent-list-dispatch [expected] (matchers/equals expected))
+(defn i-persistent-set-dispatch [expected] (matchers/equals expected))
+(defn cons-dispatch [expected] (matchers/equals expected))
+(defn repeat-dispatch [expected] (matchers/equals expected))
+(defn lazy-seq-dispatch [expected] (matchers/equals expected))
+
+;; embeds compound types
+(defn i-persistent-map-dispatch [expected] (matchers/embeds expected))
+
+;; other
+(defn pattern-dispatch [expected] (matchers/regex expected))
+(defn function-dispatch [expected] (core/match-pred expected))
+
+(def type->dispatch
+  {nil                            #'nil-dispatch
+   java.lang.Class                #'class-dispatch
+   java.lang.Integer              #'integer-dispatch
+   java.lang.Short                #'short-dispatch
+   java.lang.Long                 #'long-dispatch
+   java.lang.Float                #'float-dispatch
+   java.lang.Double               #'double-dispatch
+   java.lang.String               #'string-dispatch
+   clojure.lang.Symbol            #'symbol-dispatch
+   clojure.lang.Keyword           #'keyword-dispatch
+   java.lang.Boolean              #'boolean-dispatch
+   java.util.UUID                 #'uuid-dispatch
+   java.util.Date                 #'date-dispatch
+   java.time.LocalDate            #'local-date-dispatch
+   java.time.LocalDateTime        #'local-date-time-dispatch
+   java.time.LocalTime            #'local-time-dispatch
+   java.time.YearMonth            #'year-month-dispatch
+   clojure.lang.Ratio             #'ratio-dispatch
+   java.math.BigDecimal           #'big-decimal-dispatch
+   java.math.BigInteger           #'big-integer-dispatch
+   clojure.lang.BigInt            #'big-int-dispatch
+   java.lang.Character            #'character-dispatch
+   clojure.lang.Var               #'var-dispatch
+
+   clojure.lang.IPersistentMap    #'i-persistent-map-dispatch
+   clojure.lang.IPersistentVector #'i-persistent-vector-dispatch
+   clojure.lang.IPersistentList   #'i-persistent-list-dispatch
+   clojure.lang.IPersistentSet    #'i-persistent-list-dispatch
+   clojure.lang.Cons              #'cons-dispatch
+   clojure.lang.Repeat            #'repeat-dispatch
+   clojure.lang.LazySeq           #'lazy-seq-dispatch
+   java.util.regex.Pattern        #'pattern-dispatch})
+
+
+(def type-symbol->dispatch
+  (->> type->dispatch
+       (map (fn [[k v]] [(-> k pr-str symbol) v]))
+       (into {})))
+
+(defn var->qualified-ref [datatype]
+  (symbol (str
+            (-> type-symbol->dispatch datatype meta :ns ns-name)
+            "/"
+            (-> type-symbol->dispatch datatype meta :name))))
+
+(defmacro wrap-match-with [type->default-matcher body]
+  (let [dispatch-vars+matcher-targets (mapcat
+                                        (fn [[k v]] [(var->qualified-ref k) v])
+                                        type->default-matcher)]
+    `(with-redefs [~@dispatch-vars+matcher-targets]
+      ~body)))

--- a/src/cljc/matcher_combinators/parser.cljc
+++ b/src/cljc/matcher_combinators/parser.cljc
@@ -1,5 +1,6 @@
 (ns matcher-combinators.parser
   (:require [matcher-combinators.core :as core]
+            [matcher-combinators.dispatch :as dispatch]
             [matcher-combinators.matchers :as matchers])
   #?(:clj
      (:import [clojure.lang Keyword Symbol Ratio BigInt IPersistentMap
@@ -16,63 +17,63 @@
   ;; function as predicate
   function
   (match [this actual]
-    (core/match-pred this actual))
+    ((dispatch/function-dispatch this) actual))
 
   ;; equals base types
   nil
   (match [this actual]
-    (core/match (matchers/equals this) actual))
+    (core/match (dispatch/nil-dispatch this) actual))
 
   number
   (match [this actual]
-    (core/match (matchers/equals this) actual))
+    (core/match (dispatch/integer-dispatch this) actual))
 
   string
   (match [this actual]
-    (core/match (matchers/equals this) actual))
+    (core/match (dispatch/string-dispatch this) actual))
 
   boolean
   (match [this actual]
-    (core/match (matchers/equals this) actual))
+    (core/match (dispatch/boolean-dispatch this) actual))
 
   Keyword
   (match [this actual]
-    (core/match (matchers/equals this) actual))
+    (core/match (dispatch/keyword-dispatch this) actual))
 
   UUID
   (match [this actual]
-    (core/match (matchers/equals this) actual))
+    (core/match (dispatch/uuid-dispatch this) actual))
 
   js/Date
   (match [this actual]
-    (core/match (matchers/equals this) actual))
+    (core/match (dispatch/date-dispatch this) actual))
 
   Var
   (match [this actual]
-    (core/match (matchers/equals this) actual))
+    (core/match (dispatch/var-dispatch this) actual))
 
   ;; equals nested types
   Cons
   (match [this actual]
-    (core/match (matchers/equals this) actual))
+    (core/match (dispatch/cons-dispatch this) actual))
 
   Repeat
   (match [this actual]
-    (core/match (matchers/equals this) actual))
+    (core/match (dispatch/repeat-dispatch this) actual))
 
   default
   (match [this actual]
     (cond
       (satisfies? IMap this)
-      (core/match (matchers/embeds this) actual)
+      (core/match (dispatch/i-persistent-map-dispatch this) actual)
 
       (or (satisfies? ISet this)
           (satisfies? ISequential this))
-      (core/match (matchers/equals this) actual)))
+      (core/match (dispatch/i-persistent-vector-dispatch this) actual)))
 
   js/RegExp
   (match [this actual]
-    (core/match (matchers/regex this) actual))))
+    (core/match (dispatch/pattern-dispatch this) actual))))
 
 #?(:clj (do
 (defmacro mimic-matcher [matcher-builder & types]
@@ -93,41 +94,40 @@
 (extend-type clojure.lang.Fn
   core/Matcher
   (match [this actual]
-    (core/match-pred this actual)))
+    ((dispatch/function-dispatch this) actual)))
 
 (mimic-matcher-java-primitives matchers/equals
                                "[B")
 
-(mimic-matcher matchers/equals
-               nil
-               java.lang.Class
-               Integer
-               Short
-               Long
-               Float
-               Double
-               String
-               Symbol
-               Keyword
-               Boolean
-               UUID
-               Date
-               LocalDate
-               LocalDateTime
-               LocalTime
-               YearMonth
-               Ratio
-               BigDecimal
-               BigInteger
-               BigInt
-               Character
-               Var)
+(mimic-matcher dispatch/nil-dispatch nil)
+(mimic-matcher dispatch/class-dispatch java.lang.Class)
+(mimic-matcher dispatch/integer-dispatch Integer)
+(mimic-matcher dispatch/short-dispatch Short)
+(mimic-matcher dispatch/long-dispatch Long)
+(mimic-matcher dispatch/float-dispatch Float)
+(mimic-matcher dispatch/double-dispatch Double)
+(mimic-matcher dispatch/string-dispatch String)
+(mimic-matcher dispatch/symbol-dispatch Symbol)
+(mimic-matcher dispatch/keyword-dispatch Keyword)
+(mimic-matcher dispatch/boolean-dispatch Boolean)
+(mimic-matcher dispatch/uuid-dispatch UUID)
+(mimic-matcher dispatch/date-dispatch Date)
+(mimic-matcher dispatch/local-date-dispatch LocalDate)
+(mimic-matcher dispatch/local-date-time-dispatch LocalDateTime)
+(mimic-matcher dispatch/local-time-dispatch LocalTime)
+(mimic-matcher dispatch/year-month-dispatch YearMonth)
+(mimic-matcher dispatch/ratio-dispatch Ratio)
+(mimic-matcher dispatch/big-decimal-dispatch BigDecimal)
+(mimic-matcher dispatch/big-integer-dispatch BigInteger)
+(mimic-matcher dispatch/big-int-dispatch BigInt)
+(mimic-matcher dispatch/character-dispatch Character)
+(mimic-matcher dispatch/var-dispatch Var)
 
-(mimic-matcher matchers/embeds IPersistentMap)
-(mimic-matcher matchers/equals IPersistentVector)
-(mimic-matcher matchers/equals IPersistentList)
-(mimic-matcher matchers/equals IPersistentSet)
-(mimic-matcher matchers/equals Cons)
-(mimic-matcher matchers/equals Repeat)
-(mimic-matcher matchers/equals LazySeq)
-(mimic-matcher matchers/regex Pattern)))
+(mimic-matcher dispatch/i-persistent-map-dispatch IPersistentMap)
+(mimic-matcher dispatch/i-persistent-vector-dispatch IPersistentVector)
+(mimic-matcher dispatch/i-persistent-list-dispatch IPersistentList)
+(mimic-matcher dispatch/i-persistent-list-dispatch IPersistentSet)
+(mimic-matcher dispatch/cons-dispatch Cons)
+(mimic-matcher dispatch/repeat-dispatch Repeat)
+(mimic-matcher dispatch/lazy-seq-dispatch LazySeq)
+(mimic-matcher dispatch/pattern-dispatch Pattern)))

--- a/src/cljc/matcher_combinators/test.cljc
+++ b/src/cljc/matcher_combinators/test.cljc
@@ -1,5 +1,6 @@
 (ns matcher-combinators.test
   (:require
+    [matcher-combinators.dispatch :as dispatch]
     #?(:cljs [cljs.test    :as t :refer-macros [is are deftest testing]]
        :clj  [clojure.test :as t :refer        [is are deftest testing]])
     #?(:cljs [matcher-combinators.cljs-test]
@@ -8,3 +9,12 @@
 (declare match?)
 (declare match-with?)
 (declare thrown-match?)
+
+#?(:clj
+   (def build-match-assert
+     "Allows you to define a custom clojure.test match assert:
+
+
+     `(defmethod clojure.test/assert-expr 'baz? [msg form]
+     (build-match-assert 'baz? {java.lang.Long greater-than-matcher} msg form))`"
+     matcher-combinators.clj-test/build-match-assert))

--- a/src/cljc/matcher_combinators/test.cljc
+++ b/src/cljc/matcher_combinators/test.cljc
@@ -6,3 +6,5 @@
        :clj  [matcher-combinators.clj-test])))
 
 (declare match?)
+(declare match-with?)
+(declare thrown-match?)

--- a/src/cljc/matcher_combinators/utils.cljc
+++ b/src/cljc/matcher_combinators/utils.cljc
@@ -1,0 +1,7 @@
+(ns matcher-combinators.utils)
+
+(defn roughly? [expected actual delta]
+  (and (number? actual)
+       (>= expected (-' actual delta))
+       (<= expected (+' actual delta))))
+

--- a/test/clj/matcher_combinators/core_test.clj
+++ b/test/clj/matcher_combinators/core_test.clj
@@ -314,14 +314,9 @@
 ;; Since the parser namespace needs to be loaded to interpret functions as
 ;; matchers, and we don't want to load the parser namespce, we need to manually
 ;; wrap functions in a predicate matcher
-(defrecord PredMatcher [expected]
-  core/Matcher
-  (match [this actual]
-    (core/match-pred expected actual)))
-
 (defn- pred-matcher [expected]
   (assert ifn? expected)
-  (->PredMatcher expected))
+  (core/->PredMatcher expected))
 
 (fact
  (match (equals [(pred-matcher odd?) (pred-matcher even?)]) [1 2])

--- a/test/clj/matcher_combinators/dispatch_test.clj
+++ b/test/clj/matcher_combinators/dispatch_test.clj
@@ -35,8 +35,8 @@
 
   (fact "low-level invocation"
     (dispatch/wrap-match-with
-      {java.lang.Long ->AbsValue}
-      (s/match? -1 1))
+     {java.lang.Long ->AbsValue}
+     (s/match? -1 1))
     => true)
 
   (fact "using 2-arg match-with"
@@ -61,7 +61,7 @@
 
 (defn greater-than-matcher [expected-long]
   (matcher-combinators.core/->PredMatcher
-    (fn [actual] (> actual expected-long))))
+   (fn [actual] (> actual expected-long))))
 
 (fact "example from docstring"
   5 => (match-with {java.lang.Long greater-than-matcher}

--- a/test/clj/matcher_combinators/dispatch_test.clj
+++ b/test/clj/matcher_combinators/dispatch_test.clj
@@ -1,16 +1,36 @@
 (ns matcher-combinators.dispatch_test
   (:require [midje.sweet :as midje :refer [fact facts => falsey]]
             [matcher-combinators.core :as core]
+            [matcher-combinators.midje :refer [match-with]]
             [matcher-combinators.matchers :as m]
             [matcher-combinators.dispatch :as dispatch]
             [matcher-combinators.standalone :as s]))
 
+(defn abs [x]
+  (if (neg? x)
+    (* -1 x)
+    x))
+; (clojure.pprint/pprint (macroexpand `(match-with {clojure.lang.IPersistentMap m/equals} {:a 1 :b odd?})))
+
+(def x {clojure.lang.IPersistentMap m/equals})
+(def match-strict (match-with {clojure.lang.IPersistentMap m/equals}))
 (fact
   (s/match? -1 1) => false
 
   (dispatch/wrap-match-with
     {java.lang.Long (fn [x] (core/->Value (abs x)))}
     (s/match? -1 1))
-  => true)
+  => true
+
+  (dispatch/wrap-match-with
+   {clojure.lang.IPersistentMap m/equals}
+    (s/match? {:a 1 :b odd?} {:a 1 :b 2})) => true
+
+  {:a 1 :b 3} => (match-with
+                   {clojure.lang.IPersistentMap m/equals}
+                   {:a 1 :b odd?})
+
+  {:a 1 :b 3} => (match-strict {:a 1 :b odd?})
+  )
 
 

--- a/test/clj/matcher_combinators/dispatch_test.clj
+++ b/test/clj/matcher_combinators/dispatch_test.clj
@@ -1,7 +1,9 @@
 (ns matcher-combinators.dispatch_test
   (:require [midje.sweet :as midje :refer [fact facts => falsey]]
             [matcher-combinators.core :as core]
-            [matcher-combinators.midje :refer [match-with]]
+            [matcher-combinators.midje :refer [match match-with match-equals match-roughly]]
+            [matcher-combinators.result :as result]
+            [matcher-combinators.model :as model]
             [matcher-combinators.matchers :as m]
             [matcher-combinators.dispatch :as dispatch]
             [matcher-combinators.standalone :as s]))
@@ -10,27 +12,57 @@
   (if (neg? x)
     (* -1 x)
     x))
-; (clojure.pprint/pprint (macroexpand `(match-with {clojure.lang.IPersistentMap m/equals} {:a 1 :b odd?})))
 
-(def x {clojure.lang.IPersistentMap m/equals})
-(def match-strict (match-with {clojure.lang.IPersistentMap m/equals}))
-(fact
+(defrecord AbsValue [expected]
+  core/Matcher
+  (match [_this actual]
+    (cond
+      (= ::missing actual) {::result/type   :mismatch
+                            ::result/value  (model/->Missing expected)
+                            ::result/weight 1}
+      (= (abs expected)
+         (abs actual))     {::result/type   :match
+                            ::result/value  actual
+                            ::result/weight 0}
+      :else                {::result/type   :mismatch
+                            ::result/value  (model/->Mismatch expected actual)
+                            ::result/weight 1})))
+
+(def match-abs (match-with {java.lang.Long ->AbsValue}))
+
+(facts "match-with checker behavior"
   (s/match? -1 1) => false
 
-  (dispatch/wrap-match-with
-    {java.lang.Long (fn [x] (core/->Value (abs x)))}
-    (s/match? -1 1))
-  => true
+  (fact "low-level invocation"
+    (dispatch/wrap-match-with
+      {java.lang.Long ->AbsValue}
+      (s/match? -1 1))
+    => true)
 
-  (dispatch/wrap-match-with
-   {clojure.lang.IPersistentMap m/equals}
-    (s/match? {:a 1 :b odd?} {:a 1 :b 2})) => true
+  (fact "using 2-arg match-with"
+    1 => (match-with {java.lang.Long ->AbsValue} -1)
+    -1 => (match-with {java.lang.Long ->AbsValue} 1))
+  (fact "binding 1-arg match-with to new checker"
+    1 => (match-abs -1)
+    -1 => (match-abs 1)))
 
-  {:a 1 :b 3} => (match-with
-                   {clojure.lang.IPersistentMap m/equals}
-                   {:a 1 :b odd?})
+(facts "match-equals"
+  (fact "normal loose matching passes"
+    {:a 1 :b 3 :c 1} => (match {:a 1 :b odd?}))
+  (fact "match-equals is more strict"
+    {:a 1 :b 3 :c 1} =not=> (match-equals {:a 1 :b odd?})
+    {:a 1 :b 3} => (match-equals {:a 1 :b odd?})))
 
-  {:a 1 :b 3} => (match-strict {:a 1 :b odd?})
-  )
+(fact "match-roughly"
+  {:a 1 :b 3.05} => (match-roughly 0.1
+                                   {:a 1 :b 3.0})
+  {:a 1 :b 3.05} =not=> (match-roughly 0.001
+                                       {:a 1 :b 3.0}))
 
+(defn greater-than-matcher [expected-long]
+  (matcher-combinators.core/->PredMatcher
+    (fn [actual] (> actual expected-long))))
 
+(fact "example from docstring"
+  5 => (match-with {java.lang.Long greater-than-matcher}
+                   4))

--- a/test/clj/matcher_combinators/dispatch_test.clj
+++ b/test/clj/matcher_combinators/dispatch_test.clj
@@ -1,0 +1,16 @@
+(ns matcher-combinators.dispatch_test
+  (:require [midje.sweet :as midje :refer [fact facts => falsey]]
+            [matcher-combinators.core :as core]
+            [matcher-combinators.matchers :as m]
+            [matcher-combinators.dispatch :as dispatch]
+            [matcher-combinators.standalone :as s]))
+
+(fact
+  (s/match? -1 1) => false
+
+  (dispatch/wrap-match-with
+    {java.lang.Long (fn [x] (core/->Value (abs x)))}
+    (s/match? -1 1))
+  => true)
+
+

--- a/test/clj/matcher_combinators/dispatch_test.clj
+++ b/test/clj/matcher_combinators/dispatch_test.clj
@@ -51,7 +51,18 @@
     {:a 1 :b 3 :c 1} => (match {:a 1 :b odd?}))
   (fact "match-equals is more strict"
     {:a 1 :b 3 :c 1} =not=> (match-equals {:a 1 :b odd?})
-    {:a 1 :b 3} => (match-equals {:a 1 :b odd?})))
+    {:a 1 :b 3} => (match-equals {:a 1 :b odd?}))
+  (let [payload {:a {:b {:c 1}
+                     :d {:e {:inner-e {:x 1 :y 2}}
+                         :f 5
+                         :g 17}}}]
+    (fact "nested maps inside of an `embeds` of a match-equals are treated as equals"
+      payload
+      =not=> (match-equals {:a {:b {:c 1}
+                                :d (m/embeds {:e {:inner-e {:x 1}}})}})
+      payload
+      => (match-equals {:a {:b {:c 1}
+                            :d (m/embeds {:e {:inner-e {:x 1 :y 2}}})}}))))
 
 (fact "match-roughly"
   {:a 1 :b 3.05} => (match-roughly 0.1

--- a/test/clj/matcher_combinators/test_test.clj
+++ b/test/clj/matcher_combinators/test_test.clj
@@ -1,6 +1,6 @@
 (ns matcher-combinators.test-test
   (:require [clojure.test :refer :all]
-            [matcher-combinators.test]
+            [matcher-combinators.test :refer [build-match-assert]]
             [matcher-combinators.core :as core]
             [matcher-combinators.matchers :as m])
   (:import [clojure.lang ExceptionInfo]))
@@ -55,3 +55,11 @@
   (is (match-with? {java.lang.Long greater-than-matcher}
                    4
                    5)))
+
+(clojure.pprint/pprint (macroexpand `(build-match-assert foo? {java.lang.Long greater-than-matcher})))
+
+(defmethod clojure.test/assert-expr 'baz? [msg form]
+  (build-match-assert 'baz? {java.lang.Long greater-than-matcher} msg form))
+
+(deftest match-baz-test
+  (is (baz? 4 5)))

--- a/test/clj/matcher_combinators/test_test.clj
+++ b/test/clj/matcher_combinators/test_test.clj
@@ -46,3 +46,12 @@
     (testing "fails with nice message when you don't provide an `actual` arg to `thrown-match?`"
       (is (thrown-match? ExceptionInfo {:a 1})
           :in-wrong-place))))
+
+(defn greater-than-matcher [expected-long]
+  (core/->PredMatcher
+    (fn [actual] (> actual expected-long))))
+
+(deftest match-with-test
+  (is (match-with? {java.lang.Long greater-than-matcher}
+                   4
+                   5)))

--- a/test/clj/matcher_combinators/test_test.clj
+++ b/test/clj/matcher_combinators/test_test.clj
@@ -49,7 +49,7 @@
 
 (defn greater-than-matcher [expected-long]
   (core/->PredMatcher
-    (fn [actual] (> actual expected-long))))
+   (fn [actual] (> actual expected-long))))
 
 (deftest match-with-test
   (is (match-with? {java.lang.Long greater-than-matcher}

--- a/test/clj/matcher_combinators/test_test.clj
+++ b/test/clj/matcher_combinators/test_test.clj
@@ -56,10 +56,12 @@
                    4
                    5)))
 
-(clojure.pprint/pprint (macroexpand `(build-match-assert foo? {java.lang.Long greater-than-matcher})))
-
-(defmethod clojure.test/assert-expr 'baz? [msg form]
-  (build-match-assert 'baz? {java.lang.Long greater-than-matcher} msg form))
+(defmethod clojure.test/assert-expr 'match-greather-than? [msg form]
+  (build-match-assert 'match-greather-than? {java.lang.Long greater-than-matcher} msg form))
 
 (deftest match-baz-test
-  (is (baz? 4 5)))
+  (is (match-greather-than? 4 5)))
+
+(deftest match-equals-test
+  (is (match-equals? {:a 1}
+                     {:a 1})))

--- a/test/clj/matcher_combinators/test_test.clj
+++ b/test/clj/matcher_combinators/test_test.clj
@@ -59,7 +59,7 @@
 (defmethod clojure.test/assert-expr 'match-greather-than? [msg form]
   (build-match-assert 'match-greather-than? {java.lang.Long greater-than-matcher} msg form))
 
-(deftest match-baz-test
+(deftest match-greater-than-test
   (is (match-greather-than? 4 5)))
 
 (deftest match-equals-test

--- a/test/cljs/matcher_combinators/cljs_example_test.cljs
+++ b/test/cljs/matcher_combinators/cljs_example_test.cljs
@@ -72,3 +72,12 @@
     (testing "fails with nice message when you don't provide an `actual` arg to `thrown-match?`"
       (is (thrown-match? ExceptionInfo {:a 1})
           :in-wrong-place))))
+
+(defn greater-than-matcher [expected-long]
+  (c/->PredMatcher
+    (fn [actual] (> actual expected-long))))
+
+(deftest match-with-test
+  (is (match-with? {number greater-than-matcher}
+                   4
+                   5)))

--- a/test/cljs/matcher_combinators/cljs_example_test.cljs
+++ b/test/cljs/matcher_combinators/cljs_example_test.cljs
@@ -72,12 +72,3 @@
     (testing "fails with nice message when you don't provide an `actual` arg to `thrown-match?`"
       (is (thrown-match? ExceptionInfo {:a 1})
           :in-wrong-place))))
-
-(defn greater-than-matcher [expected-long]
-  (c/->PredMatcher
-    (fn [actual] (> actual expected-long))))
-
-(deftest match-with-test
-  (is (match-with? {number greater-than-matcher}
-                   4
-                   5)))


### PR DESCRIPTION
another attempt at https://github.com/nubank/matcher-combinators/pull/29

Inside the context of `match?` (clojure.test) / `match` (midje), data-structures are assigned default matchers, which eliminates the need to wrap data-structures with matcher-combinators when your desired matching behavior matches the defaults.

But what if your desired matching behavior deviates from the defaults?

For example, if you want to do exact map matching you need to use a log of `m/equals`:

```clojure
(deftest exact-map-matching-by-hand
  (is (match? (m/equals {:a (m/equals {:b (m/equals {:c odd?})})}))
              {:a {:b {:c 1}}})
  ;; without m/equals, the system defaults to m/embeds for maps,
  ;; which has looser matching properties
  (is (match? {:a {:b {:c odd?}}}
              {:a {:b {:c 1 :extra-c 0} :extra-b 0} :extra-a 0})))
```

This verbosity can be avoided by redefining the matcher data-type defaults

### clojure.test

You can register a custom `clojure.test` match assert expression if you are going to use it a few times:

```clojure
(defmethod clojure.test/assert-expr 'match-equals? [msg form]
  (matcher-combinators.test/build-match-assert 'match-equals? {clojure.lang.IPersistentMap m/equals} msg form))

(deftest match-equals-test
  (is (match-equals? {:a {:b {:c odd?}}}
                     {:a {:b {:c 1}}})))
```

Or if you want a one-off override of defaults, it can be done `match-with?`:

```
(deftest one-off-match-equals
  (is (match-with? {clojure.lang.IPersistentMap m/equals}
                   {:a {:b {:c odd?}}}
                   {:a {:b {:c 1}}})))
```

#### built-in matching context

- `match?`
- `match-with?`
- `match-equals?`

### midje

```clojure
(fact "match-with example"
  {:a {:b {:c odd?}}} => (match-with {clojure.lang.IPersistentMap m/equals}
                                     {:a {:b {:c odd?}}}))
(fact "match-equals example"
  {:a {:b {:c odd?}}} => (match-equals {:a {:b {:c odd?}}}))
```

#### built-in matching context

- `match`
- `match-with`
- `match-roughly`
- `match-equals`
