### PR TITLE
Implement core/Matcher for java.net.URI using mimic-matcher

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@ All notable changes to this project will be documented in this file. This
 change log follows the conventions of
 [keepachangelog.com](http://keepachangelog.com/).
 
+## [1.2.4]
+- Default to `equals` matcher for URIs
+
 ## [1.2.3]
 - Fix performance regression with order-agnostic matchers (`in-any-order`, `embeds`, `set-{embeds|equals}`)
 

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject nubank/matcher-combinators "1.2.3"
+(defproject nubank/matcher-combinators "1.2.4"
   :description "Library for creating matcher combinator to compare nested data structures"
   :url "https://github.com/nubank/matcher-combinators"
   :license {:name "Apache License, Version 2.0"}

--- a/src/cljc/matcher_combinators/dispatch.cljc
+++ b/src/cljc/matcher_combinators/dispatch.cljc
@@ -9,6 +9,9 @@
               [java.util.regex Pattern]
               [java.time LocalDate LocalDateTime LocalTime YearMonth])))
 
+(defn- cljs-uri [expected]
+  (core/->CljsUriEquals expected))
+
 ;; equals base types
 (defn nil-dispatch [expected] (matchers/equals expected))
 (defn class-dispatch [expected] (matchers/equals expected))
@@ -22,7 +25,9 @@
 (defn keyword-dispatch [expected] (matchers/equals expected))
 (defn boolean-dispatch [expected] (matchers/equals expected))
 (defn uuid-dispatch [expected] (matchers/equals expected))
-(defn uri-dispatch [expected] (matchers/equals expected))
+(defn uri-dispatch [expected]
+  #?(:clj  (matchers/equals expected)
+     :cljs (cljs-uri expected)))
 (defn date-dispatch [expected] (matchers/equals expected))
 (defn local-date-dispatch [expected] (matchers/equals expected))
 (defn local-date-time-dispatch [expected] (matchers/equals expected))

--- a/src/cljc/matcher_combinators/parser.cljc
+++ b/src/cljc/matcher_combinators/parser.cljc
@@ -5,6 +5,7 @@
      (:import [clojure.lang Keyword Symbol Ratio BigInt IPersistentMap
                IPersistentVector IPersistentList IPersistentSet
                LazySeq Repeat Cons Var]
+              [java.net URI]
               [java.util UUID Date]
               [java.util.regex Pattern]
               [java.time LocalDate LocalDateTime LocalTime YearMonth])))
@@ -111,6 +112,7 @@
                Keyword
                Boolean
                UUID
+               URI
                Date
                LocalDate
                LocalDateTime

--- a/src/cljc/matcher_combinators/parser.cljc
+++ b/src/cljc/matcher_combinators/parser.cljc
@@ -2,14 +2,14 @@
   (:require [matcher-combinators.core :as core]
             [matcher-combinators.dispatch :as dispatch]
             [matcher-combinators.matchers :as matchers])
-  #?(:clj
-     (:import [clojure.lang Keyword Symbol Ratio BigInt IPersistentMap
-               IPersistentVector IPersistentList IPersistentSet
-               LazySeq Repeat Cons Var]
-              [java.net URI]
-              [java.util UUID Date]
-              [java.util.regex Pattern]
-              [java.time LocalDate LocalDateTime LocalTime YearMonth])))
+  #?(:cljs (:import goog.Uri)
+     :clj  (:import [clojure.lang Keyword Symbol Ratio BigInt IPersistentMap
+                IPersistentVector IPersistentList IPersistentSet
+                LazySeq Repeat Cons Var]
+               [java.net URI]
+               [java.util UUID Date]
+               [java.util.regex Pattern]
+               [java.time LocalDate LocalDateTime LocalTime YearMonth])))
 
 #?(:cljs
 (extend-protocol
@@ -45,7 +45,7 @@
   (match [this actual]
     (core/match (dispatch/uuid-dispatch this) actual))
 
-  URI
+  goog.Uri
   (match [this actual]
     (core/match (dispatch/uri-dispatch this) actual))
 

--- a/test/cljs/matcher_combinators/cljs_example_test.cljs
+++ b/test/cljs/matcher_combinators/cljs_example_test.cljs
@@ -4,11 +4,13 @@
             [matcher-combinators.parser]
             [matcher-combinators.matchers :as m]
             [matcher-combinators.core :as c]
-            [matcher-combinators.test]))
+            [matcher-combinators.test])
+  (:import [goog.Uri]))
 
 (def now-date (js/Date.))
 (def now-time (.getTime now-date))
 (def a-var (var now-time))
+(def uri (goog.Uri.parse "http://www.google.com:80/path?q=query#frag\nmento"))
 
 (deftest basic-examples
   (testing "does it work?"
@@ -21,6 +23,10 @@
     (is (match? 0.1 0.1))
     (is (match? (uuid "00000000-0000-0000-0000-000000000000")
                 (uuid "00000000-0000-0000-0000-000000000000")))
+    (is (match? uri
+                uri))
+    (is (match? (goog.Uri.parse "http://www.google.com:80/path?q=query#frag\nmento")
+                (goog.Uri.parse "http://www.google.com:80/path?q=query#frag\nmento")))
     (is (match? now-date
                 now-date))
     (is (match? now-time


### PR DESCRIPTION
In the snippet:
```clojure
(fact "bare URI"
  (java.net.URI. "http://example.com") => (match (java.net.URI. "http://example.com")))

(fact "URI in map"
  {:a (java.net.URI. "http://example.com")} => (match {:a (java.net.URI. "http://example.com")}))
```

Before the change:
- the "bare URI" fact would return false and say that `Input wasn't a matcher`;
- the "URI in map" fact would throw an `IllegalArgumentException` because
`java.net.URI` doesn't implement the `#'matcher-combinators.core/Matcher`
protocol.

After the change both would match and return true.