### PR TITLE
fix clojure.test line number / file name report issue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@ All notable changes to this project will be documented in this file. This
 change log follows the conventions of
 [keepachangelog.com](http://keepachangelog.com/).
 
+## [1.2.1]
+- Fix issue where clojure.test mismatches wouldn't report the correct line number or file
+
 ## [1.2.0]
 Add new matching contexts:
 For Midje:

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject nubank/matcher-combinators "1.2.0"
+(defproject nubank/matcher-combinators "1.2.1"
   :description "Library for creating matcher combinator to compare nested data structures"
   :url "https://github.com/nubank/matcher-combinators"
   :license {:name "Apache License, Version 2.0"}

--- a/src/clj/matcher_combinators/clj_test.clj
+++ b/src/clj/matcher_combinators/clj_test.clj
@@ -17,7 +17,7 @@
 
 (defn- core-or-this-class-name? [^StackTraceElement stacktrace]
   (let [cl-name (.getClassName stacktrace)]
-    (or (str/starts-with? cl-name "matcher_combinators.clj-test$")
+    (or (str/starts-with? cl-name "matcher_combinators.clj_test$")
         (str/starts-with? cl-name "java.lang."))))
 
 ;; had to include this from `clojure.test` because there is no good way to run


### PR DESCRIPTION
mismatches for a file like 
```
1 (ns example (:require [clojure.test :refer :all] [matcher-combinators.test :refer [match?]]))
2 (deftest example
3   (testing "foo"
4     (is (match? 1 2))))
```
would show

```
FAIL in (example) (clj_test.clj:26)
foo
expected: (match? 1 2)
  actual: (mismatch 1 2)
```

instead of

```
FAIL in (example) (scratch.clj:4)
foo
expected: (match? 1 2)
  actual: (mismatch 1 2)
```