### PR TITLE
Default matcher for chunked-seq

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@ All notable changes to this project will be documented in this file. This
 change log follows the conventions of
 [keepachangelog.com](http://keepachangelog.com/).
 
+## [1.2.5]
+- Default to `equals` matcher for chunked-sequences
+
 ## [1.2.4]
 - Default to `equals` matcher for URIs
 

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject nubank/matcher-combinators "1.2.4"
+(defproject nubank/matcher-combinators "1.2.5"
   :description "Library for creating matcher combinator to compare nested data structures"
   :url "https://github.com/nubank/matcher-combinators"
   :license {:name "Apache License, Version 2.0"}

--- a/src/cljc/matcher_combinators/dispatch.cljc
+++ b/src/cljc/matcher_combinators/dispatch.cljc
@@ -42,6 +42,7 @@
 
 ;; equals compound types
 (defn i-persistent-vector-dispatch [expected] (matchers/equals expected))
+(defn chunked-seq-dispatch [expected] (matchers/equals expected))
 (defn i-persistent-list-dispatch [expected] (matchers/equals expected))
 (defn i-persistent-set-dispatch [expected] (matchers/equals expected))
 (defn cons-dispatch [expected] (matchers/equals expected))
@@ -81,14 +82,15 @@
            java.lang.Character            #'character-dispatch
            clojure.lang.Var               #'var-dispatch
 
-           clojure.lang.IPersistentMap    #'i-persistent-map-dispatch
-           clojure.lang.IPersistentVector #'i-persistent-vector-dispatch
-           clojure.lang.IPersistentList   #'i-persistent-list-dispatch
-           clojure.lang.IPersistentSet    #'i-persistent-list-dispatch
-           clojure.lang.Cons              #'cons-dispatch
-           clojure.lang.Repeat            #'repeat-dispatch
-           clojure.lang.LazySeq           #'lazy-seq-dispatch
-           java.util.regex.Pattern        #'pattern-dispatch}))
+           clojure.lang.IPersistentMap              #'i-persistent-map-dispatch
+           clojure.lang.IPersistentVector           #'i-persistent-vector-dispatch
+           clojure.lang.PersistentVector$ChunkedSeq #'chunked-seq-dispatch
+           clojure.lang.IPersistentList             #'i-persistent-list-dispatch
+           clojure.lang.IPersistentSet              #'i-persistent-list-dispatch
+           clojure.lang.Cons                        #'cons-dispatch
+           clojure.lang.Repeat                      #'repeat-dispatch
+           clojure.lang.LazySeq                     #'lazy-seq-dispatch
+           java.util.regex.Pattern                  #'pattern-dispatch}))
 
 (def type-symbol->dispatch
   (->> type->dispatch

--- a/src/cljc/matcher_combinators/parser.cljc
+++ b/src/cljc/matcher_combinators/parser.cljc
@@ -4,7 +4,7 @@
             [matcher-combinators.matchers :as matchers])
   #?(:cljs (:import goog.Uri)
      :clj  (:import [clojure.lang Keyword Symbol Ratio BigInt IPersistentMap
-                IPersistentVector IPersistentList IPersistentSet
+                PersistentVector$ChunkedSeq IPersistentVector IPersistentList IPersistentSet
                 LazySeq Repeat Cons Var]
                [java.net URI]
                [java.util UUID Date]
@@ -131,6 +131,8 @@
 
 (mimic-matcher dispatch/i-persistent-map-dispatch IPersistentMap)
 (mimic-matcher dispatch/i-persistent-vector-dispatch IPersistentVector)
+(mimic-matcher dispatch/chunked-seq-dispatch PersistentVector$ChunkedSeq)
+(mimic-matcher dispatch/i-persistent-vector-dispatch Pattern)
 (mimic-matcher dispatch/i-persistent-list-dispatch IPersistentList)
 (mimic-matcher dispatch/i-persistent-list-dispatch IPersistentSet)
 (mimic-matcher dispatch/cons-dispatch Cons)

--- a/test/clj/matcher_combinators/dispatch_test.clj
+++ b/test/clj/matcher_combinators/dispatch_test.clj
@@ -77,3 +77,13 @@
 (fact "example from docstring"
   5 => (match-with {java.lang.Long greater-than-matcher}
                    4))
+
+(def chunked-seq (seq [1]))
+(fact "chunked-seq remap"
+  (s/match? chunked-seq [1 2 3])
+  => false
+
+  (dispatch/wrap-match-with
+    {clojure.lang.PersistentVector$ChunkedSeq core/->EmbedsSeq}
+    (s/match? chunked-seq [1 2 3]))
+  => true)

--- a/test/clj/matcher_combinators/parser_test.clj
+++ b/test/clj/matcher_combinators/parser_test.clj
@@ -97,6 +97,10 @@
       (core/match [10] [10]))
     => truthy))
 
+(def chunked-seq (seq [1 2 3]))
+(fact "chunked sequences act as equals matchers"
+  (core/match chunked-seq [10])) => truthy
+
 (fact "lists also act as equals matchers"
   (fact
    (= (core/match (equals [(equals 10)]) [10])


### PR DESCRIPTION
Never heard of `chunked-seq` in clojure but I guess they are a thing because a test was failing because it didn't have the match protocol implemented for it.

didn't find much info on them, maybe https://stackoverflow.com/questions/25711534/what-does-types-like-clojure-lang-persistentvectorchunkedseq-mean-in-clojure