### PR TITLE
replace +' with + in roughly matching

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ change log follows the conventions of
 [keepachangelog.com](http://keepachangelog.com/).
 
 ## [1.2.6]
+- replace `+'` with `+` and `-'` with `-` in roughly matching
 - Default to `equals` matcher for array-seq
 
 ## [1.2.5]

--- a/src/cljc/matcher_combinators/utils.cljc
+++ b/src/cljc/matcher_combinators/utils.cljc
@@ -2,8 +2,8 @@
 
 (defn roughly? [expected actual delta]
   (and (number? actual)
-       (>= expected (-' actual delta))
-       (<= expected (+' actual delta))))
+       (>= expected (- actual delta))
+       (<= expected (+ actual delta))))
 
 (defn find-first [pred coll]
   (->> coll (filter pred) first))


### PR DESCRIPTION
It was code adapted from midje and I don't know why the `+'` was used instead of `+`.

addresses https://github.com/nubank/matcher-combinators/issues/90