### PR TITLE
Optionally allow omitting the first argument to `thrown-match?`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@ All notable changes to this project will be documented in this file. This
 change log follows the conventions of
 [keepachangelog.com](http://keepachangelog.com/).
 
+## [1.2.7]
+- Optionally allow omitting the first argument to `thrown-match?`: `(thrown-match? {:foo 1} (bang!)`
+
 ## [1.2.6]
 - replace `+'` with `+` and `-'` with `-` in roughly matching
 - Default to `equals` matcher for array-seq

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject nubank/matcher-combinators "1.2.6"
+(defproject nubank/matcher-combinators "1.2.7"
   :description "Library for creating matcher combinator to compare nested data structures"
   :url "https://github.com/nubank/matcher-combinators"
   :license {:name "Apache License, Version 2.0"}

--- a/project.clj
+++ b/project.clj
@@ -29,7 +29,7 @@
                                   [org.clojure/clojurescript "1.10.520"]]}
              :1.8 {:dependencies [[org.clojure/clojure "1.8.0"]]}}
 
-  :aliases {"lint"     ["do" "cljfmt"]
+  :aliases {"lint"     ["do" "cljfmt" "check,"]
             "lint-fix" ["do" "cljfmt" "fix,"]
             "test-clj" ["all" "do" ["test"] ["check"]]
             "test-phantom" ["doo" "phantom" "test"]

--- a/src/cljc/matcher_combinators/test.cljc
+++ b/src/cljc/matcher_combinators/test.cljc
@@ -1,6 +1,6 @@
 (ns matcher-combinators.test
   (:require
-    [matcher-combinators.dispatch :as dispatch]
+    [matcher-combinators.dispatch]
     #?(:cljs [cljs.test    :as t :refer-macros [is are deftest testing]]
        :clj  [clojure.test :as t :refer        [is are deftest testing]])
     #?(:cljs [matcher-combinators.cljs-test]

--- a/test/clj/matcher_combinators/dispatch_test.clj
+++ b/test/clj/matcher_combinators/dispatch_test.clj
@@ -84,10 +84,9 @@
   => false
 
   (dispatch/wrap-match-with
-    {clojure.lang.PersistentVector$ChunkedSeq core/->EmbedsSeq}
-    (s/match? chunked-seq [1 2 3]))
+   {clojure.lang.PersistentVector$ChunkedSeq core/->EmbedsSeq}
+   (s/match? chunked-seq [1 2 3]))
   => true)
-
 
 (fact "array-seqs"
   (s/match? (clojure.lang.ArraySeq/create (into-array [1 2]))

--- a/test/clj/matcher_combinators/midje_test.clj
+++ b/test/clj/matcher_combinators/midje_test.clj
@@ -205,7 +205,6 @@
 (def now (java.time.LocalDateTime/now))
 (def now-local-time (java.time.LocalTime/now))
 (def an-id-string "67b22046-7e9f-46b2-a3b9-e68618242864")
-(def an-id (java.util.UUID/fromString an-id-string))
 (def another-id (java.util.UUID/fromString "8f488446-374e-4975-9670-35ca0a633da1"))
 (def response-time (java.time.LocalDateTime/now))
 

--- a/test/clj/matcher_combinators/parser_test.clj
+++ b/test/clj/matcher_combinators/parser_test.clj
@@ -35,7 +35,7 @@
   (let [scheme          (gen/elements #{"http" "https"})
         authority       (gen/elements #{"www.foo.com" "www.bar.com:80"})
         path            (gen/one-of [(gen/return nil)
-                                          (gen/fmap #(str "/" %) gen/string-alphanumeric)])
+                                     (gen/fmap #(str "/" %) gen/string-alphanumeric)])
         args-validation (fn [[_scheme authority path query fragment]]
                           (not (or ;; a URI with just a scheme is invalid
                                 (every? nil? (list authority path query fragment))
@@ -43,9 +43,9 @@
                                 (and (not (nil? fragment))
                                      (every? nil? (list authority path query))))))]
 
-  (gen/fmap
-    (fn [[scheme authority path query fragment]] (URI. scheme authority path query fragment))
-    (gen/such-that
+    (gen/fmap
+     (fn [[scheme authority path query fragment]] (URI. scheme authority path query fragment))
+     (gen/such-that
       args-validation
       (gen/tuple scheme authority path query-gen query-gen)))))
 

--- a/test/clj/matcher_combinators/test_test.clj
+++ b/test/clj/matcher_combinators/test_test.clj
@@ -3,7 +3,7 @@
             [matcher-combinators.test :refer :all]
             [matcher-combinators.core :as core]
             [matcher-combinators.matchers :as m])
-  (:import [clojure.lang ExceptionInfo IExceptionInfo]))
+  (:import [clojure.lang ExceptionInfo]))
 
 (def example-matcher {:username string?
                       :account  {:id        integer?

--- a/test/clj/matcher_combinators/test_test.clj
+++ b/test/clj/matcher_combinators/test_test.clj
@@ -3,7 +3,7 @@
             [matcher-combinators.test :refer :all]
             [matcher-combinators.core :as core]
             [matcher-combinators.matchers :as m])
-  (:import [clojure.lang ExceptionInfo]))
+  (:import [clojure.lang ExceptionInfo IExceptionInfo]))
 
 (def example-matcher {:username string?
                       :account  {:id        integer?
@@ -39,9 +39,11 @@
 (deftest exception-matching
   (testing "is"
     (is (thrown-match? ExceptionInfo {:foo 1} (bang!))))
+  (testing "is with default ExceptionInfo class"
+    (is (thrown-match? {:foo 1} (bang!))))
   (testing "are"
     (are [data-matcher]
-         (thrown-match? ExceptionInfo data-matcher (bang!))
+         (thrown-match? data-matcher (bang!))
       {:foo 1}
       {:bar 2}))
   (testing "are with redefs"
@@ -57,10 +59,15 @@
       (is (match? 1)
           :in-wrong-place)))
 
-  (deftest thrown-match?-no-actual-arg
-    (testing "fails with nice message when you don't provide an `actual` arg to `thrown-match?`"
+  (deftest thrown-match?-incorrect-args
+    (testing "fails with nice message when you don't provide an `actual` arg"
       (is (thrown-match? ExceptionInfo {:a 1})
-          :in-wrong-place))))
+          :in-wrong-place))
+    (testing "fails with a nice message when you don't provide enough arguments"
+      (is (thrown-match? {:a 1})
+          :in-wrong-place))
+    (testing "fails with a nice message when you provide too many arguments"
+      (is (thrown-match? ExceptionInfo {:a 1} (bang!) :extra-arg)))))
 
 (defn greater-than-matcher [expected-long]
   (core/->PredMatcher

--- a/test/clj/matcher_combinators/test_test.clj
+++ b/test/clj/matcher_combinators/test_test.clj
@@ -30,8 +30,7 @@
       "Predicates can be used in matchers")
   (is (match? {:a {:b 1}} {:a {:b 1 :c 2}}))
   (are [data-matcher data]
-       (with-redefs [match-data data]
-         (is (match? data-matcher match-data)))
+       (match? data-matcher (with-redefs [match-data data] match-data))
     {:foo 4 :bar 5} {:foo 4 :bar 5}
     {:foo 2 :bar 3} {:foo 2 :bar 3}))
 
@@ -47,8 +46,7 @@
       {:bar 2}))
   (testing "are with redefs"
     (are [data-matcher data]
-         (with-redefs [match-data data]
-           (is (thrown-match? ExceptionInfo data-matcher (bang!))))
+         (thrown-match? ExceptionInfo data-matcher (with-redefs [match-data data] (bang!)))
       {:foo 4} {:foo 4 :bar 5}
       {:foo 2} {:foo 2 :bar 3}
       {:bar 3} {:foo 2 :bar 3})))


### PR DESCRIPTION
Allow the omission of the first argument of `thrown-match?`, which is the Throwable subclass and which is almost always `ExceptionInfo`, so now the following works:

`(thrown-match? {:foo 1} (bang!)`

The 3-arity continues to work too:

`(thrown-match? ExceptionInfo {:foo 1} (bang!))`

Also, a few minor housekeeping changes:
* Ensure `lein lint` works, and run `lein lint-fix`
* Eliminate a couple unused aliases
* Add a few more test cases for `clojure.test/are`, including `with-redefs` to clarify the appropriate place to wrap (inside `match?`, not around)