### PR TITLE
add an `every` matcher

### DIFF
--- a/src/cljc/matcher_combinators/core.cljc
+++ b/src/cljc/matcher_combinators/core.cljc
@@ -410,3 +410,21 @@
       issue
       (value-match (.toString expected)
                    (.toString actual)))))
+
+(defrecord Every [matchers]
+  Matcher
+  (match [_this actual]
+    (loop [matchers matchers
+           result   {::result/type   :match
+                     ::result/value  []
+                     ::result/weight 0}]
+      (if-let [matcher (first matchers)]
+        (let [res (match matcher actual)]
+          (recur (rest matchers)
+                 (-> result
+                     (cond->
+                         (= :mismatch (::result/type res))
+                       (assoc ::result/type :mismatch))
+                     (update ::result/value conj (::result/value res))
+                     (update ::result/weight + (::result/weight res)))))
+        result))))

--- a/src/cljc/matcher_combinators/matchers.cljc
+++ b/src/cljc/matcher_combinators/matchers.cljc
@@ -65,3 +65,7 @@
 (def absent
   "Value-position matcher for maps that matches when containing map doesn't have the key pointing to this matcher."
   (core/->Absent))
+
+(defn every
+  [& matchers]
+  (core/->Every matchers))


### PR DESCRIPTION
The `every` matcher takes an arbitrary length sequence of matchers to be applied against an single actual value, and returns a single map with all of the matched and/or mismatched values.

The use case that motivated this was a large string with several regex matchers applied to it, so we express this

```clojure
(core/match
  (matchers/every 
    (matchers/regex #"abc")
    (matchers/regex #"def")) 
  long-string)
```

instead of this

```clojure
(core/match (matchers/regex #"abc") long-string)
(core/match (matchers/regex #"def") long-string)
```

