### PR TITLE
add match fn to standalone ns

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@ All notable changes to this project will be documented in this file. This
 change log follows the conventions of
 [keepachangelog.com](http://keepachangelog.com/).
 
+## [1.3.2]
+- add `matcher-combinators.standalone/match` (test-framework independent)
+
 ## [1.3.1]
 - add arglist for cljtest assert expressions
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@ All notable changes to this project will be documented in this file. This
 change log follows the conventions of
 [keepachangelog.com](http://keepachangelog.com/).
 
-## [1.3.2]
+## [1.4.0]
 - add `matcher-combinators.standalone/match` (test-framework independent)
 
 ## [1.3.1]

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject nubank/matcher-combinators "1.3.1"
+(defproject nubank/matcher-combinators "1.3.2"
   :description "Library for creating matcher combinator to compare nested data structures"
   :url "https://github.com/nubank/matcher-combinators"
   :license {:name "Apache License, Version 2.0"}

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject nubank/matcher-combinators "1.3.2"
+(defproject nubank/matcher-combinators "1.4.0"
   :description "Library for creating matcher combinator to compare nested data structures"
   :url "https://github.com/nubank/matcher-combinators"
   :license {:name "Apache License, Version 2.0"}

--- a/src/cljc/matcher_combinators/standalone.cljc
+++ b/src/cljc/matcher_combinators/standalone.cljc
@@ -3,6 +3,26 @@
             [matcher-combinators.core :as core]
             [matcher-combinators.parser]))
 
+(defn match
+  "Returns a map indicating whether the `actual` value matches the `matcher`.
+
+  `matcher` can be a matcher-combinators matcher, a predicate function of
+  actual, an expression that returns a value, or a literal value.
+
+  `actual` can be an expression that returns the actual value, or a literal.
+
+  Return map includes the following keys:
+
+  - :match/result    - either :match or :mismatch
+  - :mismatch/detail - only when :match/result is :mismatch"
+  [matcher actual]
+  (let [{:keys [matcher-combinators.result/type
+                matcher-combinators.result/value]}
+        (core/match matcher actual)]
+    (cond-> {:match/result type}
+      (= :mismatch type)
+      (assoc :mismatch/detail value))))
+
 (s/fdef match?
   :args (s/alt :partial (s/cat :matcher (partial satisfies? core/Matcher))
                :full    (s/cat :matcher (partial satisfies? core/Matcher)
@@ -10,10 +30,12 @@
   :ret boolean?)
 
 (defn match?
-  "Does the value match the provided matcher-combinator?"
+  "Given a `matcher` and `actual`, returns `true` if
+  `(match matcher actual)` results in a match. Else, returns `false.`
+
+  Given only a `matcher`, returns a function that will
+  return true or false by the same logic."
   ([matcher]
    (fn [actual] (match? matcher actual)))
   ([matcher actual]
-   (-> matcher
-       (core/match actual)
-       core/match?)))
+   (core/match? (core/match matcher actual))))

--- a/src/cljc/matcher_combinators/standalone.cljc
+++ b/src/cljc/matcher_combinators/standalone.cljc
@@ -14,7 +14,7 @@
   Return map includes the following keys:
 
   - :match/result    - either :match or :mismatch
-  - :mismatch/detail - only when :match/result is :mismatch"
+  - :mismatch/detail - the actual value with mismatch annotations. Only present when :match/result is :mismatch"
   [matcher actual]
   (let [{:keys [matcher-combinators.result/type
                 matcher-combinators.result/value]}

--- a/test/clj/matcher_combinators/standalone_test.clj
+++ b/test/clj/matcher_combinators/standalone_test.clj
@@ -1,23 +1,43 @@
 (ns matcher-combinators.standalone-test
-  (:require [midje.sweet :as midje :refer [fact facts => falsey]]
-            [matcher-combinators.standalone :as standalone]
+  (:require [clojure.spec.test.alpha :as spec.test]
+            [clojure.test :refer [deftest testing is use-fixtures]]
             [matcher-combinators.matchers :as m]
-            [matcher-combinators.parser]
             [matcher-combinators.result :as result]
-            [clojure.spec.test.alpha :as spec.test]))
+            [matcher-combinators.standalone :as standalone]))
 
-(spec.test/instrument)
+(use-fixtures :once
+  (fn [f]
+    (spec.test/instrument)
+    (f)
+    (spec.test/unstrument)))
 
-(fact "basic use of matchers with match?"
-  (standalone/match? (m/in-any-order [1 2]) [1 2]) => true
-  (standalone/match? (m/in-any-order [1 2]) [1 3]) => false)
+(deftest test-match
+  (testing "parser defaults"
+    (is (= :match    (:match/result (standalone/match 37 37))))
+    (is (= :match    (:match/result (standalone/match {:a odd?} {:a 1 :b 2}))))
+    (is (= :mismatch (:match/result (standalone/match 37 42))))
+    (is (= :mismatch (:match/result (standalone/match {:a odd?} {:a 2 :b 2})))))
 
-(fact "the parser defaults still work"
-  (standalone/match? (m/embeds {:a odd?}) {:a 1 :b 2}) => true
-  (standalone/match? {:a odd?} {:a 1 :b 2}) => true
-  (standalone/match? {:a odd?} {:a 2 :b 2}) => false)
+  (testing "explicit matchers"
+    (is (= :match    (:match/result (standalone/match (m/embeds {:a odd?}) {:a 1 :b 2}))))
+    (is (= :match    (:match/result (standalone/match (m/in-any-order [1 2]) [1 2]))))
+    (is (= :mismatch (:match/result (standalone/match (m/in-any-order [1 2]) [1 3])))))
 
-(fact "using partial version of match?"
-  ((standalone/match? (m/embeds {:a odd?})) {:a 1 :b 2})) => true
+  ;; TODO (dchelimsky,2020-03-11): consider making it a plain datastructure
+  (testing ":match/detail binds to a Mismatch object"
+    (is (instance? matcher_combinators.model.Mismatch (:mismatch/detail (standalone/match 37 42))))))
 
-(spec.test/unstrument)
+(deftest test-match?
+  (testing "parser defaults"
+    (is (standalone/match? 37 37))
+    (is (standalone/match? {:a odd?} {:a 1 :b 2}))
+    (is (not (standalone/match? 37 42)))
+    (is (not (standalone/match? {:a odd?} {:a 2 :b 2}))))
+
+  (testing "explicit matchers matchers"
+    (is (standalone/match (m/embeds {:a odd?}) {:a 1 :b 2}))
+    (is (standalone/match? (m/in-any-order [1 2]) [1 2]))
+    (is (not (standalone/match? (m/in-any-order [1 2]) [1 3]))))
+
+  (testing "using partial version of match?"
+    (is ((standalone/match? (m/embeds {:a odd?})) {:a 1 :b 2}))))


### PR DESCRIPTION
This is in response to #101 

Before this PR, if you want to use matcher-combinators outside of clojure.test or midje, you have to require the `matcher-combinators.parser` namespace, e.g.

```clojure
(require '[matcher-combinators.core :refer [match]]
         '[matcher-combinators.dispatch] ;; just because
)

(match 37 (count things))
```

That's fine if you happen to know about it, but it is not documented and, arguably, should not be a user-facing namespace.

With this PR you can just use the (already existing) `matcher-combinators.standalone` namespace:

```clojure
(require '[matcher-combinators.standalone :refer [match]])

(match 37 (count things))
```
