### PR TITLE
specify ~'match in macro

### DIFF
--- a/src/cljc/matcher_combinators/parser.cljc
+++ b/src/cljc/matcher_combinators/parser.cljc
@@ -85,14 +85,14 @@
   `(extend-protocol
     core/Matcher
      ~@(mapcat (fn [t] `(~t
-                         (match [this# actual#]
+                         (~'match [this# actual#]
                            (core/match (~matcher-builder this#) actual#)))) types)))
 
 (defmacro mimic-matcher-java-primitives [matcher-builder & type-strings]
   (let [type-pairs (->> type-strings
                         (map symbol)
                         (mapcat (fn [t] `(~t
-                                          (match [this# actual#]
+                                          (~'match [this# actual#]
                                             (core/match (~matcher-builder this#) actual#))))))]
     `(extend-protocol core/Matcher ~@type-pairs)))
 

--- a/test/clj/matcher_combinators/parser_test.clj
+++ b/test/clj/matcher_combinators/parser_test.clj
@@ -1,6 +1,6 @@
 (ns matcher-combinators.parser-test
   (:require [clojure.test :as t :refer [deftest testing is]]
-            [matcher-combinators.parser]
+            [matcher-combinators.parser :as parser]
             [matcher-combinators.matchers :refer :all]
             [matcher-combinators.core :as core]
             [clojure.test.check.generators :as gen]
@@ -129,3 +129,12 @@
       (is (= (core/match? (core/match another-object
                                       (Object.)))
              (= another-object (Object.)))))))
+
+(deftest mimic-matcher-macro-regression-test
+  ;; this is a regression test for https://github.com/nubank/matcher-combinators/pull/104
+  (testing "mimic-matcher uses non-namespaced symbol for `match`"
+    (is (= 'match
+           (-> (macroexpand `(parser/mimic-matcher dispatch/integer-dispatch Integer))
+               last
+               last
+               first)))))


### PR DESCRIPTION
In the context of these macros, `(match ...` was resolving to `(matcher-combinators.parser/match ...)`, which is not a thing. It happened to work because `extend-protocol` happens to strip the namespace off of symbol, so `any-namespace-at-all/match` is the same as `match`, but we can't count on that implementation detail.