### PR TITLE
Add match-roughly? to matcher-combinators.test

### DIFF
--- a/src/cljc/matcher_combinators/test.cljc
+++ b/src/cljc/matcher_combinators/test.cljc
@@ -15,6 +15,8 @@
 (declare ^{:arglists '([matcher actual]
                        [exception-class matcher actual])}
          thrown-match?)
+(declare ^{:arglists '([delta matcher actual])}
+         match-roughly?)
 
 #?(:clj
    (def build-match-assert


### PR DESCRIPTION
## What? 
Exposes `match-roughly?` at `matcher-combinators.test` namespace

## Why? 
* to be consistent with `match? match-with? match-thrown?`
* I was trying to use it with `defspec` and was receiving the error: 
```clojure
Syntax error compiling at (foo.clj:39:25).
Unable to resolve symbol: match-roughly? in this context 
```
* without that we have to wrap it in a `is` expression. and this is not idiomatic for `defspec`. 