### PR TITLE
fix double eval in match run context

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@ All notable changes to this project will be documented in this file. This
 change log follows the conventions of
 [keepachangelog.com](http://keepachangelog.com/).
 
+## [1.5.2]
+- fix double eval of `clojure.test` `match-equals?` arguments
+
 ## [1.5.1]
 - refactor macro to align w/ Clojure docs (no behavioural change)
 

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject nubank/matcher-combinators "1.5.1"
+(defproject nubank/matcher-combinators "1.5.2"
   :description "Library for creating matcher combinator to compare nested data structures"
   :url "https://github.com/nubank/matcher-combinators"
   :license {:name "Apache License, Version 2.0"}

--- a/src/clj/matcher_combinators/clj_test.clj
+++ b/src/clj/matcher_combinators/clj_test.clj
@@ -175,35 +175,37 @@
                               (into {}))]
     (dispatch/match-with-inner
      type->matcher'
-     `(cond
-        (not (= 2 (count '~args)))
-        (clojure.test/do-report
-         {:type     :fail
-          :message  ~msg
-          :expected (symbol (str "`" '~match-assert-name "` expects 3 arguments: a `type->matcher` map, a `matcher`, and the `actual`"))
-          :actual   (symbol (str (count '~args) " were provided: " '~form))})
-
-        (core/matcher? ~matcher)
-        (let [result# (core/match ~matcher ~actual)]
+     `(let [matcher# ~matcher
+            actual# ~actual]
+        (cond
+          (not (= 2 (count '~args)))
           (clojure.test/do-report
-           (if (core/match? result#)
-             {:type     :pass
-              :message  ~msg
-              :expected '~form
-              :actual   (list 'match? ~matcher ~actual)}
-             (with-file+line-info
-               {:type     :fail
-                :message  ~msg
-                :expected '~form
-                :actual   (tagged-for-pretty-printing (list '~'not (list 'match? ~matcher ~actual))
-                                                      result#)}))))
+            {:type     :fail
+             :message  ~msg
+             :expected (symbol (str "`" '~match-assert-name "` expects 3 arguments: a `type->matcher` map, a `matcher`, and the `actual`"))
+             :actual   (symbol (str (count '~args) " were provided: " '~form))})
 
-        :else
-        (clojure.test/do-report
-         {:type     :fail
-          :message  ~msg
-          :expected (str "The second argument of " '~match-assert-name " needs to be a matcher (implement the match protocol)")
-          :actual   '~form})))))
+          (core/matcher? matcher#)
+          (let [result# (core/match matcher# actual#)]
+            (clojure.test/do-report
+              (if (core/match? result#)
+                {:type     :pass
+                 :message  ~msg
+                 :expected '~form
+                 :actual   (list 'match? matcher# actual#)}
+                (with-file+line-info
+                  {:type     :fail
+                   :message  ~msg
+                   :expected '~form
+                   :actual   (tagged-for-pretty-printing (list '~'not (list 'match? matcher# actual#))
+                                                         result#)}))))
+
+          :else
+          (clojure.test/do-report
+            {:type     :fail
+             :message  ~msg
+             :expected (str "The second argument of " '~match-assert-name " needs to be a matcher (implement the match protocol)")
+             :actual   '~form}))))))
 
 (defmethod clojure.test/assert-expr 'match-equals? [msg form]
   (build-match-assert 'match-equals?

--- a/test/clj/matcher_combinators/test_test.clj
+++ b/test/clj/matcher_combinators/test_test.clj
@@ -99,6 +99,16 @@
   (is (match-equals? {:a 1}
                      {:a 1})))
 
+(deftest match-equals-single-eval
+  (testing "in presence of macro expansion, arguments to match-equals? are only evaluated once"
+    (let [arg-count     (atom 0)
+          matcher-count (atom 0)]
+      (is (match-equals? (do (swap! matcher-count inc)
+                             {:a 1})
+                         (do (swap! arg-count inc)
+                             {:a 1})))
+      (is (= 1 @matcher-count @arg-count)))))
+
 (deftest match-roughly-test
   (is (match-roughly? 0.1
                       {:a 1 :b 3.0}


### PR DESCRIPTION
addresses https://github.com/nubank/matcher-combinators/issues/118

![image](https://user-images.githubusercontent.com/94817/81543199-07880480-9376-11ea-9d30-feda72297251.png)


Double, double toil and trouble;
Fire burn and caldron bubble.
Fillet of a fenny snake,
In the caldron boil and bake;
Eye of newt and toe of frog,
Wool of bat and tongue of dog,
Adder's fork and blind-worm's sting,
Lizard's leg and howlet's wing,
For a charm of powerful trouble,
Like a hell-broth boil and bubble.