### PR TITLE
Replace instrumentation with orchestra + add spec for partial `match?`

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -29,7 +29,8 @@
                              [lein-ancient "0.6.15"]
                              [lein-doo "0.1.11"]]
                    :dependencies [[org.clojure/test.check "1.0.0"]
-                                  [org.clojure/clojurescript "1.10.597"]]
+                                  [org.clojure/clojurescript "1.10.597"]
+                                  [orchestra "2019.02.06-1"]]
                    :source-paths ["dev"]}
              :1.8 {:dependencies [[org.clojure/clojure "1.8.0"]]}}
 

--- a/src/cljc/matcher_combinators/standalone.cljc
+++ b/src/cljc/matcher_combinators/standalone.cljc
@@ -27,7 +27,8 @@
   :args (s/alt :partial (s/cat :matcher (partial satisfies? core/Matcher))
                :full    (s/cat :matcher (partial satisfies? core/Matcher)
                                :actual any?))
-  :ret boolean?)
+  :ret (s/or :partial fn?
+             :full boolean?))
 
 (defn match?
   "Given a `matcher` and `actual`, returns `true` if

--- a/test/clj/matcher_combinators/core_test.clj
+++ b/test/clj/matcher_combinators/core_test.clj
@@ -1,7 +1,7 @@
 (ns matcher-combinators.core-test
   (:require [midje.sweet :refer :all :exclude [exactly contains] :as sweet]
             [clojure.string :as str]
-            [clojure.spec.test.alpha :as spec.test]
+            [orchestra.spec.test :as spec.test]
             [matcher-combinators.core :as core :refer :all]
             [matcher-combinators.matchers :refer :all]
             [matcher-combinators.model :as model]

--- a/test/clj/matcher_combinators/midje_test.clj
+++ b/test/clj/matcher_combinators/midje_test.clj
@@ -5,7 +5,7 @@
             [matcher-combinators.midje :refer [match throws-match] :as ch]
             [matcher-combinators.model :as model]
             [matcher-combinators.result :as result]
-            [clojure.spec.test.alpha :as spec.test]
+            [orchestra.spec.test :as spec.test]
             [midje.emission.api :as emission])
   (:import [clojure.lang ExceptionInfo]))
 

--- a/test/clj/matcher_combinators/standalone_test.clj
+++ b/test/clj/matcher_combinators/standalone_test.clj
@@ -1,5 +1,5 @@
 (ns matcher-combinators.standalone-test
-  (:require [clojure.spec.test.alpha :as spec.test]
+  (:require [orchestra.spec.test :as spec.test]
             [clojure.test :refer [deftest testing is use-fixtures]]
             [matcher-combinators.matchers :as m]
             [matcher-combinators.result :as result]


### PR DESCRIPTION
`clojure.spec.test` doesn't catch this issue since it only validates `:args`, but [orchestra](https://github.com/jeaye/orchestra) catches it.