### PR TITLE
matcher-for

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,19 @@ All notable changes to this project will be documented in this file. This
 change log follows the conventions of
 [keepachangelog.com](http://keepachangelog.com/).
 
+## [2.0.0]
+
+- add `matchers/matcher-for` [#123](https://github.com/nubank/matcher-combinators/pull/123)
+
+### BREAKING CHANGE
+
+matcher-combinators-2.0.0 includes a breaking change for custom implementations of the
+`matcher-combinators.core/Matcher` protocol:
+
+- change the implementation of `match` to `-match` (required)
+- add an implementation of `-matcher-for` (optional, but recommended)
+  - should just return `this` e.g. `(-matcher-for [this] this)
+
 ## [1.5.2]
 - fix double eval of `clojure.test` `match-equals?` arguments
 

--- a/README.md
+++ b/README.md
@@ -135,14 +135,37 @@ Note that you can also use the `match` checker to match arguments within midje's
 
 ## Matchers
 
-### default matchers
+### Default matchers
 
-If a data-structure isn't wrapped in a specific matcher-combinator the default interpretation is:
-- map: `embeds`
+When an expected value isn't wrapped in a specific matcher the default interpretation is:
+- number, date, and other scalar values: `equals`
+- regex: `regex`
 - sequential: `equals`
 - set: `equals`
-- number, date, and other base data-structure: `equals`
-- regex: `regex`
+- map: `embeds`
+
+You can use the `matcher-for` function to discover which matcher would be used
+for a specific value, e.g.
+
+``` clojure
+(require '[matcher-combinators.matchers :as matchers])
+
+(matcher-combinators/matcher-for {:this :map})
+;; => {:expected {:this :map}}
+
+(class *1)
+;; => matcher_combinators.core.EmbedsMap
+```
+
+You can then use that matcher in place of a value, e.g.
+
+``` clojure
+(require '[matcher-combinators.standalone :as matcher-combinators])
+(matcher-combinators/match
+  (matchers/matcher-for {:this :map})
+  {:this :map :and :then-some})
+;; => {:match/result :match}
+```
 
 ### built-in matchers
 

--- a/README.md
+++ b/README.md
@@ -150,7 +150,7 @@ for a specific value, e.g.
 ``` clojure
 (require '[matcher-combinators.matchers :as matchers])
 
-(matcher-combinators/matcher-for {:this :map})
+(matchers/matcher-for {:this :map})
 ;; => {:expected {:this :map}}
 
 (class *1)

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject nubank/matcher-combinators "1.5.2"
+(defproject nubank/matcher-combinators "2.0.0"
   :description "Library for creating matcher combinator to compare nested data structures"
   :url "https://github.com/nubank/matcher-combinators"
   :license {:name "Apache License, Version 2.0"}

--- a/src/clj/matcher_combinators/midje.clj
+++ b/src/clj/matcher_combinators/midje.clj
@@ -120,7 +120,7 @@
 
 (extend-protocol core/Matcher
   Metaconstant
-  (match [this actual]
+  (-match [this actual]
     (if (and (or (symbol? actual)
                  (= (type actual) Metaconstant)
                  (= actual thread-safe-var-nesting/unbound-marker))

--- a/src/cljc/matcher_combinators/core.cljc
+++ b/src/cljc/matcher_combinators/core.cljc
@@ -8,10 +8,8 @@
 (defprotocol Matcher
   "For matching expected and actual values, providing helpful mismatch info on
   unsucessful matches"
-  (matcher-for [expected]
-    "Returns the type-specific matcher object for an expected value. This is
-    useful for discovery when you want to know which Matcher type is associated
-    to a value.")
+  (-matcher-for [expected]
+    "Do not call directly. Implementation for matcher-combinators.matchers/matcher-for.")
   (match [this actual]
     "determine if a concrete `actual` value satisfies this matcher"))
 
@@ -41,7 +39,7 @@
 
 (defrecord Value [expected]
   Matcher
-  (matcher-for [this] this)
+  (-matcher-for [this] this)
   (match [_ actual]
     (value-match expected actual)))
 
@@ -82,7 +80,7 @@
 
 (defrecord Regex [expected]
   Matcher
-  (matcher-for [this] this)
+  (-matcher-for [this] this)
   (match [_this actual]
     (if-let [issue (validate-input expected actual regex? (constantly true) 'regex regex-type)]
       issue
@@ -104,7 +102,7 @@
 
 (defrecord Absent []
   Matcher
-  (matcher-for [this] this)
+  (-matcher-for [this] this)
   (match [_this _actual]
     ;; `Absent` should never be matched against directly. That happening means
     ;; it wasn't used in the context of a map
@@ -115,7 +113,7 @@
 
 (defrecord InvalidType [provided matcher-name type-msg]
   Matcher
-  (matcher-for [this] this)
+  (-matcher-for [this] this)
   (match [_this _actual]
     {::result/type  :mismatch
      ::result/value (model/->InvalidMatcherType
@@ -165,7 +163,7 @@
 
 (defrecord EmbedsMap [expected]
   Matcher
-  (matcher-for [this] this)
+  (-matcher-for [this] this)
   (match [_this actual]
     (if-let [issue (validate-input expected actual map? 'embeds "map")]
       issue
@@ -173,7 +171,7 @@
 
 (defrecord EqualsMap [expected]
   Matcher
-  (matcher-for [this] this)
+  (-matcher-for [this] this)
   (match [_this actual]
     (if-let [issue (validate-input expected actual map? 'equals "map")]
       issue
@@ -181,7 +179,7 @@
 
 (defrecord EqualsRecord [expected]
   Matcher
-  (matcher-for [this] this)
+  (-matcher-for [this] this)
   (match [_this actual]
     (if-let [issue (validate-input expected actual record? map? 'equals "record")]
       issue
@@ -199,7 +197,7 @@
 
 (def ^:private unexpected-matcher
   (reify Matcher
-    (matcher-for [this] this)
+    (-matcher-for [this] this)
     (match [_this actual]
       {::result/type   :mismatch
        ::result/value  (model/->Unexpected actual)
@@ -243,7 +241,7 @@
 
 (defrecord EqualsSeq [expected]
   Matcher
-  (matcher-for [this] this)
+  (-matcher-for [this] this)
   (match [_this actual]
     (if-let [issue (validate-input
                     expected actual sequential? 'equals "sequential")]
@@ -327,7 +325,7 @@
 
 (defrecord InAnyOrder [expected]
   Matcher
-  (matcher-for [this] this)
+  (-matcher-for [this] this)
   (match [_this actual]
     (if-let [issue (validate-input
                     expected actual sequential? 'in-any-order "sequential")]
@@ -336,7 +334,7 @@
 
 (defrecord SetEquals [expected accept-seq?]
   Matcher
-  (matcher-for [this] this)
+  (-matcher-for [this] this)
   (match [_this actual]
     (if-let [issue (if accept-seq?
                      (validate-input expected
@@ -359,7 +357,7 @@
 
 (defrecord Prefix [expected]
   Matcher
-  (matcher-for [this] this)
+  (-matcher-for [this] this)
   (match [_this actual]
     (if-let [issue (validate-input
                     expected actual sequential? 'prefix "sequential")]
@@ -368,7 +366,7 @@
 
 (defrecord EmbedsSeq [expected]
   Matcher
-  (matcher-for [this] this)
+  (-matcher-for [this] this)
   (match [_this actual]
     (if-let [issue (validate-input
                     expected actual sequential? 'embeds "sequential")]
@@ -377,7 +375,7 @@
 
 (defrecord SetEmbeds [expected accept-seq?]
   Matcher
-  (matcher-for [this] this)
+  (-matcher-for [this] this)
   (match [_this actual]
     (if-let [issue (if accept-seq?
                      (validate-input expected
@@ -417,13 +415,13 @@
 
 (defrecord PredMatcher [pred-fn desc]
   Matcher
-  (matcher-for [this] this)
+  (-matcher-for [this] this)
   (match [this actual]
     (match-pred pred-fn desc actual)))
 
 (defrecord CljsUriEquals [expected]
   Matcher
-  (matcher-for [this] this)
+  (-matcher-for [this] this)
   (match [_this actual]
     (if-let [issue (validate-input
                     expected actual uri? 'equals "goog.Uri")]

--- a/src/cljc/matcher_combinators/core.cljc
+++ b/src/cljc/matcher_combinators/core.cljc
@@ -8,7 +8,10 @@
 (defprotocol Matcher
   "For matching expected and actual values, providing helpful mismatch info on
   unsucessful matches"
-  (matcher-for [this])
+  (matcher-for [expected]
+    "Returns the type-specific matcher object for an expected value. This is
+    useful for discovery when you want to know which Matcher type is associated
+    to a value.")
   (match [this actual]
     "determine if a concrete `actual` value satisfies this matcher"))
 

--- a/src/cljc/matcher_combinators/core.cljc
+++ b/src/cljc/matcher_combinators/core.cljc
@@ -8,6 +8,7 @@
 (defprotocol Matcher
   "For matching expected and actual values, providing helpful mismatch info on
   unsucessful matches"
+  (matcher-for [this])
   (match [this actual]
     "determine if a concrete `actual` value satisfies this matcher"))
 
@@ -37,7 +38,8 @@
 
 (defrecord Value [expected]
   Matcher
-  (match [_this actual]
+  (matcher-for [this] this)
+  (match [_ actual]
     (value-match expected actual)))
 
 (defn- validate-input
@@ -77,6 +79,7 @@
 
 (defrecord Regex [expected]
   Matcher
+  (matcher-for [this] this)
   (match [_this actual]
     (if-let [issue (validate-input expected actual regex? (constantly true) 'regex regex-type)]
       issue
@@ -98,6 +101,7 @@
 
 (defrecord Absent []
   Matcher
+  (matcher-for [this] this)
   (match [_this _actual]
     ;; `Absent` should never be matched against directly. That happening means
     ;; it wasn't used in the context of a map
@@ -108,6 +112,7 @@
 
 (defrecord InvalidType [provided matcher-name type-msg]
   Matcher
+  (matcher-for [this] this)
   (match [_this _actual]
     {::result/type  :mismatch
      ::result/value (model/->InvalidMatcherType
@@ -157,6 +162,7 @@
 
 (defrecord EmbedsMap [expected]
   Matcher
+  (matcher-for [this] this)
   (match [_this actual]
     (if-let [issue (validate-input expected actual map? 'embeds "map")]
       issue
@@ -164,6 +170,7 @@
 
 (defrecord EqualsMap [expected]
   Matcher
+  (matcher-for [this] this)
   (match [_this actual]
     (if-let [issue (validate-input expected actual map? 'equals "map")]
       issue
@@ -171,6 +178,7 @@
 
 (defrecord EqualsRecord [expected]
   Matcher
+  (matcher-for [this] this)
   (match [_this actual]
     (if-let [issue (validate-input expected actual record? map? 'equals "record")]
       issue
@@ -188,6 +196,7 @@
 
 (def ^:private unexpected-matcher
   (reify Matcher
+    (matcher-for [this] this)
     (match [_this actual]
       {::result/type   :mismatch
        ::result/value  (model/->Unexpected actual)
@@ -231,6 +240,7 @@
 
 (defrecord EqualsSeq [expected]
   Matcher
+  (matcher-for [this] this)
   (match [_this actual]
     (if-let [issue (validate-input
                     expected actual sequential? 'equals "sequential")]
@@ -314,6 +324,7 @@
 
 (defrecord InAnyOrder [expected]
   Matcher
+  (matcher-for [this] this)
   (match [_this actual]
     (if-let [issue (validate-input
                     expected actual sequential? 'in-any-order "sequential")]
@@ -322,6 +333,7 @@
 
 (defrecord SetEquals [expected accept-seq?]
   Matcher
+  (matcher-for [this] this)
   (match [_this actual]
     (if-let [issue (if accept-seq?
                      (validate-input expected
@@ -344,6 +356,7 @@
 
 (defrecord Prefix [expected]
   Matcher
+  (matcher-for [this] this)
   (match [_this actual]
     (if-let [issue (validate-input
                     expected actual sequential? 'prefix "sequential")]
@@ -352,6 +365,7 @@
 
 (defrecord EmbedsSeq [expected]
   Matcher
+  (matcher-for [this] this)
   (match [_this actual]
     (if-let [issue (validate-input
                     expected actual sequential? 'embeds "sequential")]
@@ -360,6 +374,7 @@
 
 (defrecord SetEmbeds [expected accept-seq?]
   Matcher
+  (matcher-for [this] this)
   (match [_this actual]
     (if-let [issue (if accept-seq?
                      (validate-input expected
@@ -399,11 +414,13 @@
 
 (defrecord PredMatcher [pred-fn desc]
   Matcher
+  (matcher-for [this] this)
   (match [this actual]
     (match-pred pred-fn desc actual)))
 
 (defrecord CljsUriEquals [expected]
   Matcher
+  (matcher-for [this] this)
   (match [_this actual]
     (if-let [issue (validate-input
                     expected actual uri? 'equals "goog.Uri")]

--- a/src/cljc/matcher_combinators/dispatch.cljc
+++ b/src/cljc/matcher_combinators/dispatch.cljc
@@ -61,7 +61,8 @@
 
 ;; other
 (defn pattern-dispatch [expected] (matchers/regex expected))
-(defn function-dispatch [expected] (partial core/match-pred expected (str "predicate: " expected)))
+(defn function-dispatch [expected] (core/->PredMatcher expected
+                                                       (str "predicate: " expected)))
 
 (def type->dispatch
   #?(:cljs {}

--- a/src/cljc/matcher_combinators/dispatch.cljc
+++ b/src/cljc/matcher_combinators/dispatch.cljc
@@ -1,6 +1,9 @@
 (ns matcher-combinators.dispatch
-  "core/Matchers$match gets bound to dispatch functions defined in this namespace
-  so that we can override them at runtime."
+  "Type-specific implementations of the `match` function of the
+  matcher-combinators.core/Match protocol invoke dispatch functions defined in
+  this namespace, which provide a layer of indirection between `match`
+  and the specific matcher implementation for each type. This indirection allows
+  for redefinition at runtime, necessary for the `match-with` feature."
   (:require [matcher-combinators.matchers :as matchers]
             [matcher-combinators.core :as core])
   #?(:clj

--- a/src/cljc/matcher_combinators/dispatch.cljc
+++ b/src/cljc/matcher_combinators/dispatch.cljc
@@ -1,4 +1,6 @@
 (ns matcher-combinators.dispatch
+  "core/Matchers$match gets bound to dispatch functions defined in this namespace
+  so that we can override them at runtime."
   (:require [matcher-combinators.matchers :as matchers]
             [matcher-combinators.core :as core])
   #?(:clj

--- a/src/cljc/matcher_combinators/dispatch.cljc
+++ b/src/cljc/matcher_combinators/dispatch.cljc
@@ -61,8 +61,7 @@
 
 ;; other
 (defn pattern-dispatch [expected] (matchers/regex expected))
-(defn function-dispatch [expected] (core/->PredMatcher expected
-                                                       (str "predicate: " expected)))
+(defn function-dispatch [f] (matchers/pred f))
 
 (def type->dispatch
   #?(:cljs {}

--- a/src/cljc/matcher_combinators/matchers.cljc
+++ b/src/cljc/matcher_combinators/matchers.cljc
@@ -70,3 +70,10 @@
   "Matcher that will match when `pred` of the actual value returns true."
   [pred]
   (core/->PredMatcher pred (str "predicate: " pred)))
+
+(defn matcher-for
+  "Returns the type-specific matcher object for an expected value. This is
+  useful for discovery when you want to know which Matcher type is associated
+  to a value."
+  [expected]
+  (core/-matcher-for expected))

--- a/src/cljc/matcher_combinators/matchers.cljc
+++ b/src/cljc/matcher_combinators/matchers.cljc
@@ -65,3 +65,8 @@
 (def absent
   "Value-position matcher for maps that matches when containing map doesn't have the key pointing to this matcher."
   (core/->Absent))
+
+(defn pred
+  "Matcher that match when `pred` of the actual value returns true."
+  [pred]
+  (core/->PredMatcher pred (str "predicate: " pred)))

--- a/src/cljc/matcher_combinators/matchers.cljc
+++ b/src/cljc/matcher_combinators/matchers.cljc
@@ -67,6 +67,6 @@
   (core/->Absent))
 
 (defn pred
-  "Matcher that match when `pred` of the actual value returns true."
+  "Matcher that will match when `pred` of the actual value returns true."
   [pred]
   (core/->PredMatcher pred (str "predicate: " pred)))

--- a/src/cljc/matcher_combinators/parser.cljc
+++ b/src/cljc/matcher_combinators/parser.cljc
@@ -85,7 +85,7 @@
   `(extend-protocol
     core/Matcher
      ~@(mapcat (fn [t] `(~t
-                         (~'matcher-for [this#]
+                         (~'-matcher-for [this#]
                           (~matcher-builder this#))
                          (~'match [this# actual#]
                            (core/match (~matcher-builder this#) actual#)))) types)))
@@ -94,7 +94,7 @@
   (let [type-pairs (->> type-strings
                         (map symbol)
                         (mapcat (fn [t] `(~t
-                                          (~'matcher-for [this#]
+                                          (~'-matcher-for [this#]
                                            (~matcher-builder this#))
                                           (~'match [this# actual#]
                                             (core/match (~matcher-builder this#) actual#))))))]
@@ -105,7 +105,7 @@
 
 (extend-type clojure.lang.Fn
   core/Matcher
-  (matcher-for [this] (dispatch/function-dispatch this))
+  (-matcher-for [this] (dispatch/function-dispatch this))
   (match [this actual]
     (core/match (dispatch/function-dispatch this) actual)))
 

--- a/src/cljc/matcher_combinators/parser.cljc
+++ b/src/cljc/matcher_combinators/parser.cljc
@@ -18,7 +18,7 @@
   ;; function as predicate
   function
   (match [this actual]
-    ((dispatch/function-dispatch this) actual))
+    (core/match (dispatch/function-dispatch this) actual))
 
   ;; equals base types
   nil
@@ -107,7 +107,7 @@
   core/Matcher
   (matcher-for [this] (dispatch/function-dispatch this))
   (match [this actual]
-    ((dispatch/function-dispatch this) actual)))
+    (core/match (dispatch/function-dispatch this) actual)))
 
 (mimic-matcher dispatch/nil-dispatch nil)
 (mimic-matcher dispatch/class-dispatch java.lang.Class)

--- a/src/cljc/matcher_combinators/parser.cljc
+++ b/src/cljc/matcher_combinators/parser.cljc
@@ -85,6 +85,8 @@
   `(extend-protocol
     core/Matcher
      ~@(mapcat (fn [t] `(~t
+                         (~'matcher-for [this#]
+                          (~matcher-builder this#))
                          (~'match [this# actual#]
                            (core/match (~matcher-builder this#) actual#)))) types)))
 
@@ -92,17 +94,20 @@
   (let [type-pairs (->> type-strings
                         (map symbol)
                         (mapcat (fn [t] `(~t
+                                          (~'matcher-for [this#]
+                                           (~matcher-builder this#))
                                           (~'match [this# actual#]
                                             (core/match (~matcher-builder this#) actual#))))))]
     `(extend-protocol core/Matcher ~@type-pairs)))
 
-(extend-type clojure.lang.Fn
-  core/Matcher
-  (match [this actual]
-    ((dispatch/function-dispatch this) actual)))
-
 (mimic-matcher-java-primitives matchers/equals
                                "[B")
+
+(extend-type clojure.lang.Fn
+  core/Matcher
+  (matcher-for [this] (dispatch/function-dispatch this))
+  (match [this actual]
+    ((dispatch/function-dispatch this) actual)))
 
 (mimic-matcher dispatch/nil-dispatch nil)
 (mimic-matcher dispatch/class-dispatch java.lang.Class)
@@ -140,4 +145,5 @@
 (mimic-matcher dispatch/repeat-dispatch Repeat)
 (mimic-matcher dispatch/lazy-seq-dispatch LazySeq)
 (mimic-matcher dispatch/array-seq-dispatch ArraySeq)
-(mimic-matcher dispatch/pattern-dispatch Pattern)))
+(mimic-matcher dispatch/pattern-dispatch Pattern)
+))

--- a/src/cljc/matcher_combinators/parser.cljc
+++ b/src/cljc/matcher_combinators/parser.cljc
@@ -17,57 +17,57 @@
 
   ;; function as predicate
   function
-  (match [this actual]
+  (-match [this actual]
     (core/match (dispatch/function-dispatch this) actual))
 
   ;; equals base types
   nil
-  (match [this actual]
+  (-match [this actual]
     (core/match (dispatch/nil-dispatch this) actual))
 
   number
-  (match [this actual]
+  (-match [this actual]
     (core/match (dispatch/integer-dispatch this) actual))
 
   string
-  (match [this actual]
+  (-match [this actual]
     (core/match (dispatch/string-dispatch this) actual))
 
   boolean
-  (match [this actual]
+  (-match [this actual]
     (core/match (dispatch/boolean-dispatch this) actual))
 
   Keyword
-  (match [this actual]
+  (-match [this actual]
     (core/match (dispatch/keyword-dispatch this) actual))
 
   UUID
-  (match [this actual]
+  (-match [this actual]
     (core/match (dispatch/uuid-dispatch this) actual))
 
   goog.Uri
-  (match [this actual]
+  (-match [this actual]
     (core/match (dispatch/uri-dispatch this) actual))
 
   js/Date
-  (match [this actual]
+  (-match [this actual]
     (core/match (dispatch/date-dispatch this) actual))
 
   Var
-  (match [this actual]
+  (-match [this actual]
     (core/match (dispatch/var-dispatch this) actual))
 
   ;; equals nested types
   Cons
-  (match [this actual]
+  (-match [this actual]
     (core/match (dispatch/cons-dispatch this) actual))
 
   Repeat
-  (match [this actual]
+  (-match [this actual]
     (core/match (dispatch/repeat-dispatch this) actual))
 
   default
-  (match [this actual]
+  (-match [this actual]
     (cond
       (satisfies? IMap this)
       (core/match (dispatch/i-persistent-map-dispatch this) actual)
@@ -77,7 +77,7 @@
       (core/match (dispatch/i-persistent-vector-dispatch this) actual)))
 
   js/RegExp
-  (match [this actual]
+  (-match [this actual]
     (core/match (dispatch/pattern-dispatch this) actual))))
 
 #?(:clj (do
@@ -87,7 +87,7 @@
      ~@(mapcat (fn [t] `(~t
                          (~'-matcher-for [this#]
                           (~matcher-builder this#))
-                         (~'match [this# actual#]
+                         (~'-match [this# actual#]
                            (core/match (~matcher-builder this#) actual#)))) types)))
 
 (defmacro mimic-matcher-java-primitives [matcher-builder & type-strings]
@@ -96,7 +96,7 @@
                         (mapcat (fn [t] `(~t
                                           (~'-matcher-for [this#]
                                            (~matcher-builder this#))
-                                          (~'match [this# actual#]
+                                          (~'-match [this# actual#]
                                             (core/match (~matcher-builder this#) actual#))))))]
     `(extend-protocol core/Matcher ~@type-pairs)))
 
@@ -106,7 +106,7 @@
 (extend-type clojure.lang.Fn
   core/Matcher
   (-matcher-for [this] (dispatch/function-dispatch this))
-  (match [this actual]
+  (-match [this actual]
     (core/match (dispatch/function-dispatch this) actual)))
 
 (mimic-matcher dispatch/nil-dispatch nil)

--- a/src/cljc/matcher_combinators/parser.cljc
+++ b/src/cljc/matcher_combinators/parser.cljc
@@ -109,9 +109,10 @@
   (-match [this actual]
     (core/match (dispatch/function-dispatch this) actual)))
 
-(mimic-matcher dispatch/nil-dispatch nil)
-(mimic-matcher dispatch/class-dispatch java.lang.Class)
+;; scalars
 (mimic-matcher dispatch/object-dispatch Object)
+(mimic-matcher dispatch/class-dispatch java.lang.Class)
+(mimic-matcher dispatch/nil-dispatch nil)
 (mimic-matcher dispatch/integer-dispatch Integer)
 (mimic-matcher dispatch/short-dispatch Short)
 (mimic-matcher dispatch/long-dispatch Long)
@@ -134,16 +135,15 @@
 (mimic-matcher dispatch/big-int-dispatch BigInt)
 (mimic-matcher dispatch/character-dispatch Character)
 (mimic-matcher dispatch/var-dispatch Var)
+(mimic-matcher dispatch/pattern-dispatch Pattern)
 
+;; collections
 (mimic-matcher dispatch/i-persistent-map-dispatch IPersistentMap)
 (mimic-matcher dispatch/i-persistent-vector-dispatch IPersistentVector)
 (mimic-matcher dispatch/chunked-seq-dispatch PersistentVector$ChunkedSeq)
-(mimic-matcher dispatch/i-persistent-vector-dispatch Pattern)
 (mimic-matcher dispatch/i-persistent-list-dispatch IPersistentList)
 (mimic-matcher dispatch/i-persistent-list-dispatch IPersistentSet)
 (mimic-matcher dispatch/cons-dispatch Cons)
 (mimic-matcher dispatch/repeat-dispatch Repeat)
 (mimic-matcher dispatch/lazy-seq-dispatch LazySeq)
-(mimic-matcher dispatch/array-seq-dispatch ArraySeq)
-(mimic-matcher dispatch/pattern-dispatch Pattern)
-))
+(mimic-matcher dispatch/array-seq-dispatch ArraySeq)))

--- a/src/cljc/matcher_combinators/standalone.cljc
+++ b/src/cljc/matcher_combinators/standalone.cljc
@@ -4,12 +4,9 @@
             [matcher-combinators.parser]))
 
 (defn match
-  "Returns a map indicating whether the `actual` value matches the `matcher`.
+  "Returns a map indicating whether the `actual` value matches `expected`.
 
-  `matcher` can be a matcher-combinators matcher, a predicate function of
-  actual, an expression that returns a value, or a literal value.
-
-  `actual` can be an expression that returns the actual value, or a literal.
+  `expected` can be the expected value, a matcher, or a predicate fn of actual.
 
   Return map includes the following keys:
 

--- a/test/clj/matcher_combinators/core_test.clj
+++ b/test/clj/matcher_combinators/core_test.clj
@@ -33,12 +33,11 @@
    gen/any-equatable))
 
 (defspec equals-matcher-matches-when-values-are-equal
-  {:doc      "For any scalar value or data structure, the equals matcher matches the same value"
-   :max-size 10}
+  {:max-size 10}
   (prop/for-all [v gen-any-equatable]
                 (standalone/match? (matchers/equals v) v)))
 
-(defspec equals-matchers-with-unequal-scalar-values
+(defspec equals-matcher-mismatches-when-scalar-values-are-not-equal
   {:max-size 10}
   (prop/for-all [[a b] (gen/such-that (fn [[a b]] (not= a b))
                                       (gen/tuple gen/simple-type-equatable
@@ -47,9 +46,8 @@
                  {::result/value (model/->Mismatch a b)}
                  (core/match (matchers/equals a) b))))
 
-(defspec map-matchers-with-failures-at-one-key
-  {:doc      "One key in ::result/value has a mismatch when the value at that key fails to match"
-   :max-size 10}
+(defspec map-matchers-mismatches-when-one-key-has-a-mismatched-value
+  {:max-size 10}
   (prop/for-all [expected (gen/such-that not-empty (gen/map gen/keyword gen/small-integer))
                  m        (gen/elements [matchers/equals matchers/embeds])]
                 (let [k      (first (keys expected))
@@ -60,9 +58,8 @@
                     ::result/value (assoc actual k (model/->Mismatch (k expected) (k actual)))}
                    res))))
 
-(defspec map-matchers-with-failures-at-multiple-keys
-  {:doc      "Every key in ::result/value is a mismatch when every key fails to match"
-   :max-size 10}
+(defspec map-matchers-mismatches-when-all-keys-have-a-mismatched-value
+  {:max-size 10}
   (prop/for-all [expected (gen/such-that not-empty (gen/map gen/keyword gen/small-integer))
                  m        (gen/elements [matchers/equals matchers/embeds])]
                 (let [actual (reduce-kv (fn [m k v] (assoc m k (inc v))) {} expected)
@@ -76,9 +73,8 @@
                             actual)}
                    res))))
 
-(defspec map-matchers-with-failures-due-to-missing-keys
-  {:doc      "One key in ::reult/value is a mismatch when the value at that key fails to match"
-   :max-size 10}
+(defspec map-matchers-mismatch-when-expected-keys-are-missing
+  {:max-size 10}
   (prop/for-all [expected (gen/such-that not-empty (gen/map gen/keyword gen/small-integer))
                  m        (gen/elements [matchers/equals matchers/embeds])]
                 (let [k      (first (keys expected))
@@ -89,7 +85,7 @@
                     ::result/value (assoc actual k (model/->Missing (get expected k)))}
                    res))))
 
-(defspec map-matchers-with-failures-due-to-incorrect-type
+(defspec map-matchers-mismatch-any-non-map-value
   {:max-size 10}
   (prop/for-all [m        (gen/elements [matchers/equals matchers/embeds])
                  expected (gen/map gen/keyword gen-any-equatable)

--- a/test/clj/matcher_combinators/core_test.clj
+++ b/test/clj/matcher_combinators/core_test.clj
@@ -30,7 +30,7 @@
   (gen/such-that
    (fn [v]
      (or (not (coll? v))
-         (every? (fn [node] (not (and (map? node) (contains? node false))))
+         (every? (fn [node] (not (and (set? node) (contains? node false))))
                  (default-tree-seq v))))
    gen/any-equatable))
 

--- a/test/clj/matcher_combinators/core_test.clj
+++ b/test/clj/matcher_combinators/core_test.clj
@@ -6,6 +6,7 @@
             [clojure.test.check.clojure-test :refer [defspec]]
             [clojure.string :as str]
             [orchestra.spec.test :as spec.test]
+            [matcher-combinators.clj-test]
             [matcher-combinators.core :as core :refer :all]
             [matcher-combinators.matchers :as matchers :refer :all]
             [matcher-combinators.model :as model]
@@ -599,5 +600,15 @@
                     gen/any)]
                 (= (class (matchers/equals v))
                    (class (core/matcher-for v)))))
+
+(defn greater-than-matcher [expected-long]
+  (core/->PredMatcher
+   (fn [actual] (> actual expected-long))
+   (str "greater than " expected-long)))
+
+(deftest matcher-for-works-within-match-with
+  (is (match-with? {java.lang.Long greater-than-matcher}
+                   (core/matcher-for 4)
+                   5)))
 
 (spec.test/unstrument)

--- a/test/clj/matcher_combinators/core_test.clj
+++ b/test/clj/matcher_combinators/core_test.clj
@@ -581,7 +581,8 @@
 
 (deftest matcher-for-special-cases
   (testing "matcher for a fn is a fn"
-    (is (fn? (core/matcher-for (fn [])))))
+    (is (= (class (matchers/pred (fn [])))
+           (class (core/matcher-for (fn []))))))
   (testing "matcher for a map is embeds"
     (is (= (class (matchers/embeds {}))
            (class (core/matcher-for {})))))

--- a/test/clj/matcher_combinators/core_test.clj
+++ b/test/clj/matcher_combinators/core_test.clj
@@ -23,9 +23,21 @@
     (t)
     (spec.test/unstrument)))
 
-(defspec equals-matchers-with-equal-scalar-values
-  {:max-size 10}
-  (prop/for-all [v gen/simple-type-equatable]
+(defn default-tree-seq [v]
+  (tree-seq coll? #(if (map? %) (keys %) %) v))
+
+(def gen-any-equatable
+  (gen/such-that
+   (fn [v]
+     (or (not (coll? v))
+         (every? (fn [node] (not (and (map? node) (contains? node false))))
+                 (default-tree-seq v))))
+   gen/any-equatable))
+
+(defspec equals-matcher-matches-when-values-are-equal
+  {:doc "For any scalar or structural value, "
+   :max-size 10}
+  (prop/for-all [v gen-any-equatable]
                 (core/match? (core/match (matchers/equals v) v))))
 
 (defspec equals-matchers-with-unequal-scalar-values

--- a/test/clj/matcher_combinators/core_test.clj
+++ b/test/clj/matcher_combinators/core_test.clj
@@ -579,37 +579,4 @@
                                   :in-any-order)
             ::result/weight 2}))
 
-(deftest matcher-for-special-cases
-  (testing "matcher for a fn is a fn"
-    (is (= (class (matchers/pred (fn [])))
-           (class (core/matcher-for (fn []))))))
-  (testing "matcher for a map is embeds"
-    (is (= (class (matchers/embeds {}))
-           (class (core/matcher-for {})))))
-  (testing "matcher for a regex"
-    (is (= (class (matchers/regex #"abc"))
-           (class (core/matcher-for #"abc"))))))
-
-(defspec matcher-for-most-cases
-  {:doc "matchers/equals is the default matcher for everything but functions, regexen, and maps."
-   :num-tests 1000
-   :max-size  10}
-  (prop/for-all [v (gen/such-that
-                    (fn [v] (and (not (map? v))
-                                 (not (instance? java.util.regex.Pattern v))
-                                 (not (fn? v))))
-                    gen/any)]
-                (= (class (matchers/equals v))
-                   (class (core/matcher-for v)))))
-
-(defn greater-than-matcher [expected-long]
-  (core/->PredMatcher
-   (fn [actual] (> actual expected-long))
-   (str "greater than " expected-long)))
-
-(deftest matcher-for-works-within-match-with
-  (is (match-with? {java.lang.Long greater-than-matcher}
-                   (core/matcher-for 4)
-                   5)))
-
 (spec.test/unstrument)

--- a/test/clj/matcher_combinators/dispatch_test.clj
+++ b/test/clj/matcher_combinators/dispatch_test.clj
@@ -1,99 +1,20 @@
-(ns matcher-combinators.dispatch_test
-  (:require [midje.sweet :as midje :refer [fact facts => falsey]]
+(ns matcher-combinators.dispatch-test
+  (:require [clojure.test :refer [deftest is]]
             [matcher-combinators.core :as core]
-            [matcher-combinators.midje :refer [match match-with match-equals match-roughly]]
-            [matcher-combinators.result :as result]
-            [matcher-combinators.model :as model]
-            [matcher-combinators.matchers :as m]
             [matcher-combinators.dispatch :as dispatch]
             [matcher-combinators.standalone :as s]))
 
-(defn abs [x]
-  (if (neg? x)
-    (* -1 x)
-    x))
-
-(defrecord AbsValue [expected]
-  core/Matcher
-  (match [_this actual]
-    (cond
-      (= ::missing actual) {::result/type   :mismatch
-                            ::result/value  (model/->Missing expected)
-                            ::result/weight 1}
-      (= (abs expected)
-         (abs actual))     {::result/type   :match
-                            ::result/value  actual
-                            ::result/weight 0}
-      :else                {::result/type   :mismatch
-                            ::result/value  (model/->Mismatch expected actual)
-                            ::result/weight 1})))
-
-(def match-abs (match-with {java.lang.Long ->AbsValue}))
-
-(facts "match-with checker behavior"
-  (s/match? -1 1) => false
-
-  (fact "low-level invocation"
-    (dispatch/wrap-match-with
-     {java.lang.Long ->AbsValue}
-     (s/match? -1 1))
-    => true)
-
-  (fact "using 2-arg match-with"
-    1 => (match-with {java.lang.Long ->AbsValue} -1)
-    -1 => (match-with {java.lang.Long ->AbsValue} 1))
-  (fact "binding 1-arg match-with to new checker"
-    1 => (match-abs -1)
-    -1 => (match-abs 1)))
-
-(facts "match-equals"
-  (fact "normal loose matching passes"
-    {:a 1 :b 3 :c 1} => (match {:a 1 :b odd?}))
-  (fact "match-equals is more strict"
-    {:a 1 :b 3 :c 1} =not=> (match-equals {:a 1 :b odd?})
-    {:a 1 :b 3} => (match-equals {:a 1 :b odd?}))
-  (let [payload {:a {:b {:c 1}
-                     :d {:e {:inner-e {:x 1 :y 2}}
-                         :f 5
-                         :g 17}}}]
-    (fact "nested maps inside of an `embeds` of a match-equals are treated as equals"
-      payload
-      =not=> (match-equals {:a {:b {:c 1}
-                                :d (m/embeds {:e {:inner-e {:x 1}}})}})
-      payload
-      => (match-equals {:a {:b {:c 1}
-                            :d (m/embeds {:e {:inner-e {:x 1 :y 2}}})}}))))
-
-(fact "match-roughly"
-  {:a 1 :b 3.05} => (match-roughly 0.1
-                                   {:a 1 :b 3.0})
-  {:a 1 :b 3.05} =not=> (match-roughly 0.001
-                                       {:a 1 :b 3.0}))
-
-(defn greater-than-matcher [expected-long]
-  (matcher-combinators.core/->PredMatcher
-   (fn [actual] (> actual expected-long))
-   (str "greater than " expected-long)))
-
-(fact "example from docstring"
-  5 => (match-with {java.lang.Long greater-than-matcher}
-                   4))
-
 (def chunked-seq (seq [1]))
-(fact "chunked-seq remap"
-  (s/match? chunked-seq [1 2 3])
-  => false
 
-  (dispatch/wrap-match-with
-   {clojure.lang.PersistentVector$ChunkedSeq core/->EmbedsSeq}
-   (s/match? chunked-seq [1 2 3]))
-  => true)
+(deftest chunked-seq-remap
+  (is (not (s/match? chunked-seq [1 2 3])))
 
-(fact "array-seqs"
-  (s/match? (clojure.lang.ArraySeq/create (into-array [1 2]))
-            [2 2])
-  => false
-  (s/match? (clojure.lang.ArraySeq/create (into-array [1 2]))
-            [1 2])
-  => true)
+  (is (dispatch/wrap-match-with
+       {clojure.lang.PersistentVector$ChunkedSeq core/->EmbedsSeq}
+       (s/match? chunked-seq [1 2 3]))))
 
+(deftest array-seq
+  (is (not (s/match? (clojure.lang.ArraySeq/create (into-array [1 2]))
+                     [2 2])))
+  (is (s/match? (clojure.lang.ArraySeq/create (into-array [1 2]))
+                [1 2])))

--- a/test/clj/matcher_combinators/matchers_test.clj
+++ b/test/clj/matcher_combinators/matchers_test.clj
@@ -43,9 +43,10 @@
 (deftest in-any-order
   (testing "matcher ordering with maximum matchings for diff"
     (is (match?
-         {::result/type   :mismatch
-          ::result/value  (m/embeds [a-nested-map {:id map? :model mismatch?}])
-          ::result/weight number?}
+         (m/equals
+          {::result/type   :mismatch
+           ::result/value  (m/in-any-order [a-nested-map {:id map? :model mismatch?}])
+           ::result/weight number?})
          (c/match (m/in-any-order [a-nested-map b-nested-map])
                   [a-nested-map a-nested-map]))))
 

--- a/test/clj/matcher_combinators/midje_test.clj
+++ b/test/clj/matcher_combinators/midje_test.clj
@@ -1,8 +1,9 @@
 (ns matcher-combinators.midje-test
   (:require [midje.sweet :as midje :refer [fact facts => falsey]]
             [matcher-combinators.core :as core]
+            [matcher-combinators.dispatch :as dispatch]
             [matcher-combinators.matchers :as m]
-            [matcher-combinators.midje :refer [match throws-match] :as ch]
+            [matcher-combinators.midje :refer [match throws-match match-with match-roughly match-equals]]
             [matcher-combinators.model :as model]
             [matcher-combinators.result :as result]
             [orchestra.spec.test :as spec.test]
@@ -278,5 +279,72 @@
   (throw (ex-info "foo" {:foo 1 :bar 2})) =not=> (throws-match {:foo 2})
   (throw (ex-info "foo" {:foo 1 :bar 2})) =not=> (throws-match {:foo 2} ExceptionInfo)
   (throw (ex-info "foo" {:foo 1 :bar 2})) =not=> (throws-match {:foo 1} clojure.lang.ArityException))
+
+(defrecord AbsValue [expected]
+  core/Matcher
+  (match [_this actual]
+    (cond
+      (= ::missing actual)    {::result/type   :mismatch
+                               ::result/value  (model/->Missing expected)
+                               ::result/weight 1}
+      (= (Math/abs actual)
+         (Math/abs expected)) {::result/type   :match
+                               ::result/value  actual
+                               ::result/weight 0}
+      :else                   {::result/type   :mismatch
+                               ::result/value  (model/->Mismatch expected actual)
+                               ::result/weight 1})))
+
+(def match-abs (match-with {java.lang.Long ->AbsValue}))
+
+(facts "match-with checker behavior"
+  (core/match? (core/match -1 1)) => false
+
+  (fact "low-level invocation"
+    (core/match?
+     (dispatch/wrap-match-with
+      {java.lang.Long ->AbsValue}
+      (core/match -1 1)))
+    => true)
+
+  (fact "using 2-arg match-with"
+    1 => (match-with {java.lang.Long ->AbsValue} -1)
+    -1 => (match-with {java.lang.Long ->AbsValue} 1))
+  (fact "binding 1-arg match-with to new checker"
+    1 => (match-abs -1)
+    -1 => (match-abs 1)))
+
+(facts "match-equals"
+  (fact "normal loose matching passes"
+    {:a 1 :b 3 :c 1} => (match {:a 1 :b odd?}))
+  (fact "match-equals is more strict"
+    {:a 1 :b 3 :c 1} =not=> (match-equals {:a 1 :b odd?})
+    {:a 1 :b 3} => (match-equals {:a 1 :b odd?}))
+  (let [payload {:a {:b {:c 1}
+                     :d {:e {:inner-e {:x 1 :y 2}}
+                         :f 5
+                         :g 17}}}]
+    (fact "nested maps inside of an `embeds` of a match-equals are treated as equals"
+      payload
+      =not=> (match-equals {:a {:b {:c 1}
+                                :d (m/embeds {:e {:inner-e {:x 1}}})}})
+      payload
+      => (match-equals {:a {:b {:c 1}
+                            :d (m/embeds {:e {:inner-e {:x 1 :y 2}}})}}))))
+
+(fact "match-roughly"
+  {:a 1 :b 3.05} => (match-roughly 0.1
+                                   {:a 1 :b 3.0})
+  {:a 1 :b 3.05} =not=> (match-roughly 0.001
+                                       {:a 1 :b 3.0}))
+
+(defn greater-than-matcher [expected-long]
+  (matcher-combinators.core/->PredMatcher
+   (fn [actual] (> actual expected-long))
+   (str "greater than " expected-long)))
+
+(fact "example from docstring"
+  5 => (match-with {java.lang.Long greater-than-matcher}
+                   4))
 
 (spec.test/unstrument)

--- a/test/clj/matcher_combinators/midje_test.clj
+++ b/test/clj/matcher_combinators/midje_test.clj
@@ -282,7 +282,7 @@
 
 (defrecord AbsValue [expected]
   core/Matcher
-  (match [_this actual]
+  (-match [_this actual]
     (cond
       (= ::missing actual)    {::result/type   :mismatch
                                ::result/value  (model/->Missing expected)

--- a/test/clj/matcher_combinators/parser_test.clj
+++ b/test/clj/matcher_combinators/parser_test.clj
@@ -12,19 +12,19 @@
 (def gen-big-decimal
   (gen/fmap (fn [[integral fractional]]
               (BigDecimal. (str integral "." fractional)))
-            (gen/tuple gen/int gen/pos-int)))
+            (gen/tuple gen/small-integer gen/nat)))
 
 (def gen-big-int
-  (gen/fmap #(* 1N %) gen/int))
+  (gen/fmap #(* 1N %) gen/small-integer))
 
 (def gen-java-integer
-  (gen/fmap #(Integer. %) gen/int))
+  (gen/fmap #(Integer. %) gen/small-integer))
 
 (def gen-float
-  (gen/fmap #(float %) gen/int))
+  (gen/fmap #(float %) gen/small-integer))
 
 (def gen-short
-  (gen/fmap short gen/int))
+  (gen/fmap short gen/small-integer))
 
 (def gen-var (gen/elements (vals (ns-interns 'clojure.core))))
 
@@ -130,10 +130,17 @@
                                       (Object.)))
              (= another-object (Object.)))))))
 
-(deftest mimic-matcher-macro-regression-test
+(deftest mimic-matcher-macro
+  (testing "mimic-matcher uses non-namespaced symbol for `-matcher-for`"
+    (is (= '-matcher-for
+           (->> (macroexpand `(parser/mimic-matcher dispatch/integer-dispatch Integer))
+                last
+                butlast
+                last
+                first))))
   ;; this is a regression test for https://github.com/nubank/matcher-combinators/pull/104
-  (testing "mimic-matcher uses non-namespaced symbol for `match`"
-    (is (= 'match
+  (testing "mimic-matcher uses non-namespaced symbol for `-match`"
+    (is (= '-match
            (-> (macroexpand `(parser/mimic-matcher dispatch/integer-dispatch Integer))
                last
                last


### PR DESCRIPTION
Here's a proposed solution for #110 that @fernando-nubank and I cooked up.

`matcher-for` creates a matcher for you, so you can inspect it:

```clojure
(matchers/matcher-for 37)
;; => matcher_combinators.core.Value#{:expected 37}
```

And then you can also then use it!

```clojure
(let [m (matchers/matcher-for 37)]
  (standalone/match? m 37))
;; => true
```

It even works within `match-with?`:

```clojure
(deftest matcher-for-works-within-match-with
  (is (match-with? {java.lang.Long greater-than-matcher}
                   (matchers/matcher-for 4)
                   5)))
```

This PR also moves some tests around and converts more from midje to clojure.test (and adds a generative for `matcher-for`.

## TODO

- [x] get feedback
- [x] update README
- [x] ensure works with cljs
- [x] change `Matcher/match` to `Matcher/-match` (internal)
  - [x] and add `core/match` to make it a non-breaking change for standard use
- [x] update CHANGELOG
  - note that it is a breaking change for custom implementations of `Matcher`
- [x] bump major version 