### PR TITLE
Use set matcher if the expected is a clojure set or a java set

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ change log follows the conventions of
 ## [2.0.0]
 
 - add `matchers/matcher-for` [#123](https://github.com/nubank/matcher-combinators/pull/123)
+- use set matching logic for `java.util.Set` [#125](https://github.com/nubank/matcher-combinators/pull/125)
 
 ### BREAKING CHANGE
 

--- a/src/cljc/matcher_combinators/core.cljc
+++ b/src/cljc/matcher_combinators/core.cljc
@@ -346,6 +346,12 @@
       issue
       (match-any-order expected actual false))))
 
+(defn- matchable-set?
+  "Clojure's set functions expect clojure.lang.IPersistentSet, but
+  matching works just fine with java.util.Set as well."
+  [s]
+  (or (set? s) (instance? java.util.Set s)))
+
 (defrecord SetEquals [expected accept-seq?]
   Matcher
   (-matcher-for [this] this)
@@ -353,24 +359,24 @@
     (if-let [issue (if accept-seq?
                      (validate-input expected
                                      actual
-                                     #(or (set? %) (sequential? %))
-                                     set?
+                                     #(or (matchable-set? %) (sequential? %))
+                                     matchable-set?
                                      'set-equals
                                      "set or sequential")
                      (validate-input expected
                                      actual
-                                     (fn [s] (or (set? s) (instance? java.util.Set s)))
+                                     matchable-set?
                                      'equals
                                      "set"))]
       issue
       (let [{::result/keys [type value weight]} (match-any-order
-                                                  (vec expected) (vec actual) false)]
+                                                 (vec expected) (vec actual) false)]
         {::result/type   type
          ::result/value  (set value)
          ::result/weight weight}))))
 
 (defrecord Prefix [expected]
-  Matcher
+n  Matcher
   (-matcher-for [this] this)
   (-match [_this actual]
     (if-let [issue (validate-input
@@ -394,13 +400,13 @@
     (if-let [issue (if accept-seq?
                      (validate-input expected
                                      actual
-                                     #(or (set? %) (sequential? %))
-                                     set?
+                                     #(or (matchable-set? %) (sequential? %))
+                                     matchable-set?
                                      'set-embeds
                                      "set or sequential")
                      (validate-input expected
                                      actual
-                                     set?
+                                     matchable-set?
                                      'embeds
                                      "set"))]
       issue

--- a/src/cljc/matcher_combinators/core.cljc
+++ b/src/cljc/matcher_combinators/core.cljc
@@ -359,7 +359,7 @@
                                      "set or sequential")
                      (validate-input expected
                                      actual
-                                     set?
+                                     (fn [s] (or (set? s) (instance? java.util.Set s)))
                                      'equals
                                      "set"))]
       issue

--- a/src/cljc/matcher_combinators/core.cljc
+++ b/src/cljc/matcher_combinators/core.cljc
@@ -350,7 +350,8 @@
   "Clojure's set functions expect clojure.lang.IPersistentSet, but
   matching works just fine with java.util.Set as well."
   [s]
-  (or (set? s) (instance? java.util.Set s)))
+  #?(:clj  (or (set? s) (instance? java.util.Set s))
+     :cljs (set? s)))
 
 (defrecord SetEquals [expected accept-seq?]
   Matcher
@@ -376,7 +377,7 @@
          ::result/weight weight}))))
 
 (defrecord Prefix [expected]
-n  Matcher
+  Matcher
   (-matcher-for [this] this)
   (-match [_this actual]
     (if-let [issue (validate-input

--- a/test/clj/matcher_combinators/standalone_test.clj
+++ b/test/clj/matcher_combinators/standalone_test.clj
@@ -18,14 +18,16 @@
     (is (= :match    (:match/result (standalone/match 37 37))))
     (is (= :match    (:match/result (standalone/match {:a odd?} {:a 1 :b 2}))))
     (is (= :mismatch (:match/result (standalone/match 37 42))))
-    (is (= :mismatch (:match/result (standalone/match {:a odd?} {:a 2 :b 2})))))
+    (is (= :mismatch (:match/result (standalone/match {:a odd?} {:a 2 :b 2}))))
+    (is (= :match (:match/result (standalone/match #{1 2} java-set))))
+    (is (= :match (:match/result (standalone/match java-set #{1 2})))))
 
   (testing "explicit matchers"
     (is (= :match    (:match/result (standalone/match (m/embeds {:a odd?}) {:a 1 :b 2}))))
     (is (= :match    (:match/result (standalone/match (m/in-any-order [1 2]) [1 2]))))
     (is (= :mismatch (:match/result (standalone/match (m/in-any-order [1 2]) [1 3]))))
-    (is (= :match (:match/result (standalone/match #{1 2} java-set))))
-    (is (= :match (:match/result (standalone/match java-set #{1 2})))))
+    (is (= :match (:match/result (standalone/match (m/set-equals [odd? even?]) java-set))))
+    (is (= :match (:match/result (standalone/match (m/set-embeds [odd? even?]) java-set)))))
 
   ;; TODO (dchelimsky,2020-03-11): consider making it a plain datastructure
   (testing ":match/detail binds to a Mismatch object"

--- a/test/clj/matcher_combinators/standalone_test.clj
+++ b/test/clj/matcher_combinators/standalone_test.clj
@@ -11,6 +11,8 @@
     (f)
     (spec.test/unstrument)))
 
+(def java-set (doto (new java.util.HashSet) (.add 1) (.add 2)))
+
 (deftest test-match
   (testing "parser defaults"
     (is (= :match    (:match/result (standalone/match 37 37))))
@@ -21,7 +23,9 @@
   (testing "explicit matchers"
     (is (= :match    (:match/result (standalone/match (m/embeds {:a odd?}) {:a 1 :b 2}))))
     (is (= :match    (:match/result (standalone/match (m/in-any-order [1 2]) [1 2]))))
-    (is (= :mismatch (:match/result (standalone/match (m/in-any-order [1 2]) [1 3])))))
+    (is (= :mismatch (:match/result (standalone/match (m/in-any-order [1 2]) [1 3]))))
+    (is (= :match (:match/result (standalone/match #{1 2} java-set))))
+    (is (= :match (:match/result (standalone/match java-set #{1 2})))))
 
   ;; TODO (dchelimsky,2020-03-11): consider making it a plain datastructure
   (testing ":match/detail binds to a Mismatch object"


### PR DESCRIPTION
Solution for issue https://github.com/nubank/matcher-combinators/issues/116.

Clojure only recognizes `IPersistentSet` as `set?` because `java.util.Set` has no immutability semantic baked in. For the purposes of matching, we only need to read the sets, so this PR applies set matching semantics to instances of `java.util.Set` as well as `clojure.lang.IPersistentSet`.