### PR TITLE
align match? fns

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,15 +13,12 @@ change log follows the conventions of
 matcher-combinators-2.0.0 includes the following breaking changes:
 
 * for custom implementations of the `matcher-combinators.core/Matcher` protocol:
-
-- change the implementation of `match` to `-match` (required)
-- add an implementation of `-matcher-for` (optional, but recommended)
-  - should just return `this` e.g. `(-matcher-for [this] this)
-
+    * change the implementation of `match` to `-match` (required)
+    * add an implementation of `-matcher-for` (optional, but recommended)
+        * should just return `this` e.g. `(-matcher-for [this] this)
 * for users of `matcher-combinators.standalone/match?` with one argument:
-
-- this now expects a match result instead of a matcher, and returns a boolean
-- there is no built-in solution for the previous behavior
+    * this now expects a match result instead of a matcher, and returns a boolean
+        * there is no built-in solution for the previous behavior
 
 ## [1.5.2]
 - fix double eval of `clojure.test` `match-equals?` arguments

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@ matcher-combinators-2.0.0 includes the following breaking changes:
 * for custom implementations of the `matcher-combinators.core/Matcher` protocol:
     * change the implementation of `match` to `-match` (required)
     * add an implementation of `-matcher-for` (optional, but recommended)
-        * should just return `this` e.g. `(-matcher-for [this] this)
+        * should just return `this` e.g. `(-matcher-for [this] this)`
 * for users of `matcher-combinators.standalone/match?` with one argument:
     * this now expects a match result instead of a matcher, and returns a boolean
         * there is no built-in solution for the previous behavior

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,15 +6,22 @@ change log follows the conventions of
 ## [2.0.0]
 
 - add `matchers/matcher-for` [#123](https://github.com/nubank/matcher-combinators/pull/123)
+- align `standalone/match?` and `core/match?` fns [#126](https://github.com/nubank/matcher-combinators/pull/126)
 
-### BREAKING CHANGE
+### BREAKING CHANGES
 
-matcher-combinators-2.0.0 includes a breaking change for custom implementations of the
-`matcher-combinators.core/Matcher` protocol:
+matcher-combinators-2.0.0 includes the following breaking changes:
+
+* for custom implementations of the `matcher-combinators.core/Matcher` protocol:
 
 - change the implementation of `match` to `-match` (required)
 - add an implementation of `-matcher-for` (optional, but recommended)
   - should just return `this` e.g. `(-matcher-for [this] this)
+
+* for users of `matcher-combinators.standalone/match?` with one argument:
+
+- this now expects a match result instead of a matcher, and returns a boolean
+- there is no built-in solution for the previous behavior
 
 ## [1.5.2]
 - fix double eval of `clojure.test` `match-equals?` arguments

--- a/src/cljc/matcher_combinators/core.cljc
+++ b/src/cljc/matcher_combinators/core.cljc
@@ -1,6 +1,5 @@
 (ns matcher-combinators.core
   (:require [clojure.math.combinatorics :as combo]
-            [clojure.spec.alpha :as s]
             [matcher-combinators.result :as result]
             [matcher-combinators.model :as model]
             [matcher-combinators.utils :as utils]))
@@ -26,12 +25,17 @@
   [expected actual]
   (-match expected actual))
 
-(s/fdef match?
-  :args (s/cat :match-result ::result/result)
-  :ret boolean?)
+(defn match?
+  "Given a `matcher` and `actual`, returns `true` if
+  `(match matcher actual)` results in a match. Else, returns `false.`
 
-(defn match? [{::result/keys [type]}]
-  (= :match type))
+  Given a `match-result`, returns `true` if it indicates a match, else
+  `false`."
+  ([match-result]
+   (or (= :match (::result/type match-result))
+       (= :match (:match/result match-result))))
+  ([expected actual]
+   (match? (match expected actual))))
 
 (defn- mismatch? [{::result/keys [type]}]
   (= :mismatch type))

--- a/src/cljc/matcher_combinators/specs.cljc
+++ b/src/cljc/matcher_combinators/specs.cljc
@@ -13,7 +13,7 @@
 (s/def :matcher-combinators/match-args
   (s/alt :match-result        (s/alt :standalone ::standalone-match-result
                                      :core       ::result/result)
-         :expected-and-actual (s/cat :expected (partial satisfies? core/Matcher)
+         :expected-and-actual (s/cat :expected (fn [v] (satisfies? core/Matcher v))
                                      :actual   any?)))
 
 (s/fdef matcher-combinators.core/match?

--- a/src/cljc/matcher_combinators/specs.cljc
+++ b/src/cljc/matcher_combinators/specs.cljc
@@ -23,14 +23,3 @@
 (s/fdef matcher-combinators.standalone/match?
   :args :matcher-combinators/match-args
   :ret boolean?)
-
-(comment
-
-  (def args-spec)
-
-  (s/valid? :matcher-combinators/match-args [1 2])
-  (s/valid? :matcher-combinators/match-args [{:match/result :match}])
-  (s/valid? :matcher-combinators/match-args [{:match/result :mismatch}])
-  (s/valid? :matcher-combinators/match-args [{:match/result :mismatch} {:match/result :mismatch}])
-  (s/valid? :matcher-combinators/match-args [{:match/result :mismatch} {:a :b}])
-  )

--- a/src/cljc/matcher_combinators/specs.cljc
+++ b/src/cljc/matcher_combinators/specs.cljc
@@ -1,0 +1,36 @@
+(ns matcher-combinators.specs
+  (:require [clojure.spec.alpha :as s]
+            [matcher-combinators.core :as core]
+            [matcher-combinators.standalone :as standalone]
+            [matcher-combinators.result :as result]))
+
+(s/def :match/result    ::result/type)
+(s/def :mismatch/detail ::result/value)
+(s/def ::standalone-match-result
+  (s/keys :req [:match/result]
+          :opt [:mismatch/detail]))
+
+(s/def :matcher-combinators/match-args
+  (s/alt :match-result        (s/alt :standalone ::standalone-match-result
+                                     :core       ::result/result)
+         :expected-and-actual (s/cat :expected (partial satisfies? core/Matcher)
+                                     :actual   any?)))
+
+(s/fdef matcher-combinators.core/match?
+  :args :matcher-combinators/match-args
+  :ret boolean?)
+
+(s/fdef matcher-combinators.standalone/match?
+  :args :matcher-combinators/match-args
+  :ret boolean?)
+
+(comment
+
+  (def args-spec)
+
+  (s/valid? :matcher-combinators/match-args [1 2])
+  (s/valid? :matcher-combinators/match-args [{:match/result :match}])
+  (s/valid? :matcher-combinators/match-args [{:match/result :mismatch}])
+  (s/valid? :matcher-combinators/match-args [{:match/result :mismatch} {:match/result :mismatch}])
+  (s/valid? :matcher-combinators/match-args [{:match/result :mismatch} {:a :b}])
+  )

--- a/src/cljc/matcher_combinators/standalone.cljc
+++ b/src/cljc/matcher_combinators/standalone.cljc
@@ -20,8 +20,14 @@
       (= :mismatch type)
       (assoc :mismatch/detail value))))
 
-(def
-  ^{:doc      (-> #'core/match? meta :doc)
-    :arglists (-> #'core/match? meta :arglists)}
-  match?
-  core/match?)
+#?(:clj
+   (def
+     ^{:doc      (-> #'core/match? meta :doc)
+       :arglists (-> #'core/match? meta :arglists)}
+     match?
+     core/match?))
+
+#?(:cljs
+   (def match?
+     "See matcher-combinators.core/match?"
+     core/match?))

--- a/src/cljc/matcher_combinators/standalone.cljc
+++ b/src/cljc/matcher_combinators/standalone.cljc
@@ -1,7 +1,8 @@
 (ns matcher-combinators.standalone
   (:require [clojure.spec.alpha :as s]
             [matcher-combinators.core :as core]
-            [matcher-combinators.parser]))
+            [matcher-combinators.parser]
+            [matcher-combinators.result :as result]))
 
 (defn match
   "Returns a map indicating whether the `actual` value matches `expected`.
@@ -13,27 +14,14 @@
   - :match/result    - either :match or :mismatch
   - :mismatch/detail - the actual value with mismatch annotations. Only present when :match/result is :mismatch"
   [matcher actual]
-  (let [{:keys [matcher-combinators.result/type
-                matcher-combinators.result/value]}
+  (let [{::result/keys [type value]}
         (core/match matcher actual)]
     (cond-> {:match/result type}
       (= :mismatch type)
       (assoc :mismatch/detail value))))
 
-(s/fdef match?
-  :args (s/alt :partial (s/cat :matcher (partial satisfies? core/Matcher))
-               :full    (s/cat :matcher (partial satisfies? core/Matcher)
-                               :actual any?))
-  :ret (s/or :partial fn?
-             :full boolean?))
-
-(defn match?
-  "Given a `matcher` and `actual`, returns `true` if
-  `(match matcher actual)` results in a match. Else, returns `false.`
-
-  Given only a `matcher`, returns a function that will
-  return true or false by the same logic."
-  ([matcher]
-   (fn [actual] (match? matcher actual)))
-  ([matcher actual]
-   (core/match? (core/match matcher actual))))
+(def
+  ^{:doc      (-> #'core/match? meta :doc)
+    :arglists (-> #'core/match? meta :arglists)}
+  match?
+  core/match?)

--- a/test/clj/matcher_combinators/core_test.clj
+++ b/test/clj/matcher_combinators/core_test.clj
@@ -120,6 +120,8 @@
                  m        (gen/elements [m/equals m/in-any-order])]
                 (not (core/match? (m expected) actual))))
 
+(spec.test/instrument)
+
 (facts "on sequence matchers"
   (facts "on the equals matcher for sequences"
     (fact "on element mismatches, marks each mismatch"
@@ -205,8 +207,6 @@
                   ::result/value  (just [1 2 (model/->Missing 3)]
                                         :in-any-order)
                   ::result/weight 1})))))
-
-(spec.test/instrument)
 
 (facts "on nesting multiple matchers"
   (facts "on nesting equals matchers for sequences"

--- a/test/clj/matcher_combinators/core_test.clj
+++ b/test/clj/matcher_combinators/core_test.clj
@@ -5,37 +5,22 @@
             [clojure.test.check.properties :as prop]
             [clojure.test.check.clojure-test :refer [defspec]]
             [clojure.string :as str]
-            [clojure.walk :as walk]
             [orchestra.spec.test :as spec.test]
-            [matcher-combinators.clj-test]
-            [matcher-combinators.core :as core :refer :all]
-            [matcher-combinators.matchers :as matchers :refer :all]
+            [matcher-combinators.test-helpers :as test-helpers :refer [gen-any-equatable]]
+            [matcher-combinators.core :as core]
+            [matcher-combinators.matchers :as m]
             [matcher-combinators.model :as model]
             [matcher-combinators.result :as result]
-            [matcher-combinators.dispatch :as dispatch]
-            [matcher-combinators.parser]
             [matcher-combinators.standalone :as standalone]))
 
 (spec.test/instrument)
 
-(use-fixtures :once
-  (fn [t]
-    (spec.test/instrument)
-    (t)
-    (spec.test/unstrument)))
-
-(def gen-any-equatable
-  (gen/such-that
-   (fn [v]
-     (every? (fn [node] (or (not (set? node))
-                            (not (contains? node false))))
-             (tree-seq coll? #(if (map? %) (keys %) %) v)))
-   gen/any-equatable))
+(use-fixtures :once test-helpers/instrument)
 
 (defspec equals-matcher-matches-when-values-are-equal
   {:max-size 10}
   (prop/for-all [v gen-any-equatable]
-                (standalone/match? (matchers/equals v) v)))
+                (standalone/match? (m/equals v) v)))
 
 (defspec equals-matcher-mismatches-when-scalar-values-are-not-equal
   {:max-size 10}
@@ -44,15 +29,15 @@
                                                  gen/simple-type-equatable))]
                 (standalone/match?
                  {::result/value (model/->Mismatch a b)}
-                 (core/match (matchers/equals a) b))))
+                 (core/match (m/equals a) b))))
 
 (defspec map-matchers-mismatches-when-one-key-has-a-mismatched-value
   {:max-size 10}
-  (prop/for-all [expected (gen/such-that not-empty (gen/map gen/keyword gen/small-integer))
-                 m        (gen/elements [matchers/equals matchers/embeds])]
+  (prop/for-all [matcher  (gen/elements [m/equals m/embeds])
+                 expected (gen/such-that not-empty (gen/map gen/keyword gen/small-integer))]
                 (let [k      (first (keys expected))
                       actual (update expected k inc)
-                      res    (core/match (m expected) actual)]
+                      res    (core/match (matcher expected) actual)]
                   (standalone/match?
                    {::result/type  :mismatch
                     ::result/value (assoc actual k (model/->Mismatch (k expected) (k actual)))}
@@ -60,10 +45,10 @@
 
 (defspec map-matchers-mismatches-when-all-keys-have-a-mismatched-value
   {:max-size 10}
-  (prop/for-all [expected (gen/such-that not-empty (gen/map gen/keyword gen/small-integer))
-                 m        (gen/elements [matchers/equals matchers/embeds])]
+  (prop/for-all [matcher  (gen/elements [m/equals m/embeds])
+                 expected (gen/such-that not-empty (gen/map gen/keyword gen/small-integer))]
                 (let [actual (reduce-kv (fn [m k v] (assoc m k (inc v))) {} expected)
-                      res    (core/match (m expected) actual)]
+                      res    (core/match (matcher expected) actual)]
                   (standalone/match?
                    {::result/type :mismatch
                     ::result/value
@@ -75,11 +60,11 @@
 
 (defspec map-matchers-mismatch-when-expected-keys-are-missing
   {:max-size 10}
-  (prop/for-all [expected (gen/such-that not-empty (gen/map gen/keyword gen/small-integer))
-                 m        (gen/elements [matchers/equals matchers/embeds])]
+  (prop/for-all [matcher  (gen/elements [m/equals m/embeds])
+                 expected (gen/such-that not-empty (gen/map gen/keyword gen/small-integer))]
                 (let [k      (first (keys expected))
                       actual (dissoc expected k)
-                      res    (core/match (m expected) actual)]
+                      res    (core/match (matcher expected) actual)]
                   (standalone/match?
                    {::result/type :mismatch
                     ::result/value (assoc actual k (model/->Missing (get expected k)))}
@@ -87,10 +72,10 @@
 
 (defspec map-matchers-mismatch-any-non-map-value
   {:max-size 10}
-  (prop/for-all [m        (gen/elements [matchers/equals matchers/embeds])
+  (prop/for-all [matcher  (gen/elements [m/equals m/embeds])
                  expected (gen/map gen/keyword gen-any-equatable)
                  actual   (gen/such-that (comp not map?) gen-any-equatable)]
-                (let [res (core/match (m expected) actual)]
+                (let [res (core/match (matcher expected) actual)]
                   (standalone/match?
                    {::result/type  :mismatch
                     ::result/value (model/->Mismatch expected actual)}
@@ -100,8 +85,8 @@
   (tabular
     (facts "on common behaviors among all sequence matchers"
       (fact "matches when actual sequence elements match each matcher, in order and in total"
-        (match (?sequence-matcher [(equals {:id (equals 1) :a (equals 1)})
-                                   (equals {:id (equals 2) :a (equals 2)})])
+        (core/match (?sequence-matcher [(m/equals {:id (m/equals 1) :a (m/equals 1)})
+                                        (m/equals {:id (m/equals 2) :a (m/equals 2)})])
           [{:id 1, :a 1} {:id 2, :a 2}])
         => {::result/type   :match
             ::result/value  [{:id 1, :a 1} {:id 2, :a 2}]
@@ -109,8 +94,8 @@
 
       (fact "mismatch when none of the expected matchers is a match for one
              element of the given sequence"
-        (match (?sequence-matcher [(equals {:id (equals 1) :a (equals 1)})
-                                   (equals {:id (equals 2) :a (equals 2)})])
+        (core/match (?sequence-matcher [(m/equals {:id (m/equals 1) :a (m/equals 1)})
+                                        (m/equals {:id (m/equals 2) :a (m/equals 2)})])
           [{:id 1 :a 1} {:id 2 :a 200}])
         => (just {::result/type   :mismatch
                   ::result/value  anything
@@ -118,9 +103,9 @@
 
       (fact "only matches when all expected matchers are matched by elements of
              the given sequence"
-        (match (?sequence-matcher [(equals {:id (equals 1) :a (equals 1)})
-                                   (equals {:id (equals 2) :a (equals 2)})
-                                   (equals {:id (equals 3) :a (equals 3)})])
+        (core/match (?sequence-matcher [(m/equals {:id (m/equals 1) :a (m/equals 1)})
+                                        (m/equals {:id (m/equals 2) :a (m/equals 2)})
+                                        (m/equals {:id (m/equals 3) :a (m/equals 3)})])
           [{:id 1 :a 1} {:id 2 :a 2}])
         => (just {::result/type   :mismatch
                   ::result/value  anything
@@ -128,8 +113,8 @@
 
       (fact "only matches when all of the input sequence elements are matched
              by an expected matcher"
-        (match (?sequence-matcher [(equals {:id (equals 1) :a (equals 1)})
-                                   (equals {:id (equals 2) :a (equals 2)})])
+        (core/match (?sequence-matcher [(m/equals {:id (m/equals 1) :a (m/equals 1)})
+                                        (m/equals {:id (m/equals 2) :a (m/equals 2)})])
           [{:id 1 :a 1} {:id 2 :a 2} {:id 3 :a 3}])
         => (just {::result/type   :mismatch
                   ::result/value  anything
@@ -137,11 +122,11 @@
 
       (tabular
         (fact "mismatches when the actual input is not a sequence"
-          (match (?sequence-matcher [(equals {:id (equals 1) :a (equals 1)})
-                                     (equals {:id (equals 2) :a (equals 2)})]) ?actual)
+          (core/match (?sequence-matcher [(m/equals {:id (m/equals 1) :a (m/equals 1)})
+                                          (m/equals {:id (m/equals 2) :a (m/equals 2)})]) ?actual)
           => {::result/type   :mismatch
-              ::result/value  (model/->Mismatch [(equals {:id (equals 1) :a (equals 1)})
-                                                 (equals {:id (equals 2) :a (equals 2)})]
+              ::result/value  (model/->Mismatch [(m/equals {:id (m/equals 1) :a (m/equals 1)})
+                                                 (m/equals {:id (m/equals 2) :a (m/equals 2)})]
                                                 ?actual)
               ::result/weight 1})
         ?actual
@@ -153,89 +138,89 @@
         #{1 2}))
 
     ?sequence-matcher
-    equals
-    in-any-order)
+    m/equals
+    m/in-any-order)
 
   (facts "on the equals matcher for sequences"
     (fact "on element mismatches, marks each mismatch"
-      (match (equals [(equals 1) (equals 2)]) [2 1])
+      (core/match (m/equals [(m/equals 1) (m/equals 2)]) [2 1])
       => {::result/type   :mismatch
           ::result/value  [(model/->Mismatch 1 2) (model/->Mismatch 2 1)]
           ::result/weight 2}
 
-      (match (equals [(equals 1) (equals 2)]) [1 3])
+      (core/match (m/equals [(m/equals 1) (m/equals 2)]) [1 3])
       => {::result/type   :mismatch
           ::result/value  [1 (model/->Mismatch 2 3)]
           ::result/weight 1})
 
     (fact "mismatch reports elements in correct order"
-      (match (equals [(equals 1) (equals 2) (equals 3)])
+      (core/match (m/equals [(m/equals 1) (m/equals 2) (m/equals 3)])
         (list 1 2 4))
       => {::result/type   :mismatch
           ::result/value  [1 2 (model/->Mismatch 3 4)]
           ::result/weight 1})
 
     (fact "when there are more elements than expected matchers, mark each extra element as Unexpected"
-      (match (equals [(equals 1) (equals 2)]) [1 2 3])
+      (core/match (m/equals [(m/equals 1) (m/equals 2)]) [1 2 3])
       => {::result/type   :mismatch
           ::result/value  [1 2 (model/->Unexpected 3)]
           ::result/weight 1})
 
     (fact "Mismatch plays well with nil"
-      (match (equals [(equals 1) (equals 2) (equals 3)]) [1 2 nil])
+      (core/match (m/equals [(m/equals 1) (m/equals 2) (m/equals 3)]) [1 2 nil])
       => {::result/type   :mismatch
           ::result/value  [1 2 (model/->Mismatch 3 nil)]
           ::result/weight 1})
 
     (fact "when there are more matchers then actual elements, append the expected values marked as Missing"
-      (match (equals [(equals 1) (equals 2) (equals 3)]) [1 2])
+      (core/match (m/equals [(m/equals 1) (m/equals 2) (m/equals 3)]) [1 2])
       => {::result/type   :mismatch
           ::result/value  [1 2 (model/->Missing 3)]
           ::result/weight 1}
 
-      (match (equals [(equals {:a (equals 1)}) (equals {:b (equals 2)})]) [{:a 1}])
+      (core/match (m/equals [(m/equals {:a (m/equals 1)}) (m/equals {:b (m/equals 2)})]) [{:a 1}])
       => {::result/type   :mismatch
-          ::result/value  [{:a 1} (model/->Missing {:b (equals 2)})]
+          ::result/value  [{:a 1} (model/->Missing {:b (m/equals 2)})]
           ::result/weight 1}))
 
   (facts "on the in-any-order sequence matcher"
     (tabular
       (facts "common behavior for all in-any-order arities"
         (fact "matches a sequence with elements corresponding to the expected matchers, in different orders"
-          (match
-           (?in-any-order-matcher [(equals {:id (equals 1) :x (equals 1)})
-                                   (equals {:id (equals 2) :x (equals 2)})])
+          (core/match
+           (?in-any-order-matcher [(m/equals {:id (m/equals 1) :x (m/equals 1)})
+                                   (m/equals {:id (m/equals 2) :x (m/equals 2)})])
             [{:id 2 :x 2} {:id 1 :x 1}])
           => {::result/type   :match
               ::result/value  [{:id 2 :x 2} {:id 1 :x 1}]
               ::result/weight 0}
 
-          (match
-           (?in-any-order-matcher [(equals {:id (equals 1) :x (equals 1)})
-                                   (equals {:id (equals 2) :x (equals 2)})
-                                   (equals {:id (equals 3) :x (equals 3)})])
+          (core/match
+           (?in-any-order-matcher [(m/equals {:id (m/equals 1) :x (m/equals 1)})
+                                   (m/equals {:id (m/equals 2) :x (m/equals 2)})
+                                   (m/equals {:id (m/equals 3) :x (m/equals 3)})])
             [{:id 2 :x 2} {:id 1 :x 1} {:id 3 :x 3}])
           => {::result/type   :match
               ::result/value  [{:id 2 :x 2} {:id 1 :x 1} {:id 3 :x 3}]
               ::result/weight 0}))
       ?in-any-order-matcher
-      in-any-order)
+      m/in-any-order)
 
     (facts "the 1-argument arity has a simple all-or-nothing behavior:"
       (fact "in-any-order for list of same value/matchers"
-        (match (in-any-order [(equals 2) (equals 2)]) [2 2])
+        (core/match (m/in-any-order [(m/equals 2) (m/equals 2)]) [2 2])
         => {::result/type   :match
             ::result/value  [2 2]
             ::result/weight 0})
 
       (fact "when there the matcher and list count differ, mark specific mismatches"
-        (match (in-any-order [(equals 1) (equals 2)]) [1 2 3])
+        (core/match (m/in-any-order [(m/equals 1) (m/equals 2)]) [1 2 3])
         => (just {::result/type   :mismatch
                   ::result/value  (just [1 2 (model/->Unexpected 3)]
                                         :in-any-order)
                   ::result/weight 1})
 
-        (match (in-any-order [(equals 1) (equals 2) (equals 3)]) [1 2])
+        (core/match (m/in-any-order [(m/equals 1) (m/equals 2) (m/equals 3)]) [1 2])
         => (just {::result/type   :mismatch
                   ::result/value  (just [1 2 (model/->Missing 3)]
                                         :in-any-order)
@@ -243,55 +228,55 @@
 
 (facts "on nesting multiple matchers"
   (facts "on nesting equals matchers for sequences"
-    (match
-     (equals [(equals [(equals 1) (equals 2)]) (equals 20)])
+    (core/match
+     (m/equals [(m/equals [(m/equals 1) (m/equals 2)]) (m/equals 20)])
       [[1 2] 20])
     => {::result/type   :match
         ::result/value  [[1 2] 20]
         ::result/weight 0}
 
-    (match
-     (equals [(equals [(equals 1) (equals 2)]) (equals 20)])
+    (core/match
+     (m/equals [(m/equals [(m/equals 1) (m/equals 2)]) (m/equals 20)])
       [[1 5] 20])
     => {::result/type   :mismatch
         ::result/value  [[1 (model/->Mismatch 2 5)] 20]
         ::result/weight 1}
 
-    (match
-     (equals [(equals [(equals 1) (equals 2)]) (equals 20)])
+    (core/match
+     (m/equals [(m/equals [(m/equals 1) (m/equals 2)]) (m/equals 20)])
       [[1 5] 21])
     => {::result/type   :mismatch
         ::result/value  [[1 (model/->Mismatch 2 5)] (model/->Mismatch 20 21)]
         ::result/weight 2})
 
   (fact "sequence type is preserved in mismatch output"
-    (-> (equals [(equals [(equals 1)])])
-        (match [[2]])
+    (-> (m/equals [(m/equals [(m/equals 1)])])
+        (core/match [[2]])
         ::result/value)
     => #(instance? (class (vector)) %)
 
-    (-> (equals [(equals [(equals 1)])])
-        (match (list [2]))
+    (-> (m/equals [(m/equals [(m/equals 1)])])
+        (core/match (list [2]))
         ::result/value)
     => #(instance? (class (list 'placeholder)) %))
 
   (fact "nesting in-any-order matchers"
-    (match
-     (in-any-order [(equals {:id (equals 1) :a (equals 1)})
-                    (equals {:id (equals 2) :a (equals 2)})])
+    (core/match
+     (m/in-any-order [(m/equals {:id (m/equals 1) :a (m/equals 1)})
+                      (m/equals {:id (m/equals 2) :a (m/equals 2)})])
       [{:id 1 :a 1} {:id 2 :a 2}])
     => {::result/type   :match
         ::result/value  [{:id 1 :a 1} {:id 2 :a 2}]
         ::result/weight 0})
 
   (facts "nesting embeds for maps"
-    (match
-     (embeds {:a (equals 42) :m (embeds {:x (equals "foo")})})
+    (core/match
+     (m/embeds {:a (m/equals 42) :m (m/embeds {:x (m/equals "foo")})})
       {:a 42 :m {:x "foo"}})
     => {::result/type   :match
         ::result/value  {:a 42 :m {:x "foo"}}
-        ::result/weight 0} (match (embeds {:a (equals 42)
-                                           :m (embeds {:x (equals "foo")})})
+        ::result/weight 0} (core/match (m/embeds {:a (m/equals 42)
+                                                  :m (m/embeds {:x (m/equals "foo")})})
                              {:a 42
                               :m {:x "bar"}})
     => {::result/type   :mismatch
@@ -299,8 +284,8 @@
                          :m {:x (model/->Mismatch "foo" "bar")}}
         ::result/weight 1}
 
-    (match (embeds {:a (equals 42)
-                    :m (embeds {:x (equals "foo")})})
+    (core/match (m/embeds {:a (m/equals 42)
+                           :m (m/embeds {:x (m/equals "foo")})})
       {:a 43
        :m {:x "bar"}})
     => {::result/type   :mismatch
@@ -308,17 +293,17 @@
                          :m {:x (model/->Mismatch "foo" "bar")}}
         ::result/weight 2})
 
-  (match (equals [(equals {:a (equals 42)
-                           :b (equals 1337)})
-                  (equals 20)])
+  (core/match (m/equals [(m/equals {:a (m/equals 42)
+                                    :b (m/equals 1337)})
+                         (m/equals 20)])
     [{:a 42 :b 1337} 20])
   => {::result/type   :match
       ::result/value  [{:a 42 :b 1337} 20]
       ::result/weight 0}
 
-  (match (equals [(equals {:a (equals 42)
-                           :b (equals 1337)})
-                  (equals 20)])
+  (core/match (m/equals [(m/equals {:a (m/equals 42)
+                                    :b (m/equals 1337)})
+                         (m/equals 20)])
     [{:a 43 :b 1337} 20])
   => {::result/type   :mismatch
       ::result/value  [{:a (model/->Mismatch 42 43) :b 1337} 20]
@@ -332,11 +317,11 @@
   (core/->PredMatcher expected (str expected)))
 
 (fact
- (match (equals [(pred-matcher odd?) (pred-matcher even?)]) [1 2])
+ (core/match (m/equals [(pred-matcher odd?) (pred-matcher even?)]) [1 2])
   => {::result/type   :match
       ::result/value  [1 2]
       ::result/weight 0}
-  (match (equals [(pred-matcher odd?) (pred-matcher even?)]) [1])
+  (core/match (m/equals [(pred-matcher odd?) (pred-matcher even?)]) [1])
   => (just {::result/type   :mismatch
             ::result/value  (just [1 anything])
             ::result/weight 1}))
@@ -365,7 +350,7 @@
                         :unmatched nil?
                         :matched   (just [anything anything])}))
   (fact "works well with identical matchers"
-    (#'core/matches-in-any-order? [(equals 2) (equals 2)] [2 2] false [])
+    (#'core/matches-in-any-order? [(m/equals 2) (m/equals 2)] [2 2] false [])
     => (sweet/contains {:matched?  true
                         :unmatched empty?
                         :matched   (just [anything anything])}))
@@ -383,15 +368,15 @@
 
 (tabular
   (fact "matching for absence in map"
-    (core/match (?matcher {:a (equals 42)
-                           :b absent})
+    (core/match (?matcher {:a (m/equals 42)
+                           :b m/absent})
       {:a 42})
     => (just {::result/type   :match
               ::result/value  {:a 42}
               ::result/weight 0})
 
-    (core/match (?matcher {:a (equals 42)
-                           :b absent})
+    (core/match (?matcher {:a (m/equals 42)
+                           :b m/absent})
       {:a 42
        :b 43})
     => (just {::result/type   :mismatch
@@ -399,12 +384,12 @@
                                      :b (just {:actual 43})})
               ::result/weight #(or (= 1 %) (= 2 %))}))
   ?matcher
-  equals
-  embeds)
+  m/equals
+  m/embeds)
 
 (fact "`absent` interaction with keys pointing to `nil` values"
-  (core/match (equals {:a (equals 42)
-                       :b absent})
+  (core/match (m/equals {:a (m/equals 42)
+                         :b m/absent})
     {:a 42
      :b nil})
   => (just {::result/type   :mismatch
@@ -413,7 +398,7 @@
             ::result/weight 2}))
 
 (fact "using `absent` incorrectly outside of a map"
-  (core/match (equals [(equals 42) absent])
+  (core/match (m/equals [(m/equals 42) m/absent])
     [42])
   => (just {::result/type   :mismatch
             ::result/value  (just [42 {:message "`absent` matcher should only be used as the value in a map"}])
@@ -429,105 +414,105 @@
                                                "provided: 1"})
               ::result/weight number?}))
   ?matcher
-  prefix
-  embeds)
+  m/prefix
+  m/embeds)
 
 (def pred-set #{(pred-matcher odd?) (pred-matcher pos?)})
 (def pred-seq [(pred-matcher odd?) (pred-matcher pos?)])
 
-(def short-equals-seq (map equals [1 3]))
+(def short-equals-seq (map m/equals [1 3]))
 
 (fact "embeds for sequences"
-  (core/match (embeds short-equals-seq) [3 4 1]) => (just {::result/type   :match
-                                                           ::result/value  (just [3 4 1])
-                                                           ::result/weight 0})
-  (core/match (embeds short-equals-seq) [3 4 1 5]) => (just {::result/type   :match
-                                                             ::result/value  (just [3 4 1 5])
-                                                             ::result/weight 0}))
+  (core/match (m/embeds short-equals-seq) [3 4 1]) => (just {::result/type   :match
+                                                             ::result/value  (just [3 4 1])
+                                                             ::result/weight 0})
+  (core/match (m/embeds short-equals-seq) [3 4 1 5]) => (just {::result/type   :match
+                                                               ::result/value  (just [3 4 1 5])
+                                                               ::result/weight 0}))
 
 (fact "embeds /set-equals matches"
-  (core/match (embeds pred-set) #{1 3}) => (just {::result/type   :match
-                                                  ::result/value  (just #{1 3})
-                                                  ::result/weight 0})
-  (core/match (set-embeds pred-seq) #{1 3}) => (just {::result/type   :match
-                                                      ::result/value  (just #{1 3})
-                                                      ::result/weight 0})
-  (core/match (equals pred-set) #{1 3}) => (just {::result/type   :match
-                                                  ::result/value  (just #{1 3})
-                                                  ::result/weight 0})
-  (core/match (set-equals pred-seq) #{1 3}) => (just {::result/type   :match
-                                                      ::result/value  (just #{1 3})
-                                                      ::result/weight 0}))
+  (core/match (m/embeds pred-set) #{1 3}) => (just {::result/type   :match
+                                                    ::result/value  (just #{1 3})
+                                                    ::result/weight 0})
+  (core/match (m/set-embeds pred-seq) #{1 3}) => (just {::result/type   :match
+                                                        ::result/value  (just #{1 3})
+                                                        ::result/weight 0})
+  (core/match (m/equals pred-set) #{1 3}) => (just {::result/type   :match
+                                                    ::result/value  (just #{1 3})
+                                                    ::result/weight 0})
+  (core/match (m/set-equals pred-seq) #{1 3}) => (just {::result/type   :match
+                                                        ::result/value  (just #{1 3})
+                                                        ::result/weight 0}))
 
 (fact "embeds /equals mismatches due to type"
-  (core/match (equals pred-seq) #{1 3})
+  (core/match (m/equals pred-seq) #{1 3})
   => (just {::result/type   :mismatch
             ::result/value  (just {:actual   #{1 3}
                                    :expected anything})
             ::result/weight 1})
-  (core/match (equals pred-set) [1 3])
+  (core/match (m/equals pred-set) [1 3])
   => (just {::result/type   :mismatch
             ::result/value  (just {:actual   [1 3]
                                    :expected anything})
             ::result/weight 1})
-  (core/match (embeds pred-seq) #{1 3})
+  (core/match (m/embeds pred-seq) #{1 3})
   => (just {::result/type   :mismatch
             ::result/value  (just {:actual   #{1 3}
                                    :expected anything})
             ::result/weight 1})
-  (core/match (embeds pred-set) [1 3])
+  (core/match (m/embeds pred-set) [1 3])
   => (just {::result/type   :mismatch
             ::result/value  (just {:actual   [1 3]
                                    :expected anything})
             ::result/weight 1})
-  (core/match (embeds 1) [1])
+  (core/match (m/embeds 1) [1])
   => (just {::result/type   :mismatch
             ::result/value  (just {:expected-type-msg #"^embeds *"
                                    :provided          #"^provided: 1"})
             ::result/weight 1}))
 
 (fact "embeds /set-equals mismatches due to type"
-  (core/match (set-embeds pred-seq) [1 3])
+  (core/match (m/set-embeds pred-seq) [1 3])
   => (just {::result/type   :mismatch
             ::result/value  (just {:actual   [1 3]
                                    :expected anything})
             ::result/weight 1})
-  (core/match (set-equals pred-seq) [1 3])
+  (core/match (m/set-equals pred-seq) [1 3])
   => (just {::result/type   :mismatch
             ::result/value  (just {:actual   [1 3]
                                    :expected anything})
             ::result/weight 1})
-  (core/match (set-embeds 1) [1 3])
+  (core/match (m/set-embeds 1) [1 3])
   => (just {::result/type   :mismatch
             ::result/value  (just {:expected-type-msg #"^set-embeds*"
                                    :provided          #"^provided: 1"})
             ::result/weight 1})
-  (core/match (set-equals 1) [1 3])
+  (core/match (m/set-equals 1) [1 3])
   => (just {::result/type   :mismatch
             ::result/value  (just {:expected-type-msg #"^set-equals*"
                                    :provided          #"^provided: 1"})
             ::result/weight 1}))
 
 (fact "embeds /set-equals mismatches due to content"
-  (core/match (set-embeds pred-set) #{1 -2})
+  (core/match (m/set-embeds pred-set) #{1 -2})
   => (just {::result/type  :mismatch
             ::result/value (just #{1 (just {:actual   -2
                                             :expected anything})})
             ::result/weight 1})
 
-  (core/match (set-embeds pred-seq) #{1 -2})
+  (core/match (m/set-embeds pred-seq) #{1 -2})
   => (just {::result/type :mismatch
             ::result/weight 1
             ::result/value (just #{1 (just {:actual   -2
                                             :expected anything})})})
 
-  (core/match (equals pred-set) #{1 -2})
+  (core/match (m/equals pred-set) #{1 -2})
   => (just {::result/type :mismatch
             ::result/weight 1
             ::result/value (just #{1 (just {:actual   -2
                                             :expected anything})})})
 
-  (core/match (set-equals pred-seq) #{1 -2})
+  (core/match (m/set-equals pred-seq) #{1 -2})
   => (just {::result/type :mismatch
             ::result/weight 1
             ::result/value (just #{1 (just {:actual   -2
@@ -537,38 +522,38 @@
                     (pred-matcher even?)})
 (def even-odd-seq (into [] even-odd-set))
 (fact "Order agnostic checks show fine-grained mismatch details"
-  (core/match (equals even-odd-set) #{1 2 -3})
+  (core/match (m/equals even-odd-set) #{1 2 -3})
   => (just {::result/type   :mismatch
             ::result/value  #{1 2 (model/->Unexpected -3)}
             ::result/weight 1})
 
-  (core/match (in-any-order even-odd-seq) [1 2 -3])
+  (core/match (m/in-any-order even-odd-seq) [1 2 -3])
   => (just {::result/type   :mismatch
             ::result/value  (just [1 2 (model/->Unexpected -3)]
                                   :in-any-order)
             ::result/weight 1})
 
-  (core/match (in-any-order even-odd-seq) [1])
+  (core/match (m/in-any-order even-odd-seq) [1])
   => (just {::result/type   :mismatch
             ::result/value  (just [1 (just (model/->Missing anything))]
                                   :in-any-order)
             ::result/weight 1})
 
-  (core/match (equals even-odd-set) #{1})
+  (core/match (m/equals even-odd-set) #{1})
   => (just {::result/type   :mismatch
             ::result/value  (just #{1 (just (model/->Missing anything))}
                                   :in-any-order)
             ::result/weight 1}))
 
 (fact "in-any-order minimal mismatch test"
-  (core/match (equals [(equals {:a (equals "1") :x (equals "12")})])
+  (core/match (m/equals [(m/equals {:a (m/equals "1") :x (m/equals "12")})])
     [{:a "1" :x "12="}])
   => {::result/type   :mismatch
       ::result/value  [{:a "1" :x (model/->Mismatch "12" "12=")}]
       ::result/weight 1}
 
-  (core/match (in-any-order [(equals {:a (equals "2") :x (equals "14")})
-                             (equals {:a (equals "1") :x (equals "12")})])
+  (core/match (m/in-any-order [(m/equals {:a (m/equals "2") :x (m/equals "14")})
+                               (m/equals {:a (m/equals "1") :x (m/equals "12")})])
     [{:a "1" :x "12="} {:a "2" :x "14="}])
   => (just {::result/type   :mismatch
             ::result/value  (just [{:a "1" :x (model/->Mismatch "12" "12=")}
@@ -576,8 +561,8 @@
                                   :in-any-order)
             ::result/weight 2})
 
-  (core/match (in-any-order [(equals {:a (equals "2") :x (equals "14")})
-                             (equals {:a (equals "1") :x (equals "12")})])
+  (core/match (m/in-any-order [(m/equals {:a (m/equals "2") :x (m/equals "14")})
+                               (m/equals {:a (m/equals "1") :x (m/equals "12")})])
     [{:a "1" :x "12="} {:a "2" :x "14="}])
   => (just {::result/type   :mismatch
             ::result/value  (just [{:a "2" :x (model/->Mismatch "14" "14=")}

--- a/test/clj/matcher_combinators/core_test.clj
+++ b/test/clj/matcher_combinators/core_test.clj
@@ -82,7 +82,7 @@
 
 (defspec sequence-matchers-match-when-sequences-are-equal
   {:max-size 10}
-  (prop/for-all [s (gen/such-that sequential? gen-any-equatable)
+  (prop/for-all [s (gen/such-that sequential? gen-any-equatable {:max-tries 100})
                  m (gen/elements [m/equals m/in-any-order])]
                 (core/match? (m s) s)))
 
@@ -113,9 +113,9 @@
                       expected s]
                   (not (core/match? (m expected) actual)))))
 
-(defspec sequence-matchers-match-when-sequences-are-equal
+(defspec sequence-matchers-mismatch-when-actual-is-not-sequential
   {:max-size 10}
-  (prop/for-all [expected (gen/such-that sequential? gen-any-equatable)
+  (prop/for-all [expected (gen/such-that sequential? gen-any-equatable {:max-tries 100})
                  actual   gen/simple-type-equatable
                  m        (gen/elements [m/equals m/in-any-order])]
                 (not (core/match? (m expected) actual))))

--- a/test/clj/matcher_combinators/matchers_test.clj
+++ b/test/clj/matcher_combinators/matchers_test.clj
@@ -7,6 +7,7 @@
             [matcher-combinators.matchers :as m]
             [matcher-combinators.core :as c]
             [matcher-combinators.test]
+            [matcher-combinators.test-helpers :refer [greater-than-matcher]]
             [matcher-combinators.result :as result])
   (:import [matcher_combinators.model Mismatch Missing InvalidMatcherType]))
 
@@ -238,11 +239,6 @@
                     gen/any)]
                 (= (class (m/equals v))
                    (class (m/matcher-for v)))))
-
-(defn greater-than-matcher [expected-long]
-  (c/->PredMatcher
-   (fn [actual] (> actual expected-long))
-   (str "greater than " expected-long)))
 
 (deftest matcher-for-works-within-match-with
   (is (match-with? {java.lang.Long greater-than-matcher}

--- a/test/clj/matcher_combinators/midje_test.clj
+++ b/test/clj/matcher_combinators/midje_test.clj
@@ -6,6 +6,7 @@
             [matcher-combinators.midje :refer [match throws-match match-with match-roughly match-equals]]
             [matcher-combinators.model :as model]
             [matcher-combinators.result :as result]
+            [matcher-combinators.test-helpers :refer [greater-than-matcher]]
             [orchestra.spec.test :as spec.test]
             [midje.emission.api :as emission])
   (:import [clojure.lang ExceptionInfo]))
@@ -337,11 +338,6 @@
                                    {:a 1 :b 3.0})
   {:a 1 :b 3.05} =not=> (match-roughly 0.001
                                        {:a 1 :b 3.0}))
-
-(defn greater-than-matcher [expected-long]
-  (matcher-combinators.core/->PredMatcher
-   (fn [actual] (> actual expected-long))
-   (str "greater than " expected-long)))
 
 (fact "example from docstring"
   5 => (match-with {java.lang.Long greater-than-matcher}

--- a/test/clj/matcher_combinators/standalone_test.clj
+++ b/test/clj/matcher_combinators/standalone_test.clj
@@ -1,6 +1,7 @@
 (ns matcher-combinators.standalone-test
   (:require [orchestra.spec.test :as spec.test]
             [clojure.test :refer [deftest testing is use-fixtures]]
+            [matcher-combinators.specs]
             [matcher-combinators.matchers :as m]
             [matcher-combinators.test-helpers :as test-helpers]
             [matcher-combinators.result :as result]
@@ -20,21 +21,31 @@
     (is (= :match    (:match/result (standalone/match (m/in-any-order [1 2]) [1 2]))))
     (is (= :mismatch (:match/result (standalone/match (m/in-any-order [1 2]) [1 3])))))
 
-  ;; TODO (dchelimsky,2020-03-11): consider making it a plain datastructure
   (testing ":match/detail binds to a Mismatch object"
     (is (instance? matcher_combinators.model.Mismatch (:mismatch/detail (standalone/match 37 42))))))
 
 (deftest test-match?
-  (testing "parser defaults"
-    (is (standalone/match? 37 37))
-    (is (standalone/match? {:a odd?} {:a 1 :b 2}))
-    (is (not (standalone/match? 37 42)))
-    (is (not (standalone/match? {:a odd?} {:a 2 :b 2}))))
+  (testing "with match result"
+    (testing "with core match result"
+      (is (standalone/match? {::result/type :match
+                              ::result/value nil
+                              ::result/weight 0}))
+      (is (not (standalone/match? {::result/type :mismatch
+                                   ::result/value nil
+                                   ::result/weight 1}))))
 
-  (testing "explicit matchers matchers"
-    (is (standalone/match (m/embeds {:a odd?}) {:a 1 :b 2}))
-    (is (standalone/match? (m/in-any-order [1 2]) [1 2]))
-    (is (not (standalone/match? (m/in-any-order [1 2]) [1 3]))))
+    (testing "with standalone match result"
+      (is (standalone/match? {:match/result :match}))
+      (is (not (standalone/match? {:match/result :mismatch})))))
 
-  (testing "using partial version of match?"
-    (is ((standalone/match? (m/embeds {:a odd?})) {:a 1 :b 2}))))
+  (testing "with expected and actual"
+    (testing "parser defaults"
+      (is (standalone/match? 37 37))
+      (is (standalone/match? {:a odd?} {:a 1 :b 2}))
+      (is (not (standalone/match? 37 42)))
+      (is (not (standalone/match? {:a odd?} {:a 2 :b 2}))))
+
+    (testing "explicit matchers"
+      (is (standalone/match? (m/embeds {:a odd?}) {:a 1 :b 2}))
+      (is (standalone/match? (m/in-any-order [1 2]) [1 2]))
+      (is (not (standalone/match? (m/in-any-order [1 2]) [1 3]))))))

--- a/test/clj/matcher_combinators/standalone_test.clj
+++ b/test/clj/matcher_combinators/standalone_test.clj
@@ -2,14 +2,11 @@
   (:require [orchestra.spec.test :as spec.test]
             [clojure.test :refer [deftest testing is use-fixtures]]
             [matcher-combinators.matchers :as m]
+            [matcher-combinators.test-helpers :as test-helpers]
             [matcher-combinators.result :as result]
             [matcher-combinators.standalone :as standalone]))
 
-(use-fixtures :once
-  (fn [f]
-    (spec.test/instrument)
-    (f)
-    (spec.test/unstrument)))
+(use-fixtures :once test-helpers/instrument)
 
 (deftest test-match
   (testing "parser defaults"

--- a/test/clj/matcher_combinators/test_helpers.clj
+++ b/test/clj/matcher_combinators/test_helpers.clj
@@ -1,0 +1,18 @@
+(ns matcher-combinators.test-helpers
+  (:require [clojure.test.check.generators :as gen]
+            [orchestra.spec.test :as spec.test]))
+
+(defn instrument
+  "Test fixture to turn on clojure.spec instrumentation."
+  [t]
+  (spec.test/instrument)
+  (t)
+  (spec.test/unstrument))
+
+(def gen-any-equatable
+  (gen/such-that
+   (fn [v]
+     (every? (fn [node] (or (not (set? node))
+                            (not (contains? node false))))
+             (tree-seq coll? #(if (map? %) (keys %) %) v)))
+   gen/any-equatable))

--- a/test/clj/matcher_combinators/test_helpers.clj
+++ b/test/clj/matcher_combinators/test_helpers.clj
@@ -20,8 +20,11 @@
   See https://github.com/nubank/matcher-combinators/issues/124"
   (gen/such-that
    (fn [v]
-     (every? (fn [node] (or (not (set? node))
-                            (not (contains? node false))))
+     (every? (fn [node]
+               (if (or (set? node)
+                       (sequential? node))
+                 (not (contains? (into #{} node) false))
+                 true))
              (tree-seq coll? #(if (map? %) (vals %) %) v)))
    gen/any-equatable))
 

--- a/test/clj/matcher_combinators/test_helpers.clj
+++ b/test/clj/matcher_combinators/test_helpers.clj
@@ -10,6 +10,13 @@
   (spec.test/unstrument))
 
 (def gen-any-equatable
+  "Generates from gen/any-equatable such that there is no set in the
+  resulting structure that contains the value `false`. This is to get
+  around a bug which causes `(match? #{false} #{false})` to return
+  false.  Until that is fixed, use this generator instead of
+  gen/any-equatable.
+
+  See https://github.com/nubank/matcher-combinators/issues/124"
   (gen/such-that
    (fn [v]
      (every? (fn [node] (or (not (set? node))

--- a/test/clj/matcher_combinators/test_helpers.clj
+++ b/test/clj/matcher_combinators/test_helpers.clj
@@ -1,6 +1,7 @@
 (ns matcher-combinators.test-helpers
   (:require [clojure.test.check.generators :as gen]
-            [orchestra.spec.test :as spec.test]))
+            [orchestra.spec.test :as spec.test]
+            [matcher-combinators.core :as core]))
 
 (defn instrument
   "Test fixture to turn on clojure.spec instrumentation."
@@ -23,3 +24,8 @@
                             (not (contains? node false))))
              (tree-seq coll? #(if (map? %) (vals %) %) v)))
    gen/any-equatable))
+
+(defn greater-than-matcher [expected-long]
+  (core/->PredMatcher
+   (fn [actual] (> actual expected-long))
+   (str "greater than " expected-long)))

--- a/test/clj/matcher_combinators/test_helpers.clj
+++ b/test/clj/matcher_combinators/test_helpers.clj
@@ -14,5 +14,5 @@
    (fn [v]
      (every? (fn [node] (or (not (set? node))
                             (not (contains? node false))))
-             (tree-seq coll? #(if (map? %) (keys %) %) v)))
+             (tree-seq coll? #(if (map? %) (vals %) %) v)))
    gen/any-equatable))

--- a/test/clj/matcher_combinators/test_test.clj
+++ b/test/clj/matcher_combinators/test_test.clj
@@ -1,6 +1,7 @@
 (ns matcher-combinators.test-test
   (:require [clojure.test :refer :all]
             [matcher-combinators.test :refer :all]
+            [matcher-combinators.test-helpers :refer [greater-than-matcher]]
             [matcher-combinators.core :as core]
             [matcher-combinators.matchers :as m])
   (:import [clojure.lang ExceptionInfo]))
@@ -78,11 +79,6 @@
           :in-wrong-place))
     (testing "fails with a nice message when you provide too many arguments"
       (is (thrown-match? ExceptionInfo {:a 1} (bang!) :extra-arg)))))
-
-(defn greater-than-matcher [expected-long]
-  (core/->PredMatcher
-   (fn [actual] (> actual expected-long))
-   (str "greater than " expected-long)))
 
 (deftest match-with-test
   (is (match-with? {java.lang.Long greater-than-matcher}

--- a/test/cljs/matcher_combinators/cljs_example_test.cljs
+++ b/test/cljs/matcher_combinators/cljs_example_test.cljs
@@ -57,9 +57,9 @@
   (is (standalone/match? (m/in-any-order [1 2]) [1 2]))
   (is (not (standalone/match? (m/in-any-order [1 2]) [1 3]))))
 
-(deftest partial-standalone
+(deftest standalone-with-match-result
   (testing "using partial version of match?"
-    (is ((standalone/match? (m/embeds {:a odd?})) {:a 1 :b 2}))))
+    (is (standalone/match? (standalone/match (m/embeds {:a odd?}) {:a 1 :b 2})))))
 
 (defn bang! [] (throw (ex-info "an exception" {:foo 1 :bar 2})))
 


### PR DESCRIPTION
There are currently 3 versions of `match?`:

* `matcher-combinators.core/match?`
* `matcher-combinators.standalone/match?`
* `matcher-combinators.test/match?` (clojure.test `assert-expr` - not really a function)

They all have different semantics, which is cause for much confusion.

This PR aligns them as follows:

* all three have an arity-2 version e.g. `(match? expected actual)`, where `expected` could be a value or a matcher
* the `core` and `standalone` functions each have an arity-1 version e.g. `(match? match-result)`
* all arities of all 3 versions return a boolean

What changed?

* `standalone.match?` with one arg expects a match-result and returns a boolean
  * this is a breaking change, but using the 1-arity version of this is an edge case and should not have a wide-reaching impact
* `core.match?` now supports 1 argument
  * previously it only supported 2
* the `fdefs` for both versions are the same, and have moved to a new `specs` namespace so they are only loaded when needed (in tests)