### PR TITLE
redesign match fns

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,15 +7,19 @@ change log follows the conventions of
 
 - add `matchers/matcher-for` [#123](https://github.com/nubank/matcher-combinators/pull/123)
 - use set matching logic for `java.util.Set` [#125](https://github.com/nubank/matcher-combinators/pull/125)
+- align `standalone/match?` and `core/match?` fns [#126](https://github.com/nubank/matcher-combinators/pull/126)
 
-### BREAKING CHANGE
+### BREAKING CHANGES
 
-matcher-combinators-2.0.0 includes a breaking change for custom implementations of the
-`matcher-combinators.core/Matcher` protocol:
+matcher-combinators-2.0.0 includes the following breaking changes:
 
-- change the implementation of `match` to `-match` (required)
-- add an implementation of `-matcher-for` (optional, but recommended)
-  - should just return `this` e.g. `(-matcher-for [this] this)
+* for custom implementations of the `matcher-combinators.core/Matcher` protocol:
+    * change the implementation of `match` to `-match` (required)
+    * add an implementation of `-matcher-for` (optional, but recommended)
+        * should just return `this` e.g. `(-matcher-for [this] this)`
+* for users of `matcher-combinators.standalone/match?` with one argument:
+    * this now expects a match result instead of a matcher, and returns a boolean
+        * there is no built-in solution for the previous behavior
 
 ## [1.5.2]
 - fix double eval of `clojure.test` `match-equals?` arguments

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,9 @@ change log follows the conventions of
 
 - add `matchers/matcher-for` [#123](https://github.com/nubank/matcher-combinators/pull/123)
 - use set matching logic for `java.util.Set` [#125](https://github.com/nubank/matcher-combinators/pull/125)
-- align `standalone/match?` and `core/match?` fns [#126](https://github.com/nubank/matcher-combinators/pull/126)
+- changes to `match?` fn [#126](https://github.com/nubank/matcher-combinators/pull/126)
+  - add `indicates-match?` to `matcher-combinators-core` and `matcher-combinators/standalone` namespaces
+  - deprecate arity-1 branch of `match?`
 
 ### BREAKING CHANGES
 

--- a/src/clj/matcher_combinators/clj_test.clj
+++ b/src/clj/matcher_combinators/clj_test.clj
@@ -49,7 +49,7 @@
 
        (core/matcher? matcher#)
        (let [result# (core/match matcher# actual#)
-             match?# (core/match? result#)]
+             match?# (core/indicates-match? result#)]
          (clojure.test/do-report
           (if match?#
             {:type     :pass
@@ -89,7 +89,7 @@
         (core/matcher? ~matcher)
         (let [result# (core/match ~matcher ~actual)]
           (clojure.test/do-report
-           (if (core/match? result#)
+           (if (core/indicates-match? result#)
              {:type     :pass
               :message  ~msg
               :expected '~form
@@ -137,7 +137,7 @@
             (catch ~klass e#
               (let [result# (core/match ~matcher (ex-data e#))]
                 (clojure.test/do-report
-                 (if (core/match? result#)
+                 (if (core/indicates-match? result#)
                    {:type     :pass
                     :message  ~msg
                     :expected '~form
@@ -190,7 +190,7 @@
           (core/matcher? matcher#)
           (let [result# (core/match matcher# actual#)]
             (clojure.test/do-report
-              (if (core/match? result#)
+              (if (core/indicates-match? result#)
                 {:type     :pass
                  :message  ~msg
                  :expected '~form

--- a/src/clj/matcher_combinators/midje.clj
+++ b/src/clj/matcher_combinators/midje.clj
@@ -21,7 +21,7 @@
     (checking/as-data-laden-falsehood
      {:notes [(exception/friendly-stacktrace actual)]})
     (let [{::result/keys [type value] :as result} (core/match matcher actual)]
-      (if (core/match? result)
+      (if (core/indicates-match? result)
         true
         (checking/as-data-laden-falsehood {:notes [(printer/as-string [type value])]})))))
 

--- a/src/cljc/matcher_combinators/cljs_test.cljc
+++ b/src/cljc/matcher_combinators/cljs_test.cljc
@@ -40,7 +40,7 @@
        (core/matcher? matcher#)
        (let [result# (core/match matcher# actual#)]
          (t/do-report
-           (if (core/match? result#)
+           (if (core/indicates-match? result#)
              {:type     :pass
               :message  ~msg
               :expected '~form
@@ -87,7 +87,7 @@
           (catch ~klass e#
             (let [result# (core/match ~matcher (ex-data e#))]
               (t/do-report
-               (if (core/match? result#)
+               (if (core/indicates-match? result#)
                  {:type     :pass
                   :message  ~msg
                   :expected '~form

--- a/src/cljc/matcher_combinators/specs.cljc
+++ b/src/cljc/matcher_combinators/specs.cljc
@@ -1,0 +1,25 @@
+(ns matcher-combinators.specs
+  (:require [clojure.spec.alpha :as s]
+            [matcher-combinators.core :as core]
+            [matcher-combinators.standalone :as standalone]
+            [matcher-combinators.result :as result]))
+
+(s/def :match/result    ::result/type)
+(s/def :mismatch/detail ::result/value)
+(s/def ::standalone-match-result
+  (s/keys :req [:match/result]
+          :opt [:mismatch/detail]))
+
+(s/def :matcher-combinators/match-args
+  (s/alt :match-result        (s/alt :standalone ::standalone-match-result
+                                     :core       ::result/result)
+         :expected-and-actual (s/cat :expected (fn [v] (satisfies? core/Matcher v))
+                                     :actual   any?)))
+
+(s/fdef matcher-combinators.core/match?
+  :args :matcher-combinators/match-args
+  :ret boolean?)
+
+(s/fdef matcher-combinators.standalone/match?
+  :args :matcher-combinators/match-args
+  :ret boolean?)

--- a/src/cljc/matcher_combinators/standalone.cljc
+++ b/src/cljc/matcher_combinators/standalone.cljc
@@ -1,7 +1,8 @@
 (ns matcher-combinators.standalone
   (:require [clojure.spec.alpha :as s]
             [matcher-combinators.core :as core]
-            [matcher-combinators.parser]))
+            [matcher-combinators.parser]
+            [matcher-combinators.result :as result]))
 
 (defn match
   "Returns a map indicating whether the `actual` value matches `expected`.
@@ -13,27 +14,32 @@
   - :match/result    - either :match or :mismatch
   - :mismatch/detail - the actual value with mismatch annotations. Only present when :match/result is :mismatch"
   [matcher actual]
-  (let [{:keys [matcher-combinators.result/type
-                matcher-combinators.result/value]}
+  (let [{::result/keys [type value]}
         (core/match matcher actual)]
     (cond-> {:match/result type}
       (= :mismatch type)
       (assoc :mismatch/detail value))))
 
-(s/fdef match?
-  :args (s/alt :partial (s/cat :matcher (partial satisfies? core/Matcher))
-               :full    (s/cat :matcher (partial satisfies? core/Matcher)
-                               :actual any?))
-  :ret (s/or :partial fn?
-             :full boolean?))
+#?(:clj
+   (def
+     ^{:doc      (-> #'core/indicates-match? meta :doc)
+       :arglists (-> #'core/indicates-match? meta :arglists)}
+     indicates-match?
+     core/indicates-match?))
 
-(defn match?
-  "Given a `matcher` and `actual`, returns `true` if
-  `(match matcher actual)` results in a match. Else, returns `false.`
+#?(:cljs
+   (def indicates-match?
+     "See matcher-combinators.core/indicates-match?"
+     core/indicates-match?))
 
-  Given only a `matcher`, returns a function that will
-  return true or false by the same logic."
-  ([matcher]
-   (fn [actual] (match? matcher actual)))
-  ([matcher actual]
-   (core/match? (core/match matcher actual))))
+#?(:clj
+   (def
+     ^{:doc      (-> #'core/match? meta :doc)
+       :arglists (-> #'core/match? meta :arglists)}
+     match?
+     core/match?))
+
+#?(:cljs
+   (def match?
+     "See matcher-combinators.core/match?"
+     core/match?))

--- a/test/clj/matcher_combinators/matchers_test.clj
+++ b/test/clj/matcher_combinators/matchers_test.clj
@@ -7,6 +7,7 @@
             [matcher-combinators.matchers :as m]
             [matcher-combinators.core :as c]
             [matcher-combinators.test]
+            [matcher-combinators.test-helpers :refer [greater-than-matcher]]
             [matcher-combinators.result :as result])
   (:import [matcher_combinators.model Mismatch Missing InvalidMatcherType]))
 
@@ -238,11 +239,6 @@
                     gen/any)]
                 (= (class (m/equals v))
                    (class (m/matcher-for v)))))
-
-(defn greater-than-matcher [expected-long]
-  (c/->PredMatcher
-   (fn [actual] (> actual expected-long))
-   (str "greater than " expected-long)))
 
 (deftest matcher-for-works-within-match-with
   (is (match-with? {java.lang.Long greater-than-matcher}

--- a/test/clj/matcher_combinators/midje_test.clj
+++ b/test/clj/matcher_combinators/midje_test.clj
@@ -6,6 +6,7 @@
             [matcher-combinators.midje :refer [match throws-match match-with match-roughly match-equals]]
             [matcher-combinators.model :as model]
             [matcher-combinators.result :as result]
+            [matcher-combinators.test-helpers :refer [greater-than-matcher]]
             [orchestra.spec.test :as spec.test]
             [midje.emission.api :as emission])
   (:import [clojure.lang ExceptionInfo]))
@@ -298,10 +299,10 @@
 (def match-abs (match-with {java.lang.Long ->AbsValue}))
 
 (facts "match-with checker behavior"
-  (core/match? (core/match -1 1)) => false
+  (core/indicates-match? (core/match -1 1)) => false
 
   (fact "low-level invocation"
-    (core/match?
+    (core/indicates-match?
      (dispatch/wrap-match-with
       {java.lang.Long ->AbsValue}
       (core/match -1 1)))
@@ -337,11 +338,6 @@
                                    {:a 1 :b 3.0})
   {:a 1 :b 3.05} =not=> (match-roughly 0.001
                                        {:a 1 :b 3.0}))
-
-(defn greater-than-matcher [expected-long]
-  (matcher-combinators.core/->PredMatcher
-   (fn [actual] (> actual expected-long))
-   (str "greater than " expected-long)))
 
 (fact "example from docstring"
   5 => (match-with {java.lang.Long greater-than-matcher}

--- a/test/clj/matcher_combinators/parser_test.clj
+++ b/test/clj/matcher_combinators/parser_test.clj
@@ -126,8 +126,7 @@
                          an-object)
              (core/match an-object
                          an-object)))
-      (is (= (core/match? (core/match another-object
-                                      (Object.)))
+      (is (= (core/indicates-match? (core/match another-object (Object.)))
              (= another-object (Object.)))))))
 
 (deftest mimic-matcher-macro

--- a/test/clj/matcher_combinators/standalone_test.clj
+++ b/test/clj/matcher_combinators/standalone_test.clj
@@ -1,15 +1,13 @@
 (ns matcher-combinators.standalone-test
   (:require [orchestra.spec.test :as spec.test]
             [clojure.test :refer [deftest testing is use-fixtures]]
+            [matcher-combinators.specs]
             [matcher-combinators.matchers :as m]
+            [matcher-combinators.test-helpers :as test-helpers]
             [matcher-combinators.result :as result]
             [matcher-combinators.standalone :as standalone]))
 
-(use-fixtures :once
-  (fn [f]
-    (spec.test/instrument)
-    (f)
-    (spec.test/unstrument)))
+(use-fixtures :once test-helpers/instrument)
 
 (def java-set (doto (new java.util.HashSet) (.add 1) (.add 2)))
 
@@ -29,9 +27,20 @@
     (is (= :match (:match/result (standalone/match (m/set-equals [odd? even?]) java-set))))
     (is (= :match (:match/result (standalone/match (m/set-embeds [odd? even?]) java-set)))))
 
-  ;; TODO (dchelimsky,2020-03-11): consider making it a plain datastructure
   (testing ":match/detail binds to a Mismatch object"
     (is (instance? matcher_combinators.model.Mismatch (:mismatch/detail (standalone/match 37 42))))))
+
+(deftest test-indicates-match?
+  (testing "with core match result"
+    (is (standalone/indicates-match? {::result/type :match
+                                      ::result/value nil
+                                      ::result/weight 0}))
+    (is (not (standalone/indicates-match? {::result/type :mismatch
+                                           ::result/value nil
+                                           ::result/weight 1}))))
+  (testing "with standalone match result"
+    (is (standalone/indicates-match? {:match/result :match}))
+    (is (not (standalone/indicates-match? {:match/result :mismatch})))))
 
 (deftest test-match?
   (testing "parser defaults"
@@ -40,10 +49,7 @@
     (is (not (standalone/match? 37 42)))
     (is (not (standalone/match? {:a odd?} {:a 2 :b 2}))))
 
-  (testing "explicit matchers matchers"
-    (is (standalone/match (m/embeds {:a odd?}) {:a 1 :b 2}))
+  (testing "explicit matchers"
+    (is (standalone/match? (m/embeds {:a odd?}) {:a 1 :b 2}))
     (is (standalone/match? (m/in-any-order [1 2]) [1 2]))
-    (is (not (standalone/match? (m/in-any-order [1 2]) [1 3]))))
-
-  (testing "using partial version of match?"
-    (is ((standalone/match? (m/embeds {:a odd?})) {:a 1 :b 2}))))
+    (is (not (standalone/match? (m/in-any-order [1 2]) [1 3])))))

--- a/test/clj/matcher_combinators/test_helpers.clj
+++ b/test/clj/matcher_combinators/test_helpers.clj
@@ -1,0 +1,34 @@
+(ns matcher-combinators.test-helpers
+  (:require [clojure.test.check.generators :as gen]
+            [orchestra.spec.test :as spec.test]
+            [matcher-combinators.core :as core]))
+
+(defn instrument
+  "Test fixture to turn on clojure.spec instrumentation."
+  [t]
+  (spec.test/instrument)
+  (t)
+  (spec.test/unstrument))
+
+(def gen-any-equatable
+  "Generates from gen/any-equatable such that there is no set in the
+  resulting structure that contains the value `false`. This is to get
+  around a bug which causes `(match? #{false} #{false})` to return
+  false.  Until that is fixed, use this generator instead of
+  gen/any-equatable.
+
+  See https://github.com/nubank/matcher-combinators/issues/124"
+  (gen/such-that
+   (fn [v]
+     (every? (fn [node]
+               (if (or (set? node)
+                       (sequential? node))
+                 (not (contains? (into #{} node) false))
+                 true))
+             (tree-seq coll? #(if (map? %) (vals %) %) v)))
+   gen/any-equatable))
+
+(defn greater-than-matcher [expected-long]
+  (core/->PredMatcher
+   (fn [actual] (> actual expected-long))
+   (str "greater than " expected-long)))

--- a/test/clj/matcher_combinators/test_test.clj
+++ b/test/clj/matcher_combinators/test_test.clj
@@ -1,6 +1,7 @@
 (ns matcher-combinators.test-test
   (:require [clojure.test :refer :all]
             [matcher-combinators.test :refer :all]
+            [matcher-combinators.test-helpers :refer [greater-than-matcher]]
             [matcher-combinators.core :as core]
             [matcher-combinators.matchers :as m])
   (:import [clojure.lang ExceptionInfo]))
@@ -78,11 +79,6 @@
           :in-wrong-place))
     (testing "fails with a nice message when you provide too many arguments"
       (is (thrown-match? ExceptionInfo {:a 1} (bang!) :extra-arg)))))
-
-(defn greater-than-matcher [expected-long]
-  (core/->PredMatcher
-   (fn [actual] (> actual expected-long))
-   (str "greater than " expected-long)))
 
 (deftest match-with-test
   (is (match-with? {java.lang.Long greater-than-matcher}

--- a/test/cljs/matcher_combinators/cljs_example_test.cljs
+++ b/test/cljs/matcher_combinators/cljs_example_test.cljs
@@ -55,11 +55,8 @@
 
 (deftest standalone
   (is (standalone/match? (m/in-any-order [1 2]) [1 2]))
-  (is (not (standalone/match? (m/in-any-order [1 2]) [1 3]))))
-
-(deftest partial-standalone
-  (testing "using partial version of match?"
-    (is ((standalone/match? (m/embeds {:a odd?})) {:a 1 :b 2}))))
+  (is (not (standalone/match? (m/in-any-order [1 2]) [1 3])))
+  (is (standalone/indicates-match? (standalone/match (m/embeds {:a odd?}) {:a 1 :b 2}))))
 
 (defn bang! [] (throw (ex-info "an exception" {:foo 1 :bar 2})))
 


### PR DESCRIPTION
There are currently 3 versions of `match?`:

* `matcher-combinators.core/match?`
* `matcher-combinators.standalone/match?`
* `matcher-combinators.test/match?` (clojure.test `assert-expr` - not really a function)

They all have different semantics, which is cause for much confusion.

This PR addresses this as follows:

* `match?` is now the arity-2 version
  * the arity-1 version is present but deprecated
* new `indicates-match?` fn replaces the arity-1 version of `match?