### PR TITLE
Add `indicates-match?` (and deprecate `core/match?`)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ change log follows the conventions of
 
 - add `matchers/matcher-for` [#123](https://github.com/nubank/matcher-combinators/pull/123)
 - use set matching logic for `java.util.Set` [#125](https://github.com/nubank/matcher-combinators/pull/125)
+- add `core/indicates-match?` and deprecate `core/match?`
+  - `core/match?` is mostly for internal use and occasionally used to build match?
+    fns in other libraries
 
 ### BREAKING CHANGE
 

--- a/src/clj/matcher_combinators/clj_test.clj
+++ b/src/clj/matcher_combinators/clj_test.clj
@@ -49,7 +49,7 @@
 
        (core/matcher? matcher#)
        (let [result# (core/match matcher# actual#)
-             match?# (core/match? result#)]
+             match?# (core/indicates-match? result#)]
          (clojure.test/do-report
           (if match?#
             {:type     :pass
@@ -89,7 +89,7 @@
         (core/matcher? ~matcher)
         (let [result# (core/match ~matcher ~actual)]
           (clojure.test/do-report
-           (if (core/match? result#)
+           (if (core/indicates-match? result#)
              {:type     :pass
               :message  ~msg
               :expected '~form
@@ -137,7 +137,7 @@
             (catch ~klass e#
               (let [result# (core/match ~matcher (ex-data e#))]
                 (clojure.test/do-report
-                 (if (core/match? result#)
+                 (if (core/indicates-match? result#)
                    {:type     :pass
                     :message  ~msg
                     :expected '~form
@@ -190,7 +190,7 @@
           (core/matcher? matcher#)
           (let [result# (core/match matcher# actual#)]
             (clojure.test/do-report
-              (if (core/match? result#)
+              (if (core/indicates-match? result#)
                 {:type     :pass
                  :message  ~msg
                  :expected '~form

--- a/src/clj/matcher_combinators/midje.clj
+++ b/src/clj/matcher_combinators/midje.clj
@@ -21,7 +21,7 @@
     (checking/as-data-laden-falsehood
      {:notes [(exception/friendly-stacktrace actual)]})
     (let [{::result/keys [type value] :as result} (core/match matcher actual)]
-      (if (core/match? result)
+      (if (core/indicates-match? result)
         true
         (checking/as-data-laden-falsehood {:notes [(printer/as-string [type value])]})))))
 

--- a/src/cljc/matcher_combinators/cljs_test.cljc
+++ b/src/cljc/matcher_combinators/cljs_test.cljc
@@ -40,7 +40,7 @@
        (core/matcher? matcher#)
        (let [result# (core/match matcher# actual#)]
          (t/do-report
-           (if (core/match? result#)
+           (if (core/indicates-match? result#)
              {:type     :pass
               :message  ~msg
               :expected '~form
@@ -87,7 +87,7 @@
           (catch ~klass e#
             (let [result# (core/match ~matcher (ex-data e#))]
               (t/do-report
-               (if (core/match? result#)
+               (if (core/indicates-match? result#)
                  {:type     :pass
                   :message  ~msg
                   :expected '~form

--- a/src/cljc/matcher_combinators/standalone.cljc
+++ b/src/cljc/matcher_combinators/standalone.cljc
@@ -36,4 +36,4 @@
   ([matcher]
    (fn [actual] (match? matcher actual)))
   ([matcher actual]
-   (core/match? (core/match matcher actual))))
+   (core/indicates-match? (core/match matcher actual))))

--- a/test/clj/matcher_combinators/core_test.clj
+++ b/test/clj/matcher_combinators/core_test.clj
@@ -14,23 +14,10 @@
             [matcher-combinators.result :as result]
             [matcher-combinators.dispatch :as dispatch]
             [matcher-combinators.parser]
-            [matcher-combinators.standalone :as standalone]))
+            [matcher-combinators.standalone :as standalone]
+            [matcher-combinators.test-helpers :as test-helpers :refer [gen-any-equatable]]))
 
-(spec.test/instrument)
-
-(use-fixtures :once
-  (fn [t]
-    (spec.test/instrument)
-    (t)
-    (spec.test/unstrument)))
-
-(def gen-any-equatable
-  (gen/such-that
-   (fn [v]
-     (every? (fn [node] (or (not (set? node))
-                            (not (contains? node false))))
-             (tree-seq coll? #(if (map? %) (keys %) %) v)))
-   gen/any-equatable))
+(use-fixtures :once test-helpers/instrument)
 
 (defspec equals-matcher-matches-when-values-are-equal
   {:max-size 10}
@@ -95,6 +82,8 @@
                    {::result/type  :mismatch
                     ::result/value (model/->Mismatch expected actual)}
                    res))))
+
+(spec.test/instrument)
 
 (facts "on sequence matchers"
   (tabular

--- a/test/clj/matcher_combinators/matchers_test.clj
+++ b/test/clj/matcher_combinators/matchers_test.clj
@@ -1,5 +1,5 @@
 (ns matcher-combinators.matchers-test
-  (:require [clojure.test :refer [deftest testing is]]
+  (:require [clojure.test :refer [deftest testing is use-fixtures]]
             [clojure.test.check.generators :as gen]
             [clojure.test.check.properties :as prop]
             [clojure.test.check.clojure-test :refer [defspec]]
@@ -7,8 +7,11 @@
             [matcher-combinators.matchers :as m]
             [matcher-combinators.core :as c]
             [matcher-combinators.test]
-            [matcher-combinators.result :as result])
+            [matcher-combinators.result :as result]
+            [matcher-combinators.test-helpers :as test-helpers :refer [greater-than-matcher]])
   (:import [matcher_combinators.model Mismatch Missing InvalidMatcherType]))
+
+(use-fixtures :once test-helpers/instrument)
 
 (def now (java.time.LocalDateTime/now))
 (def an-id-string "67b22046-7e9f-46b2-a3b9-e68618242864")
@@ -238,11 +241,6 @@
                     gen/any)]
                 (= (class (m/equals v))
                    (class (m/matcher-for v)))))
-
-(defn greater-than-matcher [expected-long]
-  (c/->PredMatcher
-   (fn [actual] (> actual expected-long))
-   (str "greater than " expected-long)))
 
 (deftest matcher-for-works-within-match-with
   (is (match-with? {java.lang.Long greater-than-matcher}

--- a/test/clj/matcher_combinators/midje_test.clj
+++ b/test/clj/matcher_combinators/midje_test.clj
@@ -6,6 +6,7 @@
             [matcher-combinators.midje :refer [match throws-match match-with match-roughly match-equals]]
             [matcher-combinators.model :as model]
             [matcher-combinators.result :as result]
+            [matcher-combinators.test-helpers :refer [greater-than-matcher]]
             [orchestra.spec.test :as spec.test]
             [midje.emission.api :as emission])
   (:import [clojure.lang ExceptionInfo]))
@@ -337,11 +338,6 @@
                                    {:a 1 :b 3.0})
   {:a 1 :b 3.05} =not=> (match-roughly 0.001
                                        {:a 1 :b 3.0}))
-
-(defn greater-than-matcher [expected-long]
-  (matcher-combinators.core/->PredMatcher
-   (fn [actual] (> actual expected-long))
-   (str "greater than " expected-long)))
 
 (fact "example from docstring"
   5 => (match-with {java.lang.Long greater-than-matcher}

--- a/test/clj/matcher_combinators/midje_test.clj
+++ b/test/clj/matcher_combinators/midje_test.clj
@@ -298,10 +298,10 @@
 (def match-abs (match-with {java.lang.Long ->AbsValue}))
 
 (facts "match-with checker behavior"
-  (core/match? (core/match -1 1)) => false
+  (core/indicates-match? (core/match -1 1)) => false
 
   (fact "low-level invocation"
-    (core/match?
+    (core/indicates-match?
      (dispatch/wrap-match-with
       {java.lang.Long ->AbsValue}
       (core/match -1 1)))

--- a/test/clj/matcher_combinators/parser_test.clj
+++ b/test/clj/matcher_combinators/parser_test.clj
@@ -126,8 +126,7 @@
                          an-object)
              (core/match an-object
                          an-object)))
-      (is (= (core/match? (core/match another-object
-                                      (Object.)))
+      (is (= (core/indicates-match? (core/match another-object (Object.)))
              (= another-object (Object.)))))))
 
 (deftest mimic-matcher-macro

--- a/test/clj/matcher_combinators/test_helpers.clj
+++ b/test/clj/matcher_combinators/test_helpers.clj
@@ -1,0 +1,34 @@
+(ns matcher-combinators.test-helpers
+  (:require [clojure.test.check.generators :as gen]
+            [orchestra.spec.test :as spec.test]
+            [matcher-combinators.core :as core]))
+
+(defn instrument
+  "Test fixture to turn on clojure.spec instrumentation."
+  [t]
+  (spec.test/instrument)
+  (t)
+  (spec.test/unstrument))
+
+(def gen-any-equatable
+  "Generates from gen/any-equatable such that there is no set in the
+  resulting structure that contains the value `false`. This is to get
+  around a bug which causes `(match? #{false} #{false})` to return
+  false.  Until that is fixed, use this generator instead of
+  gen/any-equatable.
+
+  See https://github.com/nubank/matcher-combinators/issues/124"
+  (gen/such-that
+   (fn [v]
+     (every? (fn [node]
+               (if (or (set? node)
+                       (sequential? node))
+                 (not (contains? (into #{} node) false))
+                 true))
+             (tree-seq coll? #(if (map? %) (vals %) %) v)))
+   gen/any-equatable))
+
+(defn greater-than-matcher [expected-long]
+  (core/->PredMatcher
+   (fn [actual] (> actual expected-long))
+   (str "greater than " expected-long)))

--- a/test/clj/matcher_combinators/test_test.clj
+++ b/test/clj/matcher_combinators/test_test.clj
@@ -1,9 +1,12 @@
 (ns matcher-combinators.test-test
-  (:require [clojure.test :refer :all]
+  (:require [clojure.test :refer [use-fixtures deftest testing is are]]
             [matcher-combinators.test :refer :all]
             [matcher-combinators.core :as core]
-            [matcher-combinators.matchers :as m])
+            [matcher-combinators.matchers :as m]
+            [matcher-combinators.test-helpers :as test-helpers :refer [greater-than-matcher]])
   (:import [clojure.lang ExceptionInfo]))
+
+(use-fixtures :once test-helpers/instrument)
 
 (def example-matcher {:username string?
                       :account  {:id        integer?
@@ -78,11 +81,6 @@
           :in-wrong-place))
     (testing "fails with a nice message when you provide too many arguments"
       (is (thrown-match? ExceptionInfo {:a 1} (bang!) :extra-arg)))))
-
-(defn greater-than-matcher [expected-long]
-  (core/->PredMatcher
-   (fn [actual] (> actual expected-long))
-   (str "greater than " expected-long)))
 
 (deftest match-with-test
   (is (match-with? {java.lang.Long greater-than-matcher}


### PR DESCRIPTION
There are currently 3 versions of `match?`:

* `matcher-combinators.core/match?`
* `matcher-combinators.standalone/match?`
* `matcher-combinators.test/match?` (clojure.test `assert-expr` - not really a function)

`core/match?` receives a match result (map) while the others receive expected/actual values.

This PR eliminates the confusion by deprecating `core/match?` and replacing it with a new `indicates-match?` function.

This is not a breaking change, and will have almost no fan-out within Nubank.