### PR TITLE
add Matcher impl for Symbol in cljs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@ All notable changes to this project will be documented in this file. This
 change log follows the conventions of
 [keepachangelog.com](http://keepachangelog.com/).
 
+## [2.1.0]
+
+- extend `Matcher` protocol to `Symbol` in cljs [#131](https://github.com/nubank/matcher-combinators/pull/131)
+
 ## [2.0.0]
 
 - add `matchers/matcher-for` [#123](https://github.com/nubank/matcher-combinators/pull/123)

--- a/project.clj
+++ b/project.clj
@@ -19,8 +19,8 @@
                  [org.clojure/math.combinatorics "0.1.6"]
                  [midje "1.9.9" :exclusions [org.clojure/clojure]]]
 
-  :test-paths ["test/clj"]
-  :source-paths ["src/cljc" "src/cljs" "src/clj"]
+  :source-paths ["src/clj" "src/cljc"]
+  :test-paths   ["test/clj" "test/cljc"]
 
   :profiles {:dev {:plugins [[lein-project-version "0.1.0"]
                              [lein-midje "3.2.1"]
@@ -44,14 +44,14 @@
             "test-node" ["doo" "node" "node-test" "once"]}
   ;; Below, :process-shim false is workaround for <https://github.com/bensu/doo/pull/141>
   :cljsbuild {:builds [{:id "test"
-                        :source-paths ["src/cljc" "src/cljs" "test/cljc" "test/cljs"]
+                        :source-paths ["src/cljs" "test/cljs"]
                         :compiler {:output-to "target/out/test.js"
                                    :output-dir "target/out"
                                    :main matcher-combinators.doo-runner
                                    :optimizations :none
                                    :process-shim false}}
                        {:id "advanced-test"
-                        :source-paths ["src/cljc" "src/cljs" "test/cljc" "test/cljs"]
+                        :source-paths ["src/cljs" "test/cljs"]
                         :compiler {:output-to "target/advanced_out/test.js"
                                    :output-dir "target/advanced_out"
                                    :main matcher-combinator.doo-runner
@@ -60,7 +60,7 @@
                        ;; Node.js requires :target :nodejs, hence the separate
                        ;; build configuration.
                        {:id "node-test"
-                        :source-paths ["src/cljc" "src/cljs" "test/cljc" "test/cljs"]
+                        :source-paths ["src/cljs" "test/cljs"]
                         :compiler {:output-to "target/node_out/test.js"
                                    :output-dir "target/node_out"
                                    :main matcher-combinators.doo-runner

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject nubank/matcher-combinators "2.0.0"
+(defproject nubank/matcher-combinators "2.1.0"
   :description "Library for creating matcher combinator to compare nested data structures"
   :url "https://github.com/nubank/matcher-combinators"
   :license {:name "Apache License, Version 2.0"}

--- a/src/cljc/matcher_combinators/parser.cljc
+++ b/src/cljc/matcher_combinators/parser.cljc
@@ -41,6 +41,10 @@
   (-match [this actual]
     (core/match (dispatch/keyword-dispatch this) actual))
 
+  Symbol
+  (-match [this actual]
+    (core/match (dispatch/symbol-dispatch this) actual))
+
   UUID
   (-match [this actual]
     (core/match (dispatch/uuid-dispatch this) actual))

--- a/src/cljc/matcher_combinators/standalone.cljc
+++ b/src/cljc/matcher_combinators/standalone.cljc
@@ -21,8 +21,8 @@
       (assoc :mismatch/detail value))))
 
 (s/fdef match?
-  :args (s/alt :partial (s/cat :matcher (partial satisfies? core/Matcher))
-               :full    (s/cat :matcher (partial satisfies? core/Matcher)
+  :args (s/alt :partial (s/cat :matcher (fn [matcher] (satisfies? core/Matcher matcher)))
+               :full    (s/cat :matcher (fn [matcher] (satisfies? core/Matcher matcher))
                                :actual any?))
   :ret (s/or :partial fn?
              :full boolean?))

--- a/test/cljc/matcher_combinators/test_helpers.cljc
+++ b/test/cljc/matcher_combinators/test_helpers.cljc
@@ -1,6 +1,7 @@
 (ns matcher-combinators.test-helpers
   (:require [clojure.test.check.generators :as gen]
-            [orchestra.spec.test :as spec.test]
+            #?(:cljc [clojure.spec.test.alpha :as spec.test]
+               :clj  [orchestra.spec.test :as spec.test])
             [matcher-combinators.core :as core]))
 
 (defn instrument


### PR DESCRIPTION
This PR adds `Symbol` to the cljs types that get `Matcher` implementations.

Also, converts some cljs tests to property based tests (which was actually discovered that `Symbol` was missing).