### PR TITLE
Add within-delta matcher

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,14 +10,22 @@ change log follows the conventions of
   - the overrides map now supports predicates as keys:
 
 ``` clojure
-;; this means now you can do this
-(match? (match-with [map? matchers/equals] <expected>) <actual>)
+;; before
+(is (match-with? {clojure.lang.IPersistentMap matchers/equals} <expected> <actual>))
+;; or
+(is (match-equals? <expected> <actual>))
 
-;; .. which also supports precedence of overlapping predicates, e.g.
-(match? (match-with [odd? equals pos? (roughly 0.1)] <expected>) <actual>)
+;; after
+(is (match? (matchers/match-with [map? matchers/equals] <expected> <actual>)))
 
-;; instead of this (though this is still supported)
-(match-with? {clojure.lang.IPersistentMap matchers/equals} ...)
+;; before
+(is (match-roughly? <delta> <expected> <actual>))
+;; after
+(is (match? (matchers/within-delta <delta> <expected>) <actual>))
+;; or (for nested numeric values)
+(is (match? (matchers/match-with [number? (matchers/within-delta <delta>)]
+                                 <expected>)
+            <actual>))
 ```
 
 ## [2.1.1]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,18 +4,17 @@ change log follows the conventions of
 [keepachangelog.com](http://keepachangelog.com/).
 
 ## DEV (next release)
+- add within-delta matcher
 - add match-with matcher [#134](https://github.com/nubank/matcher-combinators/issues/134)
   - also reimplemented match-with?, match-roughly? etc in terms of match-with
   - the overrides map now supports predicates as keys:
-- add within-delta matcher
 
 ``` clojure
 ;; this means now you can do this
-(match-with? [map? matchers/equals] ...)
+(match? (match-with [map? matchers/equals] <expected>) <actual>)
 
 ;; .. which also supports precedence of overlapping predicates, e.g.
-(match-with? [odd? equals
-             [pos? (roughly 0.1)] ,,,)
+(match? (match-with [odd? equals pos? (roughly 0.1)] <expected>) <actual>)
 
 ;; instead of this (though this is still supported)
 (match-with? {clojure.lang.IPersistentMap matchers/equals} ...)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ change log follows the conventions of
 - add match-with matcher [#134](https://github.com/nubank/matcher-combinators/issues/134)
   - also reimplemented match-with?, match-roughly? etc in terms of match-with
   - the overrides map now supports predicates as keys:
+- add within-delta matcher
 
 ``` clojure
 ;; this means now you can do this

--- a/src/clj/matcher_combinators/clj_test.clj
+++ b/src/clj/matcher_combinators/clj_test.clj
@@ -154,13 +154,6 @@
   (binding [*out* out]
     (printer/pretty-print (::result/value match-result))))
 
-(defn- class->symbol [cls]
-  (-> cls
-      str
-      (clojure.string/replace #"^class " "")
-      (clojure.string/replace #"^interface " "")
-      symbol))
-
 (defn build-match-assert
   "Allows you to define a custom clojure.test match assert:
 

--- a/src/clj/matcher_combinators/clj_test.clj
+++ b/src/clj/matcher_combinators/clj_test.clj
@@ -212,7 +212,7 @@
         the-rest  (rest (rest form))
         roughly-delta?  `(fn [expected#]
                            (core/->PredMatcher (fn [actual#]
-                                                 (utils/roughly? expected# actual# ~delta))
+                                                 (utils/within-delta? ~delta expected# actual#))
                                                (str "roughly " expected# " (+/- " ~delta ")")))
         form' (concat [directive] the-rest)]
     `(if (not (= 3 (count '~(rest form))))
@@ -221,14 +221,6 @@
           :message  ~msg
           :expected (symbol (str "`" '~directive "` expects 3 arguments: a `delta` number, a `matcher`, and the `actual`"))
           :actual   (symbol (str (count '~(rest form)) " were provided: " '~form))})
-       ~(build-match-assert 'match-roughly?
-                            {java.lang.Integer    roughly-delta?
-                             java.lang.Short      roughly-delta?
-                             java.lang.Long       roughly-delta?
-                             java.lang.Float      roughly-delta?
-                             java.lang.Double     roughly-delta?
-                             java.math.BigDecimal roughly-delta?
-                             java.math.BigInteger roughly-delta?
-                             clojure.lang.BigInt  roughly-delta?}
+       ~(build-match-assert 'match-roughly? [number? roughly-delta?]
                             msg
                             form'))))

--- a/src/clj/matcher_combinators/midje.clj
+++ b/src/clj/matcher_combinators/midje.clj
@@ -137,7 +137,7 @@
   "match where all numbers match if they are within the delta of their expected value"
   (fn [delta matcher]
     (let [func (fn [expected] (core/->PredMatcher (fn [actual]
-                                                    (utils/roughly? expected actual delta))
+                                                    (utils/within-delta? delta expected actual))
                                                   (str "roughly " expected " (+/- " delta ")")))]
       (match-with
        {java.lang.Integer    func

--- a/src/cljc/matcher_combinators/matchers.cljc
+++ b/src/cljc/matcher_combinators/matchers.cljc
@@ -176,15 +176,8 @@
    assoc ::match-with? true))
 
 (defn within-delta
-  "Returns a matcher that matches an actual numeric value (or any numeric
-  value within the actual structure) within delta of expected.
-
-  NOTE this uses `match-with`, and therefore does not apply to values nested within
-  a nested `match-with`."
+  "Matcher that will match when the actual value is within `delta` of `expected`."
   [delta expected]
-  (match-with [number?
-               (fn [expected]
-                 (core/->PredMatcher
-                  (fn [actual] (utils/within-delta? delta expected actual))
-                  (str "within-delta " expected " (+/- " delta ")")))]
-              expected))
+  (core/->PredMatcher
+   (fn [actual] (utils/within-delta? delta expected actual))
+   (str "within-delta " expected " (+/- " delta ")")))

--- a/src/cljc/matcher_combinators/matchers.cljc
+++ b/src/cljc/matcher_combinators/matchers.cljc
@@ -1,6 +1,7 @@
 (ns matcher-combinators.matchers
   (:require [clojure.string :as string]
-            [matcher-combinators.core :as core]))
+            [matcher-combinators.core :as core]
+            [matcher-combinators.utils :as utils]))
 
 (defn- non-internal-record? [v]
   (and (record? v)
@@ -173,3 +174,17 @@
          :else
          ((matcher-for value overrides) value))
    assoc ::match-with? true))
+
+(defn within-delta
+  "Returns a matcher that matches an actual numeric value (or any numeric
+  value within the actual structure) within delta of expected.
+
+  NOTE this uses `match-with`, and therefore does not apply to values nested within
+  a nested `match-with`."
+  [delta expected]
+  (match-with [number?
+               (fn [expected]
+                 (core/->PredMatcher
+                  (fn [actual] (utils/within-delta? delta expected actual))
+                  (str "within-delta " expected " (+/- " delta ")")))]
+              expected))

--- a/src/cljc/matcher_combinators/utils.cljc
+++ b/src/cljc/matcher_combinators/utils.cljc
@@ -1,9 +1,17 @@
-(ns matcher-combinators.utils)
+(ns matcher-combinators.utils
+  "Internal use only. Subject (and likely) to change.")
 
-(defn roughly? [expected actual delta]
-  (and (number? actual)
-       (>= expected (- actual delta))
-       (<= expected (+ actual delta))))
+(defn processable-number? [v]
+  (and (number? v)
+       (try
+         (and (not (Double/isInfinite v))
+              (not (Double/isNaN v)))
+         (catch Exception _ false))))
+
+(defn within-delta? [delta expected actual]
+  (and (processable-number? actual)
+       (>= expected (- actual (Math/abs delta)))
+       (<= expected (+ actual (Math/abs delta)))))
 
 (defn find-first [pred coll]
   (->> coll (filter pred) first))

--- a/test/clj/matcher_combinators/matchers_test.clj
+++ b/test/clj/matcher_combinators/matchers_test.clj
@@ -334,15 +334,15 @@
 (defspec within-delta-common-case
   {:doc       "works for ints, doubles, and bigdecs"
    :max-size  10}
-  (prop/for-all [v     (gen/one-of [gen/small-integer
+  (prop/for-all [delta (gen/fmap #(Math/abs %) (gen/double* {:infinite? false :NaN? false}))
+                 v     (gen/one-of [gen/small-integer
                                     (gen/double* {:infinite? false :NaN? false})
                                     (gen/fmap #(BigDecimal/valueOf %)
-                                              (gen/double* {:infinite? false :NaN? false}))])
-                 delta (gen/double* {:infinite? false :NaN? false})]
+                                              (gen/double* {:infinite? false :NaN? false}))])]
                 (c/indicates-match?
                  (c/match
-                  (m/within-delta delta {:x v})
-                  {:x (+ v delta)}))))
+                  (m/within-delta delta v)
+                  (+ v delta)))))
 
 (deftest with-delta-edge-cases
   (testing "+/-infinity and NaN return false (instead of throwing)"

--- a/test/clj/matcher_combinators/matchers_test.clj
+++ b/test/clj/matcher_combinators/matchers_test.clj
@@ -8,6 +8,7 @@
             [matcher-combinators.core :as c]
             [matcher-combinators.test]
             [matcher-combinators.result :as result]
+            [matcher-combinators.utils :as utils]
             [matcher-combinators.test-helpers :as test-helpers :refer [greater-than-matcher]])
   (:import [matcher_combinators.model Mismatch Missing InvalidMatcherType]))
 
@@ -329,3 +330,22 @@
                          {:a {:b {:c 1}
                               :d (m/embeds {:e {:inner-e {:x 1 :y 2}}})}})
            actual)))))
+
+(defspec within-delta-common-case
+  {:doc       "works for ints, doubles, and bigdecs"
+   :max-size  10}
+  (prop/for-all [v     (gen/one-of [gen/small-integer
+                                    (gen/double* {:infinite? false :NaN? false})
+                                    (gen/fmap #(BigDecimal/valueOf %)
+                                              (gen/double* {:infinite? false :NaN? false}))])
+                 delta (gen/double* {:infinite? false :NaN? false})]
+                (c/indicates-match?
+                 (c/match
+                  (m/within-delta delta {:x v})
+                  {:x (+ v delta)}))))
+
+(deftest with-delta-edge-cases
+  (testing "+/-infinity and NaN return false (instead of throwing)"
+    (is (no-match? (m/within-delta 0.1 100) ##Inf))
+    (is (no-match? (m/within-delta 0.1 100) ##-Inf))
+    (is (no-match? (m/within-delta 0.1 100) ##NaN))))


### PR DESCRIPTION
This PR adds a new `within-delta` matcher, intended to replace the midje `match-roughly` checker and clojure.test `match-roughly?` assert expr

```clojure
;; before
(is (match-roughly? <delta> <expected> <actual>))

;; after
(is (match? (within-delta <delta> <expected> <actual>))
;; or (for nested values)
(is (match? (match-with [number? (within-delta <delta>)] <expected>)
             <actual>))
```