### PR TITLE
deprecate some assert exprs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@ All notable changes to this project will be documented in this file. This
 change log follows the conventions of
 [keepachangelog.com](http://keepachangelog.com/).
 
-## DEV (next release)
+## [3.0.0]
 - add within-delta matcher (replaces match-roughly)
 - add match-with matcher [#134](https://github.com/nubank/matcher-combinators/issues/134)
   - also reimplemented match-with?, match-roughly? etc in terms of match-with

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,28 +4,30 @@ change log follows the conventions of
 [keepachangelog.com](http://keepachangelog.com/).
 
 ## DEV (next release)
-- add within-delta matcher
+- add within-delta matcher (replaces match-roughly)
 - add match-with matcher [#134](https://github.com/nubank/matcher-combinators/issues/134)
   - also reimplemented match-with?, match-roughly? etc in terms of match-with
-  - the overrides map now supports predicates as keys:
+  - the overrides map now supports predicates as keys
+- deprecate `match-with?`, `match-equals?`, `match-roughly?` assert expressions
+- deprecate `match-with`, `match-equals`, and `match-roughly` midje checkers
 
 ``` clojure
-;; before
-(is (match-with? {clojure.lang.IPersistentMap matchers/equals} <expected> <actual>))
-;; or
-(is (match-equals? <expected> <actual>))
+;; With this release, do this:
+(match? (matchers/match-with [map? matchers/equals] <expected>) <actual>)
 
-;; after
-(is (match? (matchers/match-with [map? matchers/equals] <expected> <actual>)))
+;; instead of this (deprecated, but still works)
+(match-with? {clojure.lang.IPersistentMap matchers/equals} <expected> <actual>)
+(match-equals? <expected> <actual>)
 
-;; before
-(is (match-roughly? <delta> <expected> <actual>))
-;; after
-(is (match? (matchers/within-delta <delta> <expected>) <actual>))
-;; or (for nested numeric values)
+;; and this
+(match? (matchers/within-delta <delta> <expected>) <actual>)
+;; or this
 (is (match? (matchers/match-with [number? (matchers/within-delta <delta>)]
                                  <expected>)
             <actual>))
+
+;; instead of this
+(match-roughly? <delta> <expected> <actual>)
 ```
 
 ## [2.1.1]

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject nubank/matcher-combinators "3.0.0-SNAPSHOT"
+(defproject nubank/matcher-combinators "3.0.0"
   :description "Library for creating matcher combinator to compare nested data structures"
   :url "https://github.com/nubank/matcher-combinators"
   :license {:name "Apache License, Version 2.0"}

--- a/src/cljc/matcher_combinators/core.cljc
+++ b/src/cljc/matcher_combinators/core.cljc
@@ -42,8 +42,8 @@
     :doc "DEPRECATED! Use `indicates-match?` instead."}
   match?
   [match-result]
-  (println (str "DEPRECATION WARNING: matcher-combinators.core/match? is deprecated.\n"
-                "                     Use matcher-combinators.core/indicates-match? instead."))
+  (println (str "DEPRECATION NOTICE: matcher-combinators.core/match? is deprecated.\n"
+                "                    Use matcher-combinators.core/indicates-match? instead."))
   (indicates-match? match-result))
 
 (defn matcher? [x]


### PR DESCRIPTION
This PR deprecates the `match-with?`, `match-equals?`, and `match-roughly?` assert expressions now that we can express all of those in terms of matchers.