### PR TITLE
Keep compatibility with BigDecimal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@ All notable changes to this project will be documented in this file. This
 change log follows the conventions of
 [keepachangelog.com](http://keepachangelog.com/).
 
+## [3.1.0]
+- adapt `utils/within-delta?` to accept BigDecimal as `delta` argument
+
 ## [3.0.1]
 - eliminate cljs warnings
 

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject nubank/matcher-combinators "3.0.1"
+(defproject nubank/matcher-combinators "3.1.0"
   :description "Library for creating matcher combinator to compare nested data structures"
   :url "https://github.com/nubank/matcher-combinators"
   :license {:name "Apache License, Version 2.0"}

--- a/src/cljc/matcher_combinators/utils.cljc
+++ b/src/cljc/matcher_combinators/utils.cljc
@@ -11,9 +11,11 @@
                 (not (infinite? v)))))
 
 (defn within-delta? [delta expected actual]
-  (and (processable-number? actual)
-       (>= expected (- actual (Math/abs delta)))
-       (<= expected (+ actual (Math/abs delta)))))
+  (let [delta (try (Math/abs delta)
+                   (catch IllegalArgumentException _ (.abs delta)))]
+    (and (processable-number? actual)
+         (>= expected (- actual delta))
+         (<= expected (+ actual delta)))))
 
 (defn find-first [pred coll]
   (->> coll (filter pred) first))

--- a/src/cljc/matcher_combinators/utils.cljc
+++ b/src/cljc/matcher_combinators/utils.cljc
@@ -15,7 +15,7 @@
                    #(.abs %)
                    #(Math/abs %))]
     (and (processable-number? actual)
-         (>= expected (- actual (delta-fn delta)))
+         (>= expected (- actual (abs delta)))
          (<= expected (+ actual (abs delta))))))
 
 (defn find-first [pred coll]

--- a/src/cljc/matcher_combinators/utils.cljc
+++ b/src/cljc/matcher_combinators/utils.cljc
@@ -11,7 +11,7 @@
                 (not (infinite? v)))))
 
 (defn within-delta? [delta expected actual]
-  (let [delta-fn (if (decimal? delta)
+  (let [abs (if (decimal? delta)
                    #(.abs %)
                    #(Math/abs %))]
     (and (processable-number? actual)

--- a/src/cljc/matcher_combinators/utils.cljc
+++ b/src/cljc/matcher_combinators/utils.cljc
@@ -11,11 +11,12 @@
                 (not (infinite? v)))))
 
 (defn within-delta? [delta expected actual]
-  (let [delta (try (Math/abs delta)
-                   (catch IllegalArgumentException _ (.abs delta)))]
+  (let [delta-fn (if (decimal? delta)
+                   #(.abs %)
+                   #(Math/abs %))]
     (and (processable-number? actual)
-         (>= expected (- actual delta))
-         (<= expected (+ actual delta)))))
+         (>= expected (- actual (delta-fn delta)))
+         (<= expected (+ actual (delta-fn delta))))))
 
 (defn find-first [pred coll]
   (->> coll (filter pred) first))

--- a/src/cljc/matcher_combinators/utils.cljc
+++ b/src/cljc/matcher_combinators/utils.cljc
@@ -16,7 +16,7 @@
                    #(Math/abs %))]
     (and (processable-number? actual)
          (>= expected (- actual (delta-fn delta)))
-         (<= expected (+ actual (delta-fn delta))))))
+         (<= expected (+ actual (abs delta))))))
 
 (defn find-first [pred coll]
   (->> coll (filter pred) first))

--- a/test/clj/matcher_combinators/test_test.clj
+++ b/test/clj/matcher_combinators/test_test.clj
@@ -110,4 +110,7 @@
 (deftest match-roughly-test
   (is (match-roughly? 0.1
                       {:a 1 :b 3.0}
+                      {:a 1 :b 3.05}))
+  (is (match-roughly? 0.1M
+                      {:a 1 :b 3.0}
                       {:a 1 :b 3.05})))


### PR DESCRIPTION
Allow using BigDecimal as delta for match-roughly and within-delta.