### PR TITLE
refactor processable-number? helper fn for within-delta

### DIFF
--- a/src/cljc/matcher_combinators/utils.cljc
+++ b/src/cljc/matcher_combinators/utils.cljc
@@ -1,22 +1,23 @@
 (ns matcher-combinators.utils
   "Internal use only. Subject (and likely) to change.")
 
-(defn processable-number? [v]
-  #?(:clj (and (number? v)
-               (try
-                 (and (not (Double/isInfinite v))
-                      (not (Double/isNaN v)))
-                 (catch Exception _ false)))
+(defn- processable-number? [v]
+  #?(:clj (or (decimal? v)
+              (and (number? v)
+                   (not (Double/isInfinite v))
+                   (not (Double/isNaN v))))
      :cljs (and (number? v)
                 (not (infinite? v)))))
 
+(defn- abs [n]
+  (if (decimal? n)
+    (.abs n)
+    (Math/abs n)))
+
 (defn within-delta? [delta expected actual]
-  (let [abs (if (decimal? delta)
-                   #(.abs %)
-                   #(Math/abs %))]
-    (and (processable-number? actual)
-         (>= expected (- actual (abs delta)))
-         (<= expected (+ actual (abs delta))))))
+  (and (processable-number? actual)
+       (>= expected (- actual (abs delta)))
+       (<= expected (+ actual (abs delta)))))
 
 (defn find-first [pred coll]
   (->> coll (filter pred) first))

--- a/test/clj/matcher_combinators/matchers_test.clj
+++ b/test/clj/matcher_combinators/matchers_test.clj
@@ -331,18 +331,25 @@
                               :d (m/embeds {:e {:inner-e {:x 1 :y 2}}})}})
            actual)))))
 
+(def gen-processable-double
+  (gen/double* {:infinite? false :NaN? false}))
+
+(def gen-bigdec
+  (gen/fmap #(BigDecimal/valueOf %) gen-processable-double))
+
 (defspec within-delta-common-case
-  {:doc       "works for ints, doubles, and bigdecs"
+  {:doc       "works for ints, doubles, and bigdecs as delta, expected, or actual"
    :max-size  10}
-  (prop/for-all [delta (gen/fmap #(Math/abs %) (gen/double* {:infinite? false :NaN? false}))
-                 v     (gen/one-of [gen/small-integer
-                                    (gen/double* {:infinite? false :NaN? false})
-                                    (gen/fmap #(BigDecimal/valueOf %)
-                                              (gen/double* {:infinite? false :NaN? false}))])]
+  (prop/for-all [delta    (gen/one-of [gen/small-integer
+                                       gen-processable-double
+                                       gen-bigdec])
+                 expected (gen/one-of [gen/small-integer
+                                       gen-processable-double
+                                       gen-bigdec])]
                 (c/indicates-match?
                  (c/match
-                  (m/within-delta delta v)
-                  (+ v delta)))))
+                  (m/within-delta delta expected)
+                  (+ expected delta)))))
 
 (deftest with-delta-edge-cases
   (testing "+/-infinity and NaN return false (instead of throwing)"


### PR DESCRIPTION
- check for decimal instead of catching Exception when asking if
  decimal value is infinite or NaN
- update test to generate more types of numbers for delta

This is a minor internal refactoring that will not effect behavior, so not even mentioning it in changelog or bumping version. It'll get subsumed by the next release.