### PR TITLE
fix within delta in match with bug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@ All notable changes to this project will be documented in this file. This
 change log follows the conventions of
 [keepachangelog.com](http://keepachangelog.com/).
 
+## [3.1.1]
+- fix bug using `within-delta` nested in `match-with` where expected value is a list
+
 ## [3.1.0]
 - adapt `utils/within-delta?` to accept BigDecimal as `delta` argument
 

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject nubank/matcher-combinators "3.1.0"
+(defproject nubank/matcher-combinators "3.1.1"
   :description "Library for creating matcher combinator to compare nested data structures"
   :url "https://github.com/nubank/matcher-combinators"
   :license {:name "Apache License, Version 2.0"}

--- a/src/cljc/matcher_combinators/matchers.cljc
+++ b/src/cljc/matcher_combinators/matchers.cljc
@@ -124,7 +124,9 @@
 
 (defn- match-with-elements [coll overrides]
   (reduce (fn [c v] (conj c (match-with overrides v)))
-          (empty coll)
+          (if (set? coll)
+            #{}
+            [])
           coll))
 
 (defn match-with
@@ -176,8 +178,17 @@
    assoc ::match-with? true))
 
 (defn within-delta
-  "Matcher that will match when the actual value is within `delta` of `expected`."
-  [delta expected]
-  (core/->PredMatcher
-   (fn [actual] (utils/within-delta? delta expected actual))
-   (str "within-delta " expected " (+/- " delta ")")))
+  "Given `delta` and `expected`, returns a Matcher that will match
+  when the actual value is within `delta` of `expected`. Given only
+  `delta`, returns a function to be used in the context of `match-with`,
+  e.g.
+
+    (is (match? (m/match-with [number? (m/within-delta 0.01M)]
+                              <expected>)
+                <actual>))"
+  ([delta]
+   (fn [expected] (within-delta delta expected)))
+  ([delta expected]
+   (core/->PredMatcher
+    (fn [actual] (utils/within-delta? delta expected actual))
+    (str "within-delta " expected " (+/- " delta ")"))))

--- a/test/clj/matcher_combinators/matchers_test.clj
+++ b/test/clj/matcher_combinators/matchers_test.clj
@@ -351,8 +351,22 @@
                   (m/within-delta delta expected)
                   (+ expected delta)))))
 
-(deftest with-delta-edge-cases
+(deftest within-delta-edge-cases
   (testing "+/-infinity and NaN return false (instead of throwing)"
     (is (no-match? (m/within-delta 0.1 100) ##Inf))
     (is (no-match? (m/within-delta 0.1 100) ##-Inf))
     (is (no-match? (m/within-delta 0.1 100) ##NaN))))
+
+(deftest within-delta-in-match-with
+  (testing "works with a vec"
+    (is (match? (m/match-with [number? (m/within-delta 0.01M)]
+                              [{:b 1M} {:b 0M} {:b 3M}])
+                [{:b 1M} {:b 0M} {:b 3M}])))
+  (testing "works with a seq"
+    (is (match? (m/match-with [number? (m/within-delta 0.01M)]
+                              '({:b 1M} {:b 0M} {:b 3M}))
+                [{:b 1M} {:b 0M} {:b 3M}])))
+  (testing "works with a set"
+    (is (match? (m/match-with [number? (m/within-delta 0.01M)]
+                              #{{:b 1M} {:b 0M} {:b 3M}})
+                #{{:b 1M} {:b 0M} {:b 3M}}))))

--- a/test/cljc/matcher_combinators/test_helpers.cljc
+++ b/test/cljc/matcher_combinators/test_helpers.cljc
@@ -1,6 +1,6 @@
 (ns matcher-combinators.test-helpers
   (:require [clojure.test.check.generators :as gen]
-            #?(:cljc [clojure.spec.test.alpha :as spec.test]
+            #?(:cljs [clojure.spec.test.alpha :as spec.test]
                :clj  [orchestra.spec.test :as spec.test])
             [matcher-combinators.core :as core]))
 


### PR DESCRIPTION
This fixes a 3.0.0 bug when the expected value in `(match-with [pred delta] <expected>)` includes a list.

It also introduces an arity-1 version of `within-delta` so you don't have to wrap it in a partial to use it in `match-with`