### PR TITLE
clean up some tests

### DIFF
--- a/src/clj/matcher_combinators/midje.clj
+++ b/src/clj/matcher_combinators/midje.clj
@@ -37,17 +37,17 @@
                  uses the provided type->matcher map to redefine the default
                  matchers used for the specified types.
 
-                 By default when the system sees a `java.lang.Long` it applies
+                 By default when the system sees a number, it applies
                  the `equals` matcher to it.  So if, for example, we want to
-                 check that all Longs are greater than whatever Long provided
-                 in the matcher, we would do:
+                 match ints by their absolute value, we could do this:
 
-                 `(defn greater-than-matcher [expected-long]
-                    (matcher-combinators.core/->PredMatcher
-                      (fn [actual] (> actual expected-long))
-                      (str \"greater than \" expected-long)))
+                     (defn abs-value-matcher [expected]
+                       (core/->PredMatcher
+                        (fn [actual] (= (Math/abs expected)
+                                        (Math/abs actual)))
+                        (str \"equal to abs value of \" expected)))
 
-                 (match-with [int? greater-than-matcher])`
+                     (match-with [int? abs-value-matcher])
 
                  NOTE: currently doesn't work in midje `provided` expressions"
             :arglists '([type->default-matcher]

--- a/src/cljc/matcher_combinators/test.cljc
+++ b/src/cljc/matcher_combinators/test.cljc
@@ -21,7 +21,6 @@
    (def build-match-assert
      "Allows you to define a custom clojure.test match assert:
 
-
-     `(defmethod clojure.test/assert-expr 'baz? [msg form]
-     (build-match-assert 'baz? {java.lang.Long greater-than-matcher} msg form))`"
+     `(defmethod clojure.test/assert-expr 'abs-value? [msg form]
+     (build-match-assert 'abs-value? [int? abs-value-matcher] msg form))`"
      matcher-combinators.clj-test/build-match-assert))

--- a/test/clj/matcher_combinators/matchers_test.clj
+++ b/test/clj/matcher_combinators/matchers_test.clj
@@ -9,7 +9,7 @@
             [matcher-combinators.test]
             [matcher-combinators.result :as result]
             [matcher-combinators.utils :as utils]
-            [matcher-combinators.test-helpers :as test-helpers :refer [greater-than-matcher]])
+            [matcher-combinators.test-helpers :as test-helpers :refer [abs-value-matcher]])
   (:import [matcher_combinators.model Mismatch Missing InvalidMatcherType]))
 
 (use-fixtures :once test-helpers/instrument)
@@ -249,16 +249,16 @@
 
 (deftest match-with-matcher
   (testing "processes overrides in order"
-    (let [matcher (m/match-with [pos? greater-than-matcher
+    (let [matcher (m/match-with [pos? abs-value-matcher
                                  int? m/equals]
                                 5)]
-      (is (match? matcher 6))
-      (is (no-match? matcher 5)))
-    (let [matcher (m/match-with [pos? greater-than-matcher
+      (is (match? matcher 5))
+      (is (match? matcher -5)))
+    (let [matcher (m/match-with [pos? abs-value-matcher
                                  int? m/equals]
                                 -5)]
-      (is (match? matcher -5))
-      (is (no-match? matcher -6))))
+      (is (no-match? matcher 5))
+      (is (match? matcher -5))))
   (testing "maps"
     (testing "passing case with equals override"
       (is (match? (m/match-with [map? m/equals]

--- a/test/clj/matcher_combinators/test_test.clj
+++ b/test/clj/matcher_combinators/test_test.clj
@@ -3,7 +3,7 @@
             [matcher-combinators.test :refer :all]
             [matcher-combinators.core :as core]
             [matcher-combinators.matchers :as m]
-            [matcher-combinators.test-helpers :as test-helpers :refer [greater-than-matcher]])
+            [matcher-combinators.test-helpers :as test-helpers :refer [abs-value-matcher]])
   (:import [clojure.lang ExceptionInfo]))
 
 (use-fixtures :once test-helpers/instrument)
@@ -82,16 +82,20 @@
     (testing "fails with a nice message when you provide too many arguments"
       (is (thrown-match? ExceptionInfo {:a 1} (bang!) :extra-arg)))))
 
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;; DEPRECATED
+;; - the rest of these tests are for deprecated APIs
+
 (deftest match-with-test
-  (is (match-with? {java.lang.Long greater-than-matcher}
-                   4
+  (is (match-with? {java.lang.Long abs-value-matcher}
+                   -5
                    5)))
 
-(defmethod clojure.test/assert-expr 'match-greather-than? [msg form]
-  (build-match-assert 'match-greather-than? {java.lang.Long greater-than-matcher} msg form))
+(defmethod clojure.test/assert-expr 'match-abs-value? [msg form]
+  (build-match-assert 'match-abs-value? {java.lang.Long abs-value-matcher} msg form))
 
-(deftest match-greater-than-test
-  (is (match-greather-than? 4 5)))
+(deftest custom-assert-expr
+  (is (match-abs-value? - 5)))
 
 (deftest match-equals-test
   (is (match-equals? {:a 1}
@@ -109,8 +113,5 @@
 
 (deftest match-roughly-test
   (is (match-roughly? 0.1
-                      {:a 1 :b 3.0}
-                      {:a 1 :b 3.05}))
-  (is (match-roughly? 0.1M
                       {:a 1 :b 3.0}
                       {:a 1 :b 3.05})))

--- a/test/cljc/matcher_combinators/test_helpers.cljc
+++ b/test/cljc/matcher_combinators/test_helpers.cljc
@@ -2,7 +2,9 @@
   (:require [clojure.test.check.generators :as gen]
             #?(:cljs [clojure.spec.test.alpha :as spec.test]
                :clj  [orchestra.spec.test :as spec.test])
-            [matcher-combinators.core :as core]))
+            [matcher-combinators.core :as core]
+            [matcher-combinators.result :as result]
+            [matcher-combinators.model :as model]))
 
 (defn instrument
   "Test fixture to turn on clojure.spec instrumentation."
@@ -11,7 +13,8 @@
   (t)
   (spec.test/unstrument))
 
-(defn greater-than-matcher [expected-long]
+(defn abs-value-matcher [expected]
   (core/->PredMatcher
-   (fn [actual] (> actual expected-long))
-   (str "greater than " expected-long)))
+   (fn [actual] (= (Math/abs expected)
+                   (Math/abs actual)))
+   (str "equal to abs value of " expected)))


### PR DESCRIPTION
Use `abs-value-matcher` in test cases (easier to reason about than `greater-than-matcher` IMO)