### PR TITLE
Fix cljs warning for undeclared var decimal?

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@ All notable changes to this project will be documented in this file. This
 change log follows the conventions of
 [keepachangelog.com](http://keepachangelog.com/).
 
+## [3.1.2]
+- fix cljs warning for undeclared var `decimal?`
+
 ## [3.1.1]
 - fix bug using `within-delta` nested in `match-with` where expected value is a list
 

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject nubank/matcher-combinators "3.1.1"
+(defproject nubank/matcher-combinators "3.1.2"
   :description "Library for creating matcher combinator to compare nested data structures"
   :url "https://github.com/nubank/matcher-combinators"
   :license {:name "Apache License, Version 2.0"}

--- a/src/cljc/matcher_combinators/utils.cljc
+++ b/src/cljc/matcher_combinators/utils.cljc
@@ -10,9 +10,10 @@
                 (not (infinite? v)))))
 
 (defn- abs [n]
-  (if (decimal? n)
-    (.abs n)
-    (Math/abs n)))
+  #?(:clj (if (decimal? n)
+            (.abs n)
+            (Math/abs n))
+     :cljs (js/Math.abs n)))
 
 (defn ^:no-doc within-delta?
   "Internal use only. Subject to change and removal.


### PR DESCRIPTION
```
------ WARNING - :undeclared-var -----------------------------------------------
 Resource: matcher_combinators/utils.cljc:13:8
 Use of undeclared Var matcher-combinators.utils/decimal?
--------------------------------------------------------------------------------
```