### PR TITLE
add flare string diffing to output

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -14,7 +14,8 @@
                      provided [[:inner 0]]
                      tabular  [[:inner 0]]}}
 
-  :dependencies [[org.clojure/clojure "1.10.1"]
+  :dependencies [[flare "0.2.9" :exclusions [org.clojure/clojure]]
+                 [org.clojure/clojure "1.10.1"]
                  [org.clojure/spec.alpha "0.2.187"]
                  [org.clojure/math.combinatorics "0.1.6"]
                  [midje "1.9.9" :exclusions [org.clojure/clojure]]]

--- a/src/clj/matcher_combinators/clj_test.clj
+++ b/src/clj/matcher_combinators/clj_test.clj
@@ -88,7 +88,7 @@
        (core/matcher? ~matcher)
        (let [result# (core/match
                       (matchers/match-with ~type->matcher ~matcher)
-                      ~actual)]
+                       ~actual)]
          (clojure.test/do-report
           (if (core/indicates-match? result#)
             {:type     :pass
@@ -182,7 +182,7 @@
                          (matchers/match-with
                           type->matcher#
                           matcher#)
-                         actual#)]
+                          actual#)]
             (clojure.test/do-report
              (if (core/indicates-match? result#)
                {:type     :pass
@@ -222,10 +222,10 @@
         form' (concat [directive] the-rest)]
     `(if (not (= 3 (count '~(rest form))))
        (clojure.test/do-report
-         {:type     :fail
-          :message  ~msg
-          :expected (symbol (str "`" '~directive "` expects 3 arguments: a `delta` number, a `matcher`, and the `actual`"))
-          :actual   (symbol (str (count '~(rest form)) " were provided: " '~form))})
+        {:type     :fail
+         :message  ~msg
+         :expected (symbol (str "`" '~directive "` expects 3 arguments: a `delta` number, a `matcher`, and the `actual`"))
+         :actual   (symbol (str (count '~(rest form)) " were provided: " '~form))})
        ~(build-match-assert
          'match-roughly? [number? roughly-delta?]
          msg

--- a/test/clj/matcher_combinators/core_test.clj
+++ b/test/clj/matcher_combinators/core_test.clj
@@ -125,11 +125,11 @@
 
 (deftest test-deprectated-match?
   (is (core/match? {::result/type :match
-                              ::result/weight 0
-                              ::result/value :does-not-matter}))
+                    ::result/weight 0
+                    ::result/value :does-not-matter}))
 
   (is (not (core/match? {::result/type :mismatch
-                                   ::result/weight 1
+                         ::result/weight 1
                          ::result/value :does-not-matter}))))
 
 (defspec sequence-matchers-match-when-elements-match-in-order
@@ -178,7 +178,6 @@
                 (not
                  (core/indicates-match?
                   (core/match (m expected) actual)))))
-
 
 (spec.test/instrument)
 

--- a/test/clj/matcher_combinators/midje_test.clj
+++ b/test/clj/matcher_combinators/midje_test.clj
@@ -300,14 +300,12 @@
                          :f 5
                          :g 17}}}]
     (fact "nested maps inside of an `embeds` of a match-equals are treated as equals"
-          payload
-          =not=> (match-equals {:a {:b {:c 1}
-                                    :d (m/embeds {:e {:inner-e {:x 1}}})}})
-          payload
-          => (match-equals {:a {:b {:c 1}
-                                :d (m/embeds {:e {:inner-e {:x 1 :y 2}}})}}))))
-
-
+      payload
+      =not=> (match-equals {:a {:b {:c 1}
+                                :d (m/embeds {:e {:inner-e {:x 1}}})}})
+      payload
+      => (match-equals {:a {:b {:c 1}
+                            :d (m/embeds {:e {:inner-e {:x 1 :y 2}}})}}))))
 
 (facts "match-equals"
   (fact "normal loose matching passes"

--- a/test/clj/matcher_combinators/parser_test.clj
+++ b/test/clj/matcher_combinators/parser_test.clj
@@ -123,9 +123,9 @@
         another-object (RuntimeException.)]
     (testing "Objects default to equality matching"
       (is (= (core/match (equals an-object)
-                         an-object)
+               an-object)
              (core/match an-object
-                         an-object)))
+               an-object)))
       (is (= (core/indicates-match? (core/match another-object (Object.)))
              (= another-object (Object.)))))))
 

--- a/test/clj/matcher_combinators/printer_test.clj
+++ b/test/clj/matcher_combinators/printer_test.clj
@@ -36,6 +36,12 @@
                       (printer/->ColorTag :yellow expected)
                       (printer/->ColorTag :red actual))))
 
+  (fact "string mismatches show distance between strings"
+    (printer/markup-expression (model/->Mismatch "hello world" "h4110 w0r1d"))
+    => (list 'mismatch
+             (printer/->ColorTag :yellow "h(ello worl)d")
+             (printer/->ColorTag :red "h(4110 w0r1)d")))
+
   (fact "Missing values are marked up in red"
     (printer/markup-expression (model/->Missing 42))
     => (list 'missing


### PR DESCRIPTION
Midje, when reporting test failures where the expected and actual are strings, uses https://github.com/duckyuck/flare to do string diff'ing.

for example you might see output like
```
Expected:
"hello world!"
Actual:
"hello world"
Diffs: strings have 1 difference (91% similarity)
                expected: "... world(!)"
                actual:   "... world(-)"
```


This PR is a proposal to add this to matcher-combinators.

For something like this
```clojure
(fact 
  ["abc" "ayz"] => (match (matchers/in-any-order ["ay*" "ab*"])))
```

Before:
```
FAIL at (scratch.clj:50)
Actual result did not agree with the checking function.
Actual result:
["abc" "ayz"]
Checking function: (match (matchers/in-any-order ["ay*" "ab*"]))
    The checker said this about the reason:
        [:mismatch
 ((mismatch "ab*" "abc")
  (mismatch "ay*" "ayz"))]
```

after
```
FAIL at (scratch.clj:50)
Actual result did not agree with the checking function.
Actual result:
["abc" "ayz"]
Checking function: (match (matchers/in-any-order ["ay*" "ab*"]))
    The checker said this about the reason:
        [:mismatch
 ((mismatch "ab(*)" "ab(c)")
  (mismatch "ay(*)" "ay(z)"))]
```

or for

```clojure
(deftest bar
  (is (match? "hello o brave new world!"
              "hello world!")))
```
before:
```
FAIL in (bar) (test_test.clj:120)
expected: (match? "hello o brave new world!" "hello world!")
  actual: (mismatch
 "hello o brave new world!"
 "hello world!")
```
after
```
FAIL in (bar) (test_test.clj:120)
expected: (match? "hello o brave new world!" "hello world!")
  actual: (mismatch
 "hello (o brave new )world!"
 "hello (------------)world!")
```

Any suggestions on making it clearer what is expected, actual, and the diff between them?