### PR TITLE
Lift matcher name logic to matcher protocol

### DIFF
--- a/src/cljc/matcher_combinators/matchers.cljc
+++ b/src/cljc/matcher_combinators/matchers.cljc
@@ -66,13 +66,14 @@
   (core/->Regex expected))
 
 (def absent
-  "Value-position matcher for maps that matches when containing map doesn't have the key pointing to this matcher."
+  "Value-position matcher for maps that matches when containing map doesn't
+  have the key pointing to this matcher."
   (core/->Absent))
 
 (defn pred
   "Matcher that will match when `pred` of the actual value returns true."
   [pred]
-  (core/->PredMatcher pred (str "predicate: " pred)))
+  (core/->PredMatcher pred `(~'pred ~pred)))
 
 #?(:cljs (defn- cljs-uri [expected]
            (core/->CljsUriEquals expected)))


### PR DESCRIPTION
generally a nice little standardization of existing code but also needed to implement printing underlying matcher for the mismatch matcher: https://github.com/nubank/matcher-combinators/pull/158/files#r646551305