### PR TITLE
Fixed `printable-matcher` cljs error catch

### DIFF
--- a/src/cljc/matcher_combinators/core.cljc
+++ b/src/cljc/matcher_combinators/core.cljc
@@ -488,7 +488,7 @@
     (if-let [n (-base-name matcher)]
       `(~(symbol n) ~(:expected matcher))
       matcher)
-    (catch #?(:clj IllegalArgumentException :cljs Exception) _e
+    (catch #?(:clj IllegalArgumentException :cljs js/Error) _e
       matcher)))
 
 (defrecord Mismatcher


### PR DESCRIPTION
Don't know what is going on here, but looks like there was a misspell which sent me a lot of warnings in the console.

```
------ WARNING #1 - :undeclared-var --------------------------------------------
 Resource: matcher_combinators/core.cljc:491:51
 Use of undeclared Var matcher-combinators.core/Exception
```