### PR TITLE
This defines simple equality fastpaths for order agnostic matchers

### DIFF
--- a/test/clj/matcher_combinators/standalone_test.clj
+++ b/test/clj/matcher_combinators/standalone_test.clj
@@ -33,6 +33,12 @@
   (testing ":match/detail binds to a Mismatch object"
     (is (instance? matcher_combinators.model.Mismatch (:mismatch/detail (standalone/match 37 42))))))
 
+(deftest n-factorial-pathologies
+  (testing "in-any-order"
+    (is (= :match    (:match/result (standalone/match (m/in-any-order (range 10000)) (shuffle (range 10000)))))))
+  (testing "set-equals"
+    (is (= :match    (:match/result (standalone/match (m/set-equals (set (range 100000))) (set (range 100000))))))))
+
 (deftest test-match?
   (testing "parser defaults"
     (is (standalone/match? 37 37))

--- a/test/clj/matcher_combinators/standalone_test.clj
+++ b/test/clj/matcher_combinators/standalone_test.clj
@@ -35,9 +35,12 @@
 
 (deftest n-factorial-pathologies
   (testing "in-any-order"
-    (is (= :match    (:match/result (standalone/match (m/in-any-order (range 10000)) (shuffle (range 10000)))))))
+    (is (= :match    (:match/result (standalone/match (m/in-any-order (range 10000)) (shuffle (range 10000))))))
+    (is (thrown? IllegalArgumentException (standalone/match (m/in-any-order [even? odd?]) [even? odd?])))
+    (is (= :match    (:match/result (standalone/match (m/match-with [number? (m/within-delta 0.01M)] (m/in-any-order [3 4 5])) [2.99 4.99 4.01])))))
   (testing "set-equals"
-    (is (= :match    (:match/result (standalone/match (m/set-equals (set (range 100000))) (set (range 100000))))))))
+    (is (= :match    (:match/result (standalone/match (m/set-equals (set (range 100000))) (set (range 100000))))))
+    (is (= :mismatch (:match/result (standalone/match (m/set-equals [:a :a :b :c]) #{:a :b :c}))))))
 
 (deftest test-match?
   (testing "parser defaults"


### PR DESCRIPTION
- in-any-order gains a fastpath: when `clojure.core/frequencies` of
expected and actual are equal, fast match.
- set-equals gains a fastpath: check simple = when set validation is confirmed, after coercing `expected` to a set.

This does not match prior semantics like-for-like and we should definitely discuss this.

e.g.: `(matcher-combinators.standalone/match (matcher-combinators.matchers/set-equals [:a :a :b :c]) #{:a :b :c})` returns 
`{:match/result :mismatch, :mismatch/detail #{{:expected :a} :c :b :a}}` when invoked prior to these fastpaths. Now it returns `{:match/result :match}` I believe this is a bug in `set-equals`

The cardinality of the sets in the pathological case tests are sufficient to provoke bad performance running on my dev laptop; reproducing bad performance can be simply examined by commenting the body of the fast path functions (which will then return nil, which will then not provide a fast path success, which will result in the O(n!) behavior we observe today)

Encouragingly, `set-equals` was not interminably slow, just ~1.5-2 minutes without the fast path :)