### PR TITLE
rename `matcher-combinators.utils/abs` to avoid shadowing `clojure.core/abs`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@ All notable changes to this project will be documented in this file. This
 change log follows the conventions of
 [keepachangelog.com](http://keepachangelog.com/).
 
+## unreleased
+- Fix `abs already refers to: #'clojure.core/abs in namespace: matcher-combinators.utils` warning
+
 ## [3.3.1]
 - Bump midje from 1.10.3 -> 1.10.4
 

--- a/src/cljc/matcher_combinators/utils.cljc
+++ b/src/cljc/matcher_combinators/utils.cljc
@@ -9,7 +9,7 @@
      :cljs (and (number? v)
                 (not (infinite? v)))))
 
-(defn- abs [n]
+(defn- absolute [n]
   #?(:clj (if (decimal? n)
             (.abs n)
             (Math/abs n))
@@ -20,8 +20,8 @@
   Supports the `within-delta` matcher."
   [delta expected actual]
   (and (processable-number? actual)
-       (>= expected (- actual (abs delta)))
-       (<= expected (+ actual (abs delta)))))
+       (>= expected (- actual (absolute delta)))
+       (<= expected (+ actual (absolute delta)))))
 
 (defn ^:no-doc find-first
   "Internal use only. Subject to change and removal."
@@ -32,5 +32,5 @@
   "Internal use only. Subject to change and removal.
   Similar to `remove` but stops after removing 1 element"
   [pred coll]
-  (let [[x [y & z]] (split-with (complement pred) coll)]
+  (let [[x [_y & z]] (split-with (complement pred) coll)]
     (concat x z)))


### PR DESCRIPTION
I'm seeing the following warning a lot in my REPL:
```
WARNING: abs already refers to: #'clojure.core/abs in namespace: matcher-combinators.utils, being replaced by: #'matcher-combinators.utils/abs
```

I think this PR should address it