### PR TITLE
Add note to equals docstring

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,7 +158,8 @@ for a specific value, e.g.
   - scalars: matches when the given value is exactly the same as the `expected`.
   - map: matches when
       1. the keys of the `expected` map are equal to the given map's keys
-      2. the value matchers of `expected` map matches the given map's values
+      2. the value matchers of `expected` map matches the given map's values 
+         - Note: Given that the default matcher for maps is `embeds`, nested maps continue being matched with embeds (instead of also being matched with `equals`). Check out 'Overriding default matchers' below for instructions on how to match nested maps with equals too.
   - sequence: matches when the `expected` sequences's matchers match the given sequence. Similar to midje's `(just expected)`
   - set: matches when all the elements in the given set can be matched with a matcher in `expected` set and each matcher is used exactly once.
 - `embeds` operates over maps, sequences, and sets

--- a/src/cljc/matcher_combinators/matchers.cljc
+++ b/src/cljc/matcher_combinators/matchers.cljc
@@ -13,8 +13,12 @@
   "Matcher that will match when the given value is exactly the same as the
   `expected`.
 
-  Note: For maps, only the top level keys and values are checked for equality.
-  Nested maps continue being matched with `embeds`. If you want to do a deep
+  When `expected` is:
+   - A scalar or function: Value equality is used
+   - A composite data-structure (map, vector, etc): each element in `actual` must 
+  match a corresponding element in `expected`. Consistent with other matchers, 
+  equals is not recursively applied to sub-elements. This means that nested maps, 
+  for example, continue using their default matcher. If you want to do a deep  
   match, consider using `match-with` instead."
   [expected]
   (cond

--- a/src/cljc/matcher_combinators/matchers.cljc
+++ b/src/cljc/matcher_combinators/matchers.cljc
@@ -11,7 +11,11 @@
 
 (defn equals
   "Matcher that will match when the given value is exactly the same as the
-  `expected`."
+  `expected`.
+
+  Note: For maps, only the top level keys and values are checked for equality.
+  Nested maps continue being matched with `embeds`. If you want to do a deep
+  match, consider using `match-with` instead."
   [expected]
   (cond
     (sequential? expected)          (core/->EqualsSeq expected)


### PR DESCRIPTION
I recently realized that, for maps, `equals` does not have similar behavior to the clojure standard `equals`, as it only modifies the matches being done on the top level map.



This is stated in the readme (sections [built-in matchers](https://github.com/nubank/matcher-combinators#built-in-matchers) and [overriding default matchers](https://github.com/nubank/matcher-combinators#overriding-default-matchers)).

However, nothing is stated in the docstring (which is where I assume developers would look at more often, especially given IDE integrations). I've added a note there to try and make this more obvious.

I've also added an extra note in the README to highlight this point