### PR TITLE
upgrade to clojure-1.11.0, eliminate "already refers to" warnings

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -14,10 +14,13 @@
                      provided [[:inner 0]]
                      tabular  [[:inner 0]]}}
 
-  :dependencies [[org.clojure/clojure "1.10.3"]
-                 [org.clojure/spec.alpha "0.2.187"]
+  :dependencies [[org.clojure/clojure "1.11.0"]
+                 [org.clojure/spec.alpha "0.3.218"]
                  [org.clojure/math.combinatorics "0.1.6"]
-                 [midje "1.10.4" :exclusions [org.clojure/clojure]]]
+                 [midje "1.10.5" :exclusions [org.clojure/clojure]]
+                 ;; override midje's dependency on an old version
+                 ;; of pretty
+                 [io.aviso/pretty "1.1.1"]]
 
   :source-paths ["src/clj" "src/cljc"]
   :test-paths   ["test/clj" "test/cljc"]
@@ -28,10 +31,10 @@
                              [lein-cljsbuild "1.1.7"]
                              [lein-ancient "0.6.15"]
                              [lein-doo "0.1.11"]]
-                   :dependencies [[org.clojure/test.check "1.1.0"]
-                                  [org.clojure/clojurescript "1.10.866"]
+                   :dependencies [[org.clojure/test.check "1.1.1"]
+                                  [org.clojure/clojurescript "1.11.4"]
                                   [org.clojure/core.rrb-vector "0.1.2"]
-                                  [orchestra "2020.09.18-1"]]
+                                  [orchestra "2021.01.01-1"]]
                    :source-paths ["dev"]}
              :1.8 {:dependencies [[org.clojure/clojure "1.8.0"]]}}
 

--- a/src/cljc/matcher_combinators/utils.cljc
+++ b/src/cljc/matcher_combinators/utils.cljc
@@ -1,5 +1,6 @@
 (ns ^:no-doc matcher-combinators.utils
-  "Internal use only. Subject (and likely) to change.")
+  "Internal use only. Subject (and likely) to change."
+  (:refer-clojure :exclude [abs]))
 
 (defn- processable-number? [v]
   #?(:clj (or (decimal? v)
@@ -9,10 +10,19 @@
      :cljs (and (number? v)
                 (not (infinite? v)))))
 
-(defn- abs [n]
-  #?(:clj (if (decimal? n)
-            (.abs n)
-            (Math/abs n))
+(defn- abs
+  "Returns the abs value of n.
+
+  Note that clojure-1.11.0 adds abs to core, however consumers may or
+  may not be running with clojure 1.11.0 and we don't want to force
+  that dependency (at least not just a week after the release of
+  1.11.0)."
+  [n]
+  #?(:clj (if-let [core-abs (resolve 'clojure.core/abs)]
+            (core-abs n)
+            (if (decimal? n)
+              (.abs n)
+              (Math/abs n)))
      :cljs (js/Math.abs n)))
 
 (defn ^:no-doc within-delta?


### PR DESCRIPTION
Clojure-1.11.0 introduces some new functions to clojure.core that replace custom functions in some libraries, which produces "WARNING: xxx already refers to" warnings.

This PR eliminates those warnings by upgrading a transitive dependency that avoids it and using :refer-clojure with `:exclude` for warnings emanating from this lib.