### PR TITLE
support map-like values as actuals in embeds matcher

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@ All notable changes to this project will be documented in this file. This
 change log follows the conventions of
 [keepachangelog.com](http://keepachangelog.com/).
 
+## [3.5.0]
+- embeds matcher supports map like (associative, not sequential) actual values
+
 ## [3.4.0]
 - Eliminate "already refers to" warning on `abs` for clojure-1.11.0
 

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject nubank/matcher-combinators "3.4.0"
+(defproject nubank/matcher-combinators "3.5.0"
   :description "Library for creating matcher combinator to compare nested data structures"
   :url "https://github.com/nubank/matcher-combinators"
   :license {:name "Apache License, Version 2.0"}

--- a/src/cljc/matcher_combinators/core.cljc
+++ b/src/cljc/matcher_combinators/core.cljc
@@ -1,6 +1,6 @@
 (ns matcher-combinators.core
   (:require [clojure.math.combinatorics :as combo]
-            [clojure.pprint :as pprint]
+            [clojure.pprint]
             [clojure.spec.alpha :as s]
             [matcher-combinators.result :as result]
             [matcher-combinators.model :as model]
@@ -199,12 +199,18 @@
          ::result/value  mismatch-val
          ::result/weight weight}))))
 
+(def ^:private map-like?
+  "Returns true if v is associative, but not sequential. This lets us
+  support map-like structures like Datomic EntityMaps without trying
+  to compare maps to vectors (which are associative and sequential)."
+  (every-pred associative? (complement sequential?)))
+
 (defrecord EmbedsMap [expected]
   Matcher
   (-matcher-for [this] this)
   (-matcher-for [this _] this)
   (-match [this actual]
-    (if-let [issue (validate-input expected actual map? (-base-name this) "map")]
+    (if-let [issue (validate-input expected actual map? map-like? (-base-name this) "map")]
       issue
       (compare-maps expected actual identity true)))
   (-base-name [_] 'embeds))


### PR DESCRIPTION
# Problem

This fails

```clojure
(deftest person-test
  ,,,
  (match? {:first-name "David"} (fn-that-returns-datomic-entity-including {:first-name "David"}))
```

The reason is that the `embeds` matcher checks to see that the actual value is a `map?`, which a Datomic EntityMap is not.

# Solution

Generalize the type check for the actual value to allow for anything that is `associative?` but not `sequential?` (to avoid comparing vectors with maps).