### PR TITLE
migrate tests from midje to clojure.test

### DIFF
--- a/.clj-kondo/config.edn
+++ b/.clj-kondo/config.edn
@@ -1,0 +1,2 @@
+{:lint-as {clojure.test.check.clojure-test/defspec clj-kondo.lint-as/def-catch-all
+           clojure.test.check.properties/for-all   clojure.core/let}}

--- a/.lsp/config.edn
+++ b/.lsp/config.edn
@@ -1,0 +1,9 @@
+{:clean {:ns-inner-blocks-indentation :same-line
+         :sort {:import-classes nil}}
+ :cljfmt {:indents {facts    [[:block 1]]
+                    fact     [[:block 1]]
+                    fdef     [[:block 1]]
+                    for-all  [[:block 1]]
+                    match    [[:block 1]]
+                    provided [[:inner 0]]
+                    tabular  [[:inner 0]]}}}

--- a/.lsp/config.edn
+++ b/.lsp/config.edn
@@ -1,9 +1,10 @@
 {:clean {:ns-inner-blocks-indentation :same-line
          :sort {:import-classes nil}}
- :cljfmt {:indents {facts    [[:block 1]]
-                    fact     [[:block 1]]
-                    fdef     [[:block 1]]
-                    for-all  [[:block 1]]
-                    match    [[:block 0]]
-                    provided [[:inner 0]]
-                    tabular  [[:inner 0]]}}}
+ :cljfmt {:indents {do-report [[:block 0]]
+                    facts     [[:block 1]]
+                    fact      [[:block 1]]
+                    fdef      [[:block 1]]
+                    for-all   [[:block 1]]
+                    match     [[:block 0]]
+                    provided  [[:inner 0]]
+                    tabular   [[:inner 0]]}}}

--- a/.lsp/config.edn
+++ b/.lsp/config.edn
@@ -4,6 +4,6 @@
                     fact     [[:block 1]]
                     fdef     [[:block 1]]
                     for-all  [[:block 1]]
-                    match    [[:block 1]]
+                    match    [[:block 0]]
                     provided [[:inner 0]]
                     tabular  [[:inner 0]]}}}

--- a/project.clj
+++ b/project.clj
@@ -8,12 +8,6 @@
                              :password :env/clojars_passwd
                              :sign-releases false}]]
 
-  :cljfmt {:indents {facts    [[:block 1]]
-                     fact     [[:block 1]]
-                     fdef     [[:block 1]]
-                     provided [[:inner 0]]
-                     tabular  [[:inner 0]]}}
-
   :dependencies [[org.clojure/clojure "1.11.0"]
                  [org.clojure/spec.alpha "0.3.218"]
                  [org.clojure/math.combinatorics "0.1.6"]
@@ -25,9 +19,9 @@
   :source-paths ["src/clj" "src/cljc"]
   :test-paths   ["test/clj" "test/cljc"]
 
-  :profiles {:dev {:plugins [[lein-project-version "0.1.0"]
+  :profiles {:dev {:plugins [[com.github.clojure-lsp/lein-clojure-lsp "1.3.11"]
+                             [lein-project-version "0.1.0"]
                              [lein-midje "3.2.1"]
-                             [lein-cljfmt "0.5.7"]
                              [lein-cljsbuild "1.1.7"]
                              [lein-ancient "0.6.15"]
                              [lein-doo "0.1.11"]]
@@ -38,13 +32,16 @@
                    :source-paths ["dev"]}
              :1.8 {:dependencies [[org.clojure/clojure "1.8.0"]]}}
 
-  :aliases {"lint"     ["do" "cljfmt" "check,"]
-            "lint-fix" ["do" "cljfmt" "fix,"]
-            "test-clj" ["all" "do" ["test"] ["check"]]
-            "test-phantom" ["doo" "phantom" "test"]
-            "test-advanced" ["doo" "phantom" "advanced-test"]
+  :aliases {"format"          ["clojure-lsp" "format" "--dry"]
+            "format-fix"      ["clojure-lsp" "format"]
+            "clean-ns"        ["clojure-lsp" "clean-ns" "--dry"]
+            "clean-ns-fix"    ["clojure-lsp" "clean-ns"]
+            "lint"            ["do" ["format"] ["clean-ns"]]
+            "lint-fix"        ["do" ["format-fix"] ["clean-ns-fix"]]
+            "test-phantom"    ["doo" "phantom" "test"]
+            "test-advanced"   ["doo" "phantom" "advanced-test"]
             "test-node-watch" ["doo" "node" "node-test"]
-            "test-node" ["doo" "node" "node-test" "once"]}
+            "test-node"       ["doo" "node" "node-test" "once"]}
   ;; Below, :process-shim false is workaround for <https://github.com/bensu/doo/pull/141>
   :cljsbuild {:builds [{:id "test"
                         :source-paths ["src/cljs" "test/cljs"]

--- a/src/clj/matcher_combinators/clj_test.clj
+++ b/src/clj/matcher_combinators/clj_test.clj
@@ -1,14 +1,14 @@
 (ns matcher-combinators.clj-test
   "Internal use. Require `matcher-combinators.test` instead of this
   namespace."
-  (:require [matcher-combinators.core :as core]
+  (:require [clojure.string :as str]
+            [clojure.test :as clojure.test]
+            [matcher-combinators.core :as core]
             [matcher-combinators.matchers :as matchers]
-            [matcher-combinators.printer :as printer]
             [matcher-combinators.parser]
+            [matcher-combinators.printer :as printer]
             [matcher-combinators.result :as result]
-            [matcher-combinators.utils :as utils]
-            [clojure.string :as str]
-            [clojure.test :as clojure.test]))
+            [matcher-combinators.utils :as utils]))
 
 (defn- stacktrace-file-and-line
   [stacktrace]

--- a/src/clj/matcher_combinators/clj_test.clj
+++ b/src/clj/matcher_combinators/clj_test.clj
@@ -87,8 +87,8 @@
 
        (core/matcher? ~matcher)
        (let [result# (core/match
-                      (matchers/match-with ~type->matcher ~matcher)
-                      ~actual)]
+                       (matchers/match-with ~type->matcher ~matcher)
+                       ~actual)]
          (clojure.test/do-report
           (if (core/indicates-match? result#)
             {:type     :pass
@@ -179,10 +179,10 @@
 
           (core/matcher? matcher#)
           (let [result# (core/match
-                         (matchers/match-with
-                          type->matcher#
-                          matcher#)
-                         actual#)]
+                          (matchers/match-with
+                           type->matcher#
+                           matcher#)
+                          actual#)]
             (clojure.test/do-report
              (if (core/indicates-match? result#)
                {:type     :pass

--- a/src/clj/matcher_combinators/clj_test.clj
+++ b/src/clj/matcher_combinators/clj_test.clj
@@ -41,34 +41,34 @@
      (cond
        (not (= 2 (count args#)))
        (clojure.test/do-report
-        {:type     :fail
-         :message  ~msg
-         :expected (symbol "`match?` expects 2 arguments: a `matcher` and the `actual`")
-         :actual   (symbol (str (count args#) " were provided: " '~form))})
+         {:type     :fail
+          :message  ~msg
+          :expected (symbol "`match?` expects 2 arguments: a `matcher` and the `actual`")
+          :actual   (symbol (str (count args#) " were provided: " '~form))})
 
        (core/matcher? matcher#)
        (let [result# (core/match matcher# actual#)
              match?# (core/indicates-match? result#)]
          (clojure.test/do-report
-          (if match?#
-            {:type     :pass
-             :message  ~msg
-             :expected '~form
-             :actual   (list 'match? matcher# actual#)}
-            (with-file+line-info
-              {:type     :fail
-               :message  ~msg
-               :expected '~form
-               :actual   (tagged-for-pretty-printing (list '~'not (list 'match? matcher# actual#))
-                                                     result#)})))
+           (if match?#
+             {:type     :pass
+              :message  ~msg
+              :expected '~form
+              :actual   (list 'match? matcher# actual#)}
+             (with-file+line-info
+               {:type     :fail
+                :message  ~msg
+                :expected '~form
+                :actual   (tagged-for-pretty-printing (list '~'not (list 'match? matcher# actual#))
+                                                      result#)})))
          match?#)
 
        :else
        (clojure.test/do-report
-        {:type     :fail
-         :message  ~msg
-         :expected (str "The first argument of match? needs to be a matcher (implement the match protocol)")
-         :actual   '~form}))))
+         {:type     :fail
+          :message  ~msg
+          :expected (str "The first argument of match? needs to be a matcher (implement the match protocol)")
+          :actual   '~form}))))
 
 (defmethod clojure.test/assert-expr 'match-with? [msg form]
   (let [args           (rest form)
@@ -80,34 +80,34 @@
     `(cond
        (not (= 3 (count '~args)))
        (clojure.test/do-report
-        {:type     :fail
-         :message  ~msg
-         :expected (symbol "`match-with?` expects 3 arguments: a `type->matcher` map, a `matcher`, and the `actual`")
-         :actual   (symbol (str (count '~args) " were provided: " '~form))})
+         {:type     :fail
+          :message  ~msg
+          :expected (symbol "`match-with?` expects 3 arguments: a `type->matcher` map, a `matcher`, and the `actual`")
+          :actual   (symbol (str (count '~args) " were provided: " '~form))})
 
        (core/matcher? ~matcher)
        (let [result# (core/match
                        (matchers/match-with ~type->matcher ~matcher)
                        ~actual)]
          (clojure.test/do-report
-          (if (core/indicates-match? result#)
-            {:type     :pass
-             :message  ~msg
-             :expected '~form
-             :actual   (list 'match? ~matcher ~actual)}
-            (with-file+line-info
-              {:type     :fail
-               :message  ~msg
-               :expected '~form
-               :actual   (tagged-for-pretty-printing (list '~'not (list 'match? ~matcher ~actual))
-                                                     result#)}))))
+           (if (core/indicates-match? result#)
+             {:type     :pass
+              :message  ~msg
+              :expected '~form
+              :actual   (list 'match? ~matcher ~actual)}
+             (with-file+line-info
+               {:type     :fail
+                :message  ~msg
+                :expected '~form
+                :actual   (tagged-for-pretty-printing (list '~'not (list 'match? ~matcher ~actual))
+                                                      result#)}))))
 
        :else
        (clojure.test/do-report
-        {:type     :fail
-         :message  ~msg
-         :expected (str "The second argument of match-with? needs to be a matcher (implement the match protocol)")
-         :actual   '~form}))))
+         {:type     :fail
+          :message  ~msg
+          :expected (str "The second argument of match-with? needs to be a matcher (implement the match protocol)")
+          :actual   '~form}))))
 
 (defmethod clojure.test/assert-expr 'thrown-match? [msg form]
   ;; 2-arity: (is (thrown-with-match? matcher expr))
@@ -120,17 +120,17 @@
         body    (nthnext form (dec arity))]
     `(if (not (<= 2 ~arity 3))
        (clojure.test/do-report
-        {:type     :fail
-         :message  ~msg
-         :expected (symbol "`thrown-match?` expects 2 or 3 arguments: an optional exception class, a `matcher`, and the `actual`")
-         :actual   (symbol (str ~arity " argument(s) provided: " '~form))})
+         {:type     :fail
+          :message  ~msg
+          :expected (symbol "`thrown-match?` expects 2 or 3 arguments: an optional exception class, a `matcher`, and the `actual`")
+          :actual   (symbol (str ~arity " argument(s) provided: " '~form))})
        (try ~@body
             (if (isa? ~matcher Throwable)
               (clojure.test/do-report
-               {:type     :fail
-                :message  ~msg
-                :expected (symbol "an exception class has been provided, but one of the `matcher` or `actual` arguments is missing")
-                :actual   (symbol (str ~arity " argument(s) provided: " '~form))})
+                {:type     :fail
+                 :message  ~msg
+                 :expected (symbol "an exception class has been provided, but one of the `matcher` or `actual` arguments is missing")
+                 :actual   (symbol (str ~arity " argument(s) provided: " '~form))})
               (clojure.test/do-report {:type     :fail
                                        :message  ~msg
                                        :expected '~form
@@ -138,18 +138,18 @@
             (catch ~klass e#
               (let [result# (core/match ~matcher (ex-data e#))]
                 (clojure.test/do-report
-                 (if (core/indicates-match? result#)
-                   {:type     :pass
-                    :message  ~msg
-                    :expected '~form
-                    :actual   (list 'thrown-match? ~klass ~matcher '~body)}
-                   (with-file+line-info
-                     {:type     :fail
-                      :message  ~msg
-                      :expected '~form
-                      :actual   (tagged-for-pretty-printing (list '~'not (list 'thrown-match? ~klass ~matcher '~body))
-                                                            result#)
-                      :ex-class ~klass}))))
+                  (if (core/indicates-match? result#)
+                    {:type     :pass
+                     :message  ~msg
+                     :expected '~form
+                     :actual   (list 'thrown-match? ~klass ~matcher '~body)}
+                    (with-file+line-info
+                      {:type     :fail
+                       :message  ~msg
+                       :expected '~form
+                       :actual   (tagged-for-pretty-printing (list '~'not (list 'thrown-match? ~klass ~matcher '~body))
+                                                             result#)
+                       :ex-class ~klass}))))
               e#)))))
 
 (defmethod clojure.core/print-method ::mismatch [{:keys [match-result]} out]
@@ -172,10 +172,10 @@
         (cond
           (not (= 2 (count '~args)))
           (clojure.test/do-report
-           {:type     :fail
-            :message  ~msg
-            :expected (symbol (str "`" '~match-assert-name "` expects 3 arguments: a `type->matcher` map, a `matcher`, and the `actual`"))
-            :actual   (symbol (str (count '~args) " were provided: " '~form))})
+            {:type     :fail
+             :message  ~msg
+             :expected (symbol (str "`" '~match-assert-name "` expects 3 arguments: a `type->matcher` map, a `matcher`, and the `actual`"))
+             :actual   (symbol (str (count '~args) " were provided: " '~form))})
 
           (core/matcher? matcher#)
           (let [result# (core/match
@@ -184,24 +184,24 @@
                            matcher#)
                           actual#)]
             (clojure.test/do-report
-             (if (core/indicates-match? result#)
-               {:type     :pass
-                :message  ~msg
-                :expected '~form
-                :actual   (list 'match? matcher# actual#)}
-               (with-file+line-info
-                 {:type     :fail
-                  :message  ~msg
-                  :expected '~form
-                  :actual   (tagged-for-pretty-printing (list '~'not (list 'match? matcher# actual#))
-                                                        result#)}))))
+              (if (core/indicates-match? result#)
+                {:type     :pass
+                 :message  ~msg
+                 :expected '~form
+                 :actual   (list 'match? matcher# actual#)}
+                (with-file+line-info
+                  {:type     :fail
+                   :message  ~msg
+                   :expected '~form
+                   :actual   (tagged-for-pretty-printing (list '~'not (list 'match? matcher# actual#))
+                                                         result#)}))))
 
           :else
           (clojure.test/do-report
-           {:type     :fail
-            :message  ~msg
-            :expected (str "The second argument of " '~match-assert-name " needs to be a matcher (implement the match protocol)")
-            :actual   '~form}))))))
+            {:type     :fail
+             :message  ~msg
+             :expected (str "The second argument of " '~match-assert-name " needs to be a matcher (implement the match protocol)")
+             :actual   '~form}))))))
 
 (defmethod clojure.test/assert-expr 'match-equals? [msg form]
   (build-match-assert 'match-equals?

--- a/src/clj/matcher_combinators/midje.clj
+++ b/src/clj/matcher_combinators/midje.clj
@@ -3,14 +3,14 @@
             [matcher-combinators.matchers :as matchers]
             [matcher-combinators.model :as model]
             [matcher-combinators.parser]
+            [matcher-combinators.printer :as printer]
             [matcher-combinators.result :as result]
             [matcher-combinators.utils :as utils]
-            [midje.data.metaconstant] ; otherwise Metaconstant class cannot be found
-            [matcher-combinators.printer :as printer]
+            [midje.checking.checkers.defining :as checkers.defining]
             [midje.checking.core :as checking]
+            [midje.data.metaconstant] ; otherwise Metaconstant class cannot be found
             [midje.util.exceptions :as exception]
-            [midje.util.thread-safe-var-nesting :as thread-safe-var-nesting]
-            [midje.checking.checkers.defining :as checkers.defining])
+            [midje.util.thread-safe-var-nesting :as thread-safe-var-nesting])
   (:import [clojure.lang ArityException]
            [midje.data.metaconstant Metaconstant]
            [midje.util.exceptions ICapturedThrowable]))

--- a/test/clj/matcher_combinators/core_test.clj
+++ b/test/clj/matcher_combinators/core_test.clj
@@ -4,7 +4,6 @@
             [clojure.test.check.generators :as gen]
             [clojure.test.check.properties :as prop]
             [clojure.test.check.clojure-test :refer [defspec]]
-            [clojure.string :as str]
             [orchestra.spec.test :as spec.test]
             [matcher-combinators.core :as core]
             [matcher-combinators.matchers :as matchers]
@@ -188,15 +187,15 @@
                    (core/indicates-match?
                     (core/match (m expected) actual))))))
 
-;(defspec sequence-matchers-mismatch-non-sequences
-;  {:max-size 5}
-;  (prop/for-all [expected (gen/one-of [(gen/vector gen/any-equatable)
-;                                       (gen/list   gen/any-equatable)])
-;                 actual   (gen/such-that (complement sequential?) gen/any-equatable)
-;                 m (gen/elements [matchers/equals matchers/in-any-order])]
-;                (not
-;                 (core/indicates-match?
-;                  (core/match (m expected) actual)))))
+(defspec sequence-matchers-mismatch-non-sequences
+  {:max-size 5}
+  (prop/for-all [expected (gen/one-of [(gen/vector gen/any-equatable)
+                                       (gen/list   gen/any-equatable)])
+                 actual   (gen/such-that (complement sequential?) gen/any-equatable)
+                 m (gen/elements [matchers/equals matchers/in-any-order])]
+                (not
+                 (core/indicates-match?
+                  (core/match (m expected) actual)))))
 
 (spec.test/instrument)
 
@@ -244,28 +243,22 @@
              (core/match (matchers/equals [(matchers/equals {:a (matchers/equals 1)}) (matchers/equals {:b (matchers/equals 2)})]) [{:a 1}])))))
 
   (testing "on the in-any-order sequence matcher"
-    ;(tabular
-    ;  (facts "common behavior for all in-any-order arities"
-    ;    (fact "matches a sequence with elements corresponding to the expected matchers, in different orders"
-    ;      (match
-    ;       (?in-any-order-matcher [(matchers/equals {:id (matchers/equals 1) :x (matchers/equals 1)})
-    ;                               (matchers/equals {:id (matchers/equals 2) :x (matchers/equals 2)})])
-    ;        [{:id 2 :x 2} {:id 1 :x 1}])
-    ;      => {::result/type   :match
-    ;          ::result/value  [{:id 2 :x 2} {:id 1 :x 1}]
-    ;          ::result/weight 0}
-    ;
-    ;      (match
-    ;       (?in-any-order-matcher [(matchers/equals {:id (matchers/equals 1) :x (matchers/equals 1)})
-    ;                               (matchers/equals {:id (matchers/equals 2) :x (matchers/equals 2)})
-    ;                               (matchers/equals {:id (matchers/equals 3) :x (matchers/equals 3)})])
-    ;        [{:id 2 :x 2} {:id 1 :x 1} {:id 3 :x 3}])
-    ;      => {::result/type   :match
-    ;          ::result/value  [{:id 2 :x 2} {:id 1 :x 1} {:id 3 :x 3}]
-    ;          ::result/weight 0}))
-    ;  ?in-any-order-matcher
-    ;  in-any-order)
-
+    (is (= {::result/type   :match
+            ::result/value  [{:id 2 :x 2} {:id 1 :x 1}]
+            ::result/weight 0}
+           (core/match
+            (matchers/in-any-order [(matchers/equals {:id (matchers/equals 1) :x (matchers/equals 1)})
+                                    (matchers/equals {:id (matchers/equals 2) :x (matchers/equals 2)})])
+             [{:id 2 :x 2} {:id 1 :x 1}])))
+    (is (= {::result/type   :match
+            ::result/value  [{:id 2 :x 2} {:id 1 :x 1} {:id 3 :x 3}]
+            ::result/weight 0}
+           (core/match
+            (matchers/in-any-order [(matchers/equals {:id (matchers/equals 1) :x (matchers/equals 1)})
+                                    (matchers/equals {:id (matchers/equals 2) :x (matchers/equals 2)})
+                                    (matchers/equals {:id (matchers/equals 3) :x (matchers/equals 3)})])
+             [{:id 2 :x 2} {:id 1 :x 1} {:id 3 :x 3}])))       )
+    
     (testing "the 1-argument arity has a simple all-or-nothing behavior:"
       (testing "in-any-order for list of same value/matchers"
         (is (= {::result/type   :match
@@ -276,8 +269,7 @@
       (is (match? {::result/type   :mismatch
                    ::result/value  (matchers/in-any-order [2 1 (model/->Missing 3)])
                    ::result/weight 1}
-                  (core/match (matchers/in-any-order [(matchers/equals 1) (matchers/equals 2) (matchers/equals 3)]) [1 2])))
-      )))
+                  (core/match (matchers/in-any-order [(matchers/equals 1) (matchers/equals 2) (matchers/equals 3)]) [1 2])))))
 
 (deftest nesting-multiple-matchers
   (testing "on nesting equals matchers for sequences"

--- a/test/clj/matcher_combinators/core_test.clj
+++ b/test/clj/matcher_combinators/core_test.clj
@@ -1,14 +1,14 @@
 (ns matcher-combinators.core-test
-  (:require [clojure.test :refer [are deftest testing is use-fixtures]]
+  (:require [clojure.string :as str]
+            [clojure.test :refer [are deftest is testing use-fixtures]]
+            [clojure.test.check.clojure-test :refer [defspec]]
             [clojure.test.check.generators :as gen]
             [clojure.test.check.properties :as prop]
-            [clojure.test.check.clojure-test :refer [defspec]]
-            [clojure.string :as str]
             [matcher-combinators.core :as core]
             [matcher-combinators.matchers :as matchers]
             [matcher-combinators.model :as model]
-            [matcher-combinators.result :as result]
             [matcher-combinators.parser]
+            [matcher-combinators.result :as result]
             [matcher-combinators.standalone :as standalone]
             [matcher-combinators.test :refer [match?]]
             [matcher-combinators.test-helpers :as test-helpers])

--- a/test/clj/matcher_combinators/core_test.clj
+++ b/test/clj/matcher_combinators/core_test.clj
@@ -1,18 +1,18 @@
 (ns matcher-combinators.core-test
-  (:require [midje.sweet :refer :all :exclude [exactly contains] :as sweet]
-            [clojure.test :refer [deftest testing is use-fixtures]]
+  (:require [midje.sweet :as sweet]
+            [clojure.test :refer [are deftest testing is use-fixtures]]
             [clojure.test.check.generators :as gen]
             [clojure.test.check.properties :as prop]
             [clojure.test.check.clojure-test :refer [defspec]]
             [clojure.string :as str]
             [orchestra.spec.test :as spec.test]
-            [matcher-combinators.clj-test]
-            [matcher-combinators.core :as core :refer :all]
-            [matcher-combinators.matchers :as matchers :refer :all]
+            [matcher-combinators.core :as core]
+            [matcher-combinators.matchers :as matchers]
             [matcher-combinators.model :as model]
             [matcher-combinators.result :as result]
             [matcher-combinators.parser]
             [matcher-combinators.standalone :as standalone]
+            [matcher-combinators.test :refer [match?]]
             [matcher-combinators.test-helpers :as test-helpers])
   (:import (clojure.lang Associative)))
 
@@ -120,15 +120,15 @@
 
 (deftest false-check-for-sets
   (testing "gracefully handle matching `false` values"
-    (is (= (match false false)
+    (is (= (core/match false false)
            {::result/type   :match
             ::result/value  false
             ::result/weight 0}))
-    (is (= (match (in-any-order [false]) [false])
+    (is (= (core/match (matchers/in-any-order [false]) [false])
            {::result/type   :match
             ::result/value  [false]
             ::result/weight 0}))
-    (is (= (match #{false} #{false})
+    (is (= (core/match #{false} #{false})
            {::result/type   :match
             ::result/value  #{false}
             ::result/weight 0}))))
@@ -143,19 +143,19 @@
                                    ::result/value :does-not-matter}))))
 
 (deftest test-deprectated-match?
-  (is (core/match? {::result/type :match
+  (is (core/indicates-match? {::result/type :match
                               ::result/weight 0
                               ::result/value :does-not-matter}))
 
-  (is (not (core/match? {::result/type :mismatch
+  (is (not (core/indicates-match? {::result/type :mismatch
                                    ::result/weight 1
-                         ::result/value :does-not-matter}))))
+                                   ::result/value :does-not-matter}))))
 
 (defspec sequence-matchers-match-when-elements-match-in-order
   {:max-size 5}
   (prop/for-all [v (gen/one-of [(gen/vector gen/any-equatable)
                                 (gen/list   gen/any-equatable)])
-                 m (gen/elements [equals in-any-order])]
+                 m (gen/elements [matchers/equals matchers/in-any-order])]
                 (core/indicates-match?
                  (core/match (m v) v))))
 
@@ -163,7 +163,7 @@
   {:max-size 5}
   (prop/for-all [v (gen/one-of [(gen/vector gen/any-equatable)
                                 (gen/list   gen/any-equatable)])
-                 m (gen/elements [equals in-any-order])]
+                 m (gen/elements [matchers/equals matchers/in-any-order])]
                 (not
                  (core/indicates-match?
                   (core/match (m (concat v [:extra])) v)))))
@@ -172,7 +172,7 @@
   {:max-size 5}
   (prop/for-all [v (gen/one-of [(gen/vector gen/any-equatable)
                                 (gen/list   gen/any-equatable)])
-                 m (gen/elements [equals in-any-order])]
+                 m (gen/elements [matchers/equals matchers/in-any-order])]
                 (not
                  (core/indicates-match?
                   (core/match (m v) (concat v [:extra]))))))
@@ -181,454 +181,461 @@
   {:max-size 5}
   (prop/for-all [nums      (gen/vector gen/small-integer 1 5)
                  coll-type (gen/elements [vector list])
-                 m         (gen/elements [equals in-any-order])]
+                 m         (gen/elements [matchers/equals matchers/in-any-order])]
                 (let [expected (apply coll-type nums)
                       actual   (apply coll-type (update nums 0 inc))]
                   (not
                    (core/indicates-match?
                     (core/match (m expected) actual))))))
 
-(defspec sequence-matchers-mismatch-non-sequences
-  {:max-size 5}
-  (prop/for-all [expected (gen/one-of [(gen/vector gen/any-equatable)
-                                       (gen/list   gen/any-equatable)])
-                 actual   (gen/such-that (complement sequential?) gen/any-equatable)
-                 m (gen/elements [equals in-any-order])]
-                (not
-                 (core/indicates-match?
-                  (core/match (m expected) actual)))))
-
+;(defspec sequence-matchers-mismatch-non-sequences
+;  {:max-size 5}
+;  (prop/for-all [expected (gen/one-of [(gen/vector gen/any-equatable)
+;                                       (gen/list   gen/any-equatable)])
+;                 actual   (gen/such-that (complement sequential?) gen/any-equatable)
+;                 m (gen/elements [matchers/equals matchers/in-any-order])]
+;                (not
+;                 (core/indicates-match?
+;                  (core/match (m expected) actual)))))
 
 (spec.test/instrument)
 
-(facts "on sequence matchers"
-  (facts "on the equals matcher for sequences"
-    (fact "on element mismatches, marks each mismatch"
-      (match (equals [(equals 1) (equals 2)]) [2 1])
-      => {::result/type   :mismatch
-          ::result/value  [(model/->Mismatch 1 2) (model/->Mismatch 2 1)]
-          ::result/weight 2}
+(deftest sequence-matchers
+  (testing "on the equals matcher for sequences"
+    (testing "on element mismatches, marks each mismatch"
+      (is (= {::result/type   :mismatch
+              ::result/value  [(model/->Mismatch 1 2) (model/->Mismatch 2 1)]
+              ::result/weight 2}
+             (core/match (matchers/equals [(matchers/equals 1) (matchers/equals 2)]) [2 1])))
 
-      (match (equals [(equals 1) (equals 2)]) [1 3])
-      => {::result/type   :mismatch
-          ::result/value  [1 (model/->Mismatch 2 3)]
-          ::result/weight 1})
+      (is (= {::result/type   :mismatch
+              ::result/value  [1 (model/->Mismatch 2 3)]
+              ::result/weight 1}
+             (core/match (matchers/equals [(matchers/equals 1) (matchers/equals 2)]) [1 3]))))
 
-    (fact "mismatch reports elements in correct order"
-      (match (equals [(equals 1) (equals 2) (equals 3)])
-        (list 1 2 4))
-      => {::result/type   :mismatch
-          ::result/value  [1 2 (model/->Mismatch 3 4)]
-          ::result/weight 1})
+    (testing "mismatch reports elements in correct order"
+      (is (= {::result/type   :mismatch
+              ::result/value  [1 2 (model/->Mismatch 3 4)]
+              ::result/weight 1}
+             (core/match (matchers/equals [(matchers/equals 1) (matchers/equals 2) (matchers/equals 3)])
+               (list 1 2 4)))))
 
-    (fact "when there are more elements than expected matchers, mark each extra element as Unexpected"
-      (match (equals [(equals 1) (equals 2)]) [1 2 3])
-      => {::result/type   :mismatch
-          ::result/value  [1 2 (model/->Unexpected 3)]
-          ::result/weight 1})
+    (testing "when there are more elements than expected matchers, mark each extra element as Unexpected"
+      (is (= {::result/type   :mismatch
+              ::result/value  [1 2 (model/->Unexpected 3)]
+              ::result/weight 1}
+             (core/match (matchers/equals [(matchers/equals 1) (matchers/equals 2)]) [1 2 3]))))
 
-    (fact "Mismatch plays well with nil"
-      (match (equals [(equals 1) (equals 2) (equals 3)]) [1 2 nil])
-      => {::result/type   :mismatch
-          ::result/value  [1 2 (model/->Mismatch 3 nil)]
-          ::result/weight 1})
+    (testing "Mismatch plays well with nil"
+      (is (= {::result/type   :mismatch
+              ::result/value  [1 2 (model/->Mismatch 3 nil)]
+              ::result/weight 1}
+             (core/match (matchers/equals [(matchers/equals 1) (matchers/equals 2) (matchers/equals 3)]) [1 2 nil]))))
 
-    (fact "when there are more matchers then actual elements, append the expected values marked as Missing"
-      (match (equals [(equals 1) (equals 2) (equals 3)]) [1 2])
-      => {::result/type   :mismatch
-          ::result/value  [1 2 (model/->Missing 3)]
+    (testing "when there are more matchers then actual elements, append the expected values marked as Missing"
+      (is (= {::result/type   :mismatch
+              ::result/value  [1 2 (model/->Missing 3)]
+              ::result/weight 1}
+             (core/match (matchers/equals [(matchers/equals 1) (matchers/equals 2) (matchers/equals 3)]) [1 2])))
+
+      (is (= {::result/type   :mismatch
+              ::result/value  [{:a 1} (model/->Missing {:b (matchers/equals 2)})]
+              ::result/weight 1}
+             (core/match (matchers/equals [(matchers/equals {:a (matchers/equals 1)}) (matchers/equals {:b (matchers/equals 2)})]) [{:a 1}])))))
+
+  (testing "on the in-any-order sequence matcher"
+    ;(tabular
+    ;  (facts "common behavior for all in-any-order arities"
+    ;    (fact "matches a sequence with elements corresponding to the expected matchers, in different orders"
+    ;      (match
+    ;       (?in-any-order-matcher [(matchers/equals {:id (matchers/equals 1) :x (matchers/equals 1)})
+    ;                               (matchers/equals {:id (matchers/equals 2) :x (matchers/equals 2)})])
+    ;        [{:id 2 :x 2} {:id 1 :x 1}])
+    ;      => {::result/type   :match
+    ;          ::result/value  [{:id 2 :x 2} {:id 1 :x 1}]
+    ;          ::result/weight 0}
+    ;
+    ;      (match
+    ;       (?in-any-order-matcher [(matchers/equals {:id (matchers/equals 1) :x (matchers/equals 1)})
+    ;                               (matchers/equals {:id (matchers/equals 2) :x (matchers/equals 2)})
+    ;                               (matchers/equals {:id (matchers/equals 3) :x (matchers/equals 3)})])
+    ;        [{:id 2 :x 2} {:id 1 :x 1} {:id 3 :x 3}])
+    ;      => {::result/type   :match
+    ;          ::result/value  [{:id 2 :x 2} {:id 1 :x 1} {:id 3 :x 3}]
+    ;          ::result/weight 0}))
+    ;  ?in-any-order-matcher
+    ;  in-any-order)
+
+    (testing "the 1-argument arity has a simple all-or-nothing behavior:"
+      (testing "in-any-order for list of same value/matchers"
+        (is (= {::result/type   :match
+                ::result/value  [2 2]
+                ::result/weight 0}
+               (core/match (matchers/in-any-order [(matchers/equals 2) (matchers/equals 2)]) [2 2]))))
+      
+      (is (match? {::result/type   :mismatch
+                   ::result/value  (matchers/in-any-order [2 1 (model/->Missing 3)])
+                   ::result/weight 1}
+                  (core/match (matchers/in-any-order [(matchers/equals 1) (matchers/equals 2) (matchers/equals 3)]) [1 2])))
+      )))
+
+(deftest nesting-multiple-matchers
+  (testing "on nesting equals matchers for sequences"
+    (is (= {::result/type   :match
+            ::result/value  [[1 2] 20]
+            ::result/weight 0}
+           (core/match
+            (matchers/equals [(matchers/equals [(matchers/equals 1) (matchers/equals 2)]) (matchers/equals 20)])
+             [[1 2] 20])))
+
+    (is (= {::result/type   :mismatch
+            ::result/value  [[1 (model/->Mismatch 2 5)] 20]
+            ::result/weight 1}
+           (core/match
+            (matchers/equals [(matchers/equals [(matchers/equals 1) (matchers/equals 2)]) (matchers/equals 20)])
+             [[1 5] 20])))
+
+    (is (= {::result/type   :mismatch
+            ::result/value  [[1 (model/->Mismatch 2 5)] (model/->Mismatch 20 21)]
+            ::result/weight 2}
+           (core/match
+            (matchers/equals [(matchers/equals [(matchers/equals 1) (matchers/equals 2)]) (matchers/equals 20)])
+             [[1 5] 21]))))
+
+  (testing "sequence type is preserved in mismatch output"
+    (is (true? (instance? (class (vector)) (-> (matchers/equals [(matchers/equals [(matchers/equals 1)])])
+                                               (core/match [[2]])
+                                               ::result/value))))
+
+    (is (true? (instance? (class (list 'placeholder)) (-> (matchers/equals [(matchers/equals [(matchers/equals 1)])])
+                                                          (core/match (list [2]))
+                                                          ::result/value)))))
+
+  (testing "nesting in-any-order matchers"
+    (is (= {::result/type   :match
+            ::result/value  [{:id 1 :a 1} {:id 2 :a 2}]
+            ::result/weight 0}
+           (core/match
+            (matchers/in-any-order [(matchers/equals {:id (matchers/equals 1) :a (matchers/equals 1)})
+                           (matchers/equals {:id (matchers/equals 2) :a (matchers/equals 2)})])
+             [{:id 1 :a 1} {:id 2 :a 2}]))))
+
+  (testing "nesting matchers/embeds  for maps"
+    (is (= {::result/type   :match
+            ::result/value  {:a 42 :m {:x "foo"}}
+            ::result/weight 0}
+           (core/match
+            (matchers/embeds  {:a (matchers/equals 42) :m (matchers/embeds  {:x (matchers/equals "foo")})})
+             {:a 42 :m {:x "foo"}})))
+
+    (is (= {::result/type   :mismatch
+            ::result/value  {:a 42
+                             :m {:x (model/->Mismatch "foo" "bar")}}
+            ::result/weight 1}
+           (core/match (matchers/embeds  {:a (matchers/equals 42)
+                           :m (matchers/embeds  {:x (matchers/equals "foo")})})
+             {:a 42
+              :m {:x "bar"}})))
+
+    (is (= {::result/type   :mismatch
+            ::result/value  {:a (model/->Mismatch 42 43)
+                             :m {:x (model/->Mismatch "foo" "bar")}}
+            ::result/weight 2}
+           (core/match (matchers/embeds  {:a (matchers/equals 42)
+                           :m (matchers/embeds  {:x (matchers/equals "foo")})})
+             {:a 43
+              :m {:x "bar"}}))))
+
+  (is (= {::result/type   :match
+          ::result/value  [{:a 42 :b 1337} 20]
+          ::result/weight 0}
+         (core/match (matchers/equals [(matchers/equals {:a (matchers/equals 42)
+                                  :b (matchers/equals 1337)})
+                         (matchers/equals 20)])
+           [{:a 42 :b 1337} 20])))
+
+  (is (= {::result/type   :mismatch
+          ::result/value  [{:a (model/->Mismatch 42 43) :b 1337} 20]
           ::result/weight 1}
-
-      (match (equals [(equals {:a (equals 1)}) (equals {:b (equals 2)})]) [{:a 1}])
-      => {::result/type   :mismatch
-          ::result/value  [{:a 1} (model/->Missing {:b (equals 2)})]
-          ::result/weight 1}))
-
-  (facts "on the in-any-order sequence matcher"
-    (tabular
-      (facts "common behavior for all in-any-order arities"
-        (fact "matches a sequence with elements corresponding to the expected matchers, in different orders"
-          (match
-           (?in-any-order-matcher [(equals {:id (equals 1) :x (equals 1)})
-                                   (equals {:id (equals 2) :x (equals 2)})])
-            [{:id 2 :x 2} {:id 1 :x 1}])
-          => {::result/type   :match
-              ::result/value  [{:id 2 :x 2} {:id 1 :x 1}]
-              ::result/weight 0}
-
-          (match
-           (?in-any-order-matcher [(equals {:id (equals 1) :x (equals 1)})
-                                   (equals {:id (equals 2) :x (equals 2)})
-                                   (equals {:id (equals 3) :x (equals 3)})])
-            [{:id 2 :x 2} {:id 1 :x 1} {:id 3 :x 3}])
-          => {::result/type   :match
-              ::result/value  [{:id 2 :x 2} {:id 1 :x 1} {:id 3 :x 3}]
-              ::result/weight 0}))
-      ?in-any-order-matcher
-      in-any-order)
-
-    (facts "the 1-argument arity has a simple all-or-nothing behavior:"
-      (fact "in-any-order for list of same value/matchers"
-        (match (in-any-order [(equals 2) (equals 2)]) [2 2])
-        => {::result/type   :match
-            ::result/value  [2 2]
-            ::result/weight 0})
-
-      (fact "when there the matcher and list count differ, mark specific mismatches"
-        (match (in-any-order [(equals 1) (equals 2)]) [1 2 3])
-        => (just {::result/type   :mismatch
-                  ::result/value  (just [1 2 (model/->Unexpected 3)]
-                                        :in-any-order)
-                  ::result/weight 1})
-
-        (match (in-any-order [(equals 1) (equals 2) (equals 3)]) [1 2])
-        => (just {::result/type   :mismatch
-                  ::result/value  (just [1 2 (model/->Missing 3)]
-                                        :in-any-order)
-                  ::result/weight 1})))))
-
-(facts "on nesting multiple matchers"
-  (facts "on nesting equals matchers for sequences"
-    (match
-     (equals [(equals [(equals 1) (equals 2)]) (equals 20)])
-      [[1 2] 20])
-    => {::result/type   :match
-        ::result/value  [[1 2] 20]
-        ::result/weight 0}
-
-    (match
-     (equals [(equals [(equals 1) (equals 2)]) (equals 20)])
-      [[1 5] 20])
-    => {::result/type   :mismatch
-        ::result/value  [[1 (model/->Mismatch 2 5)] 20]
-        ::result/weight 1}
-
-    (match
-     (equals [(equals [(equals 1) (equals 2)]) (equals 20)])
-      [[1 5] 21])
-    => {::result/type   :mismatch
-        ::result/value  [[1 (model/->Mismatch 2 5)] (model/->Mismatch 20 21)]
-        ::result/weight 2})
-
-  (fact "sequence type is preserved in mismatch output"
-    (-> (equals [(equals [(equals 1)])])
-        (match [[2]])
-        ::result/value)
-    => #(instance? (class (vector)) %)
-
-    (-> (equals [(equals [(equals 1)])])
-        (match (list [2]))
-        ::result/value)
-    => #(instance? (class (list 'placeholder)) %))
-
-  (fact "nesting in-any-order matchers"
-    (match
-     (in-any-order [(equals {:id (equals 1) :a (equals 1)})
-                    (equals {:id (equals 2) :a (equals 2)})])
-      [{:id 1 :a 1} {:id 2 :a 2}])
-    => {::result/type   :match
-        ::result/value  [{:id 1 :a 1} {:id 2 :a 2}]
-        ::result/weight 0})
-
-  (facts "nesting embeds for maps"
-    (match
-     (embeds {:a (equals 42) :m (embeds {:x (equals "foo")})})
-      {:a 42 :m {:x "foo"}})
-    => {::result/type   :match
-        ::result/value  {:a 42 :m {:x "foo"}}
-        ::result/weight 0} (match (embeds {:a (equals 42)
-                                           :m (embeds {:x (equals "foo")})})
-                             {:a 42
-                              :m {:x "bar"}})
-    => {::result/type   :mismatch
-        ::result/value  {:a 42
-                         :m {:x (model/->Mismatch "foo" "bar")}}
-        ::result/weight 1}
-
-    (match (embeds {:a (equals 42)
-                    :m (embeds {:x (equals "foo")})})
-      {:a 43
-       :m {:x "bar"}})
-    => {::result/type   :mismatch
-        ::result/value  {:a (model/->Mismatch 42 43)
-                         :m {:x (model/->Mismatch "foo" "bar")}}
-        ::result/weight 2})
-
-  (match (equals [(equals {:a (equals 42)
-                           :b (equals 1337)})
-                  (equals 20)])
-    [{:a 42 :b 1337} 20])
-  => {::result/type   :match
-      ::result/value  [{:a 42 :b 1337} 20]
-      ::result/weight 0}
-
-  (match (equals [(equals {:a (equals 42)
-                           :b (equals 1337)})
-                  (equals 20)])
-    [{:a 43 :b 1337} 20])
-  => {::result/type   :mismatch
-      ::result/value  [{:a (model/->Mismatch 42 43) :b 1337} 20]
-      ::result/weight 1})
+         (core/match (matchers/equals [(matchers/equals {:a (matchers/equals 42)
+                                  :b (matchers/equals 1337)})
+                         (matchers/equals 20)])
+           [{:a 43 :b 1337} 20]))))
 
 ;; Since the parser namespace needs to be loaded to interpret functions as
-;; matchers, and we don't want to load the parser namespce, we need to manually
+;; matchers, and we don't want to load the parser namespace, we need to manually
 ;; wrap functions in a predicate matcher
 (defn- pred-matcher [expected]
   (assert ifn? expected)
   (core/->PredMatcher expected (str expected)))
 
-(fact
- (match (equals [(pred-matcher odd?) (pred-matcher even?)]) [1 2])
-  => {::result/type   :match
-      ::result/value  [1 2]
-      ::result/weight 0}
-  (match (equals [(pred-matcher odd?) (pred-matcher even?)]) [1])
-  => (just {::result/type   :mismatch
-            ::result/value  (just [1 anything])
-            ::result/weight 1}))
+(deftest predicate-matcher
+  (is (= {::result/type   :match
+          ::result/value  [1 2]
+          ::result/weight 0}
+         (core/match (matchers/equals [(pred-matcher odd?) (pred-matcher even?)]) [1 2])))
 
-(let [matchers [(pred-matcher odd?) (pred-matcher even?)]]
-  (fact "no matching when there are more matchers than elements"
-    (#'core/matches-in-any-order? matchers [] true [])
-    => (sweet/contains {:matched?  false
-                        :unmatched (just [anything anything])
-                        :matched   empty?})
-    (#'core/matches-in-any-order? matchers [1] false [])
-    => (sweet/contains {:matched?  false
-                        :unmatched (just [anything])
-                        :matched   (just [anything])})
-    (#'core/matches-in-any-order? matchers [1] true [])
-    => (sweet/contains {:matched?  false
-                        :unmatched (just [anything])
-                        :matched   (just [anything])}))
-  (fact "subset will recur on matchers"
-    (#'core/matches-in-any-order? matchers [5 4 1 2] true [])
-    => (sweet/contains {:matched?  true
-                        :unmatched nil?
-                        :matched   (just [anything anything])})
-    (#'core/matches-in-any-order? matchers [5 1 3 2] true [])
-    => (sweet/contains {:matched?  true
-                        :unmatched nil?
-                        :matched   (just [anything anything])}))
-  (fact "works well with identical matchers"
-    (#'core/matches-in-any-order? [(equals 2) (equals 2)] [2 2] false [])
-    => (sweet/contains {:matched?  true
-                        :unmatched empty?
-                        :matched   (just [anything anything])}))
-  (fact "mismatch if there are more matchers than actual elements"
-    (#'core/match-any-order matchers [5] false)
-    => (just {::result/type   :mismatch
-              ::result/value  (just [(just (model/->Missing anything)) 5]
-                                    :in-any-order)
-              ::result/weight 1})
-    (#'core/match-any-order matchers [5] true)
-    => (just {::result/type   :mismatch
-              ::result/value  (just [5 (just (model/->Missing anything))]
-                                    :in-any-order)
-              ::result/weight 1})))
+  ;(core/match (matchers/equals [(pred-matcher odd?) (pred-matcher even?)]) [1])
+  ;(just {::result/type   :mismatch
+  ;          ::result/value  (just [1 anything])
+  ;          ::result/weight 1})
 
-(tabular
-  (fact "matching for absence in map"
-    (core/match (?matcher {:a (equals 42)
-                           :b absent})
-      {:a 42})
-    => (just {::result/type   :match
-              ::result/value  {:a 42}
-              ::result/weight 0})
 
-    (core/match (?matcher {:a (equals 42)
-                           :b absent})
-      {:a 42
-       :b 43})
-    => (just {::result/type   :mismatch
-              ::result/value  (just {:a 42
-                                     :b (just {:actual 43})})
-              ::result/weight #(or (= 1 %) (= 2 %))}))
-  ?matcher
-  equals
-  embeds)
+  (let [matchers [(pred-matcher odd?) (pred-matcher even?)]]
+    ;(testing "no matching when there are more matchers than elements"
+    ;      (#'core/matches-in-any-order? matchers [] true [])
+    ;      => (sweet/contains {:matched?  false
+    ;                          :unmatched (just [anything anything])
+    ;                          :matched   empty?})
+    ;      (#'core/matches-in-any-order? matchers [1] false [])
+    ;      => (sweet/contains {:matched?  false
+    ;                          :unmatched (just [anything])
+    ;                          :matched   (just [anything])})
+    ;      (#'core/matches-in-any-order? matchers [1] true [])
+    ;      => (sweet/contains {:matched?  false
+    ;                          :unmatched (just [anything])
+    ;                          :matched   (just [anything])}))
 
-(fact "`absent` interaction with keys pointing to `nil` values"
-  (core/match (equals {:a (equals 42)
-                       :b absent})
-    {:a 42
-     :b nil})
-  => (just {::result/type   :mismatch
-            ::result/value  (just {:a 42
-                                   :b {:actual nil}})
-            ::result/weight 2}))
+    ;(fact "subset will recur on matchers"
+    ;      (#'core/matches-in-any-order? matchers [5 4 1 2] true [])
+    ;      => (sweet/contains {:matched?  true
+    ;                          :unmatched nil?
+    ;                          :matched   (just [anything anything])})
+    ;      (#'core/matches-in-any-order? matchers [5 1 3 2] true [])
+    ;      => (sweet/contains {:matched?  true
+    ;                          :unmatched nil?
+    ;                          :matched   (just [anything anything])}))
+    ;(fact "works well with identical matchers"
+    ;      (#'core/matches-in-any-order? [(matchers/equals 2) (matchers/equals 2)] [2 2] false [])
+    ;      => (sweet/contains {:matched?  true
+    ;                          :unmatched empty?
+    ;                          :matched   (just [anything anything])}))
 
-(fact "using `absent` incorrectly outside of a map"
-  (core/match (equals [(equals 42) absent])
-    [42])
-  => (just {::result/type   :mismatch
-            ::result/value  (just [42 {:message "`absent` matcher should only be used as the value in a map"}])
-            ::result/weight 1}))
+    ;(testing "mismatch if there are more matchers than actual elements"
+    ;      (#'core/match-any-order matchers [5] false)
+    ;      => (just {::result/type   :mismatch
+    ;                ::result/value  (just [(just (model/->Missing anything)) 5]
+    ;                                      :in-any-order)
+    ;                ::result/weight 1})
+    ;      (#'core/match-any-order matchers [5] true)
+    ;      => (just {::result/type   :mismatch
+    ;                ::result/value  (just [5 (just (model/->Missing anything))]
+    ;                                      :in-any-order)
+    ;                ::result/weight 1}))
+))
 
-(tabular
-  (fact "Providing seq/map matcher with incorrect input leads to automatic mismatch"
-    (core/match (?matcher 1) 1)
-    => (just {::result/type   :mismatch
-              ::result/value  (sweet/contains {:expected-type-msg
-                                               #(str/starts-with? % (-> ?matcher var meta :name str))
-                                               :provided
-                                               "provided: 1"})
-              ::result/weight number?}))
-  ?matcher
-  prefix
-  embeds)
+(deftest absent-in-map
+  (testing "matching for absence in map"
+    (is (= {::result/type   :match
+            ::result/value  {:a 42}
+            ::result/weight 0}
+           (core/match {:a (matchers/equals 42)
+                        :b matchers/absent }
+                       {:a 42})))
+
+    ;(core/match (?matcher {:a (matchers/equals 42)
+    ;                       :b matchers/absent })
+    ;            {:a 42
+    ;             :b 43})
+    ;=> (just {::result/type   :mismatch
+    ;          ::result/value  (just {:a 42
+    ;                                 :b (just {:actual 43})})
+    ;          ::result/weight #(or (= 1 %) (= 2 %))})
+    ))
+
+;(fact "`absent` interaction with keys pointing to `nil` values"
+;  (core/match (matchers/equals {:a (matchers/equals 42)
+;                       :b matchers/absent })
+;    {:a 42
+;     :b nil})
+;  => (just {::result/type   :mismatch
+;            ::result/value  (just {:a 42
+;                                   :b {:actual nil}})
+;            ::result/weight 2}))
+;
+;(fact "using `absent` incorrectly outside of a map"
+;  (core/match (matchers/equals [(matchers/equals 42) matchers/absent ])
+;    [42])
+;  => (just {::result/type   :mismatch
+;            ::result/value  (just [42 {:message "`absent` matcher should only be used as the value in a map"}])
+;            ::result/weight 1}))
+
+;(tabular
+;  (fact "Providing seq/map matcher with incorrect input leads to automatic mismatch"
+;    (core/match (?matcher 1) 1)
+;    => (just {::result/type   :mismatch
+;              ::result/value  (sweet/contains {:expected-type-msg
+;                                               #(str/starts-with? % (-> ?matcher var meta :name str))
+;                                               :provided
+;                                               "provided: 1"})
+;              ::result/weight number?}))
+;  ?matcher
+;  prefix
+;  embeds)
 
 (def pred-set #{(pred-matcher odd?) (pred-matcher pos?)})
 (def pred-seq [(pred-matcher odd?) (pred-matcher pos?)])
 
-(def short-equals-seq (map equals [1 3]))
+(def short-equals-seq (map matchers/equals [1 3]))
 
-(fact "embeds for sequences"
-  (core/match (embeds short-equals-seq) [3 4 1]) => (just {::result/type   :match
-                                                           ::result/value  (just [3 4 1])
-                                                           ::result/weight 0})
-  (core/match (embeds short-equals-seq) [3 4 1 5]) => (just {::result/type   :match
-                                                             ::result/value  (just [3 4 1 5])
-                                                             ::result/weight 0}))
+(deftest embeds-test
+  (testing "embeds for sequences"
+    (is (= {::result/type   :match
+            ::result/value  [3 4 1]
+            ::result/weight 0}
+           (core/match (matchers/embeds  short-equals-seq) [3 4 1])))
+    (is (= {::result/type   :match
+            ::result/value  [3 4 1 5]
+            ::result/weight 0}
+           (core/match (matchers/embeds  short-equals-seq) [3 4 1 5]))))
 
-(fact "embeds /set-equals matches"
-  (core/match (embeds pred-set) #{1 3}) => (just {::result/type   :match
-                                                  ::result/value  (just #{1 3})
-                                                  ::result/weight 0})
-  (core/match (set-embeds pred-seq) #{1 3}) => (just {::result/type   :match
-                                                      ::result/value  (just #{1 3})
-                                                      ::result/weight 0})
-  (core/match (equals pred-set) #{1 3}) => (just {::result/type   :match
-                                                  ::result/value  (just #{1 3})
-                                                  ::result/weight 0})
-  (core/match (set-equals pred-seq) #{1 3}) => (just {::result/type   :match
-                                                      ::result/value  (just #{1 3})
-                                                      ::result/weight 0}))
+  (testing "embeds /set-equals matches"
+    (is (= {::result/type   :match
+            ::result/value  #{1 3}
+            ::result/weight 0}
+           (core/match (matchers/embeds  pred-set) #{1 3})))
+    (is (= {::result/type   :match
+            ::result/value  #{1 3}
+            ::result/weight 0}
+           (core/match (matchers/set-embeds pred-seq) #{1 3})))
+    (is (= {::result/type   :match
+            ::result/value  #{1 3}
+            ::result/weight 0}
+           (core/match (matchers/equals pred-set) #{1 3})))
+    (is (= {::result/type   :match
+            ::result/value  #{1 3}
+            ::result/weight 0}
+           (core/match (matchers/set-equals pred-seq) #{1 3}))))
 
-(fact "embeds /equals mismatches due to type"
-  (core/match (equals pred-seq) #{1 3})
-  => (just {::result/type   :mismatch
-            ::result/value  (just {:actual   #{1 3}
-                                   :expected anything})
-            ::result/weight 1})
-  (core/match (equals pred-set) [1 3])
-  => (just {::result/type   :mismatch
-            ::result/value  (just {:actual   [1 3]
-                                   :expected anything})
-            ::result/weight 1})
-  (core/match (embeds pred-seq) #{1 3})
-  => (just {::result/type   :mismatch
-            ::result/value  (just {:actual   #{1 3}
-                                   :expected anything})
-            ::result/weight 1})
-  (core/match (embeds pred-set) [1 3])
-  => (just {::result/type   :mismatch
-            ::result/value  (just {:actual   [1 3]
-                                   :expected anything})
-            ::result/weight 1})
-  (core/match (embeds 1) [1])
-  => (just {::result/type   :mismatch
-            ::result/value  (just {:expected-type-msg #"^embeds *"
-                                   :provided          #"^provided: 1"})
-            ::result/weight 1}))
+  ;(fact "embeds /equals mismatches due to type"
+  ;      (core/match (matchers/equals pred-seq) #{1 3})
+  ;      => (just {::result/type   :mismatch
+  ;                ::result/value  (just {:actual   #{1 3}
+  ;                                       :expected anything})
+  ;                ::result/weight 1})
+  ;      (core/match (matchers/equals pred-set) [1 3])
+  ;      => (just {::result/type   :mismatch
+  ;                ::result/value  (just {:actual   [1 3]
+  ;                                       :expected anything})
+  ;                ::result/weight 1})
+  ;      (core/match (matchers/embeds  pred-seq) #{1 3})
+  ;      => (just {::result/type   :mismatch
+  ;                ::result/value  (just {:actual   #{1 3}
+  ;                                       :expected anything})
+  ;                ::result/weight 1})
+  ;      (core/match (matchers/embeds  pred-set) [1 3])
+  ;      => (just {::result/type   :mismatch
+  ;                ::result/value  (just {:actual   [1 3]
+  ;                                       :expected anything})
+  ;                ::result/weight 1})
+  ;      (core/match (matchers/embeds  1) [1])
+  ;      => (just {::result/type   :mismatch
+  ;                ::result/value  (just {:expected-type-msg #"^embeds *"
+  ;                                       :provided          #"^provided: 1"})
+  ;                ::result/weight 1}))
 
-(fact "embeds /set-equals mismatches due to type"
-  (core/match (set-embeds pred-seq) [1 3])
-  => (just {::result/type   :mismatch
-            ::result/value  (just {:actual   [1 3]
-                                   :expected anything})
-            ::result/weight 1})
-  (core/match (set-equals pred-seq) [1 3])
-  => (just {::result/type   :mismatch
-            ::result/value  (just {:actual   [1 3]
-                                   :expected anything})
-            ::result/weight 1})
-  (core/match (set-embeds 1) [1 3])
-  => (just {::result/type   :mismatch
-            ::result/value  (just {:expected-type-msg #"^set-embeds*"
-                                   :provided          #"^provided: 1"})
-            ::result/weight 1})
-  (core/match (set-equals 1) [1 3])
-  => (just {::result/type   :mismatch
-            ::result/value  (just {:expected-type-msg #"^set-equals*"
-                                   :provided          #"^provided: 1"})
-            ::result/weight 1}))
+  ;(fact "embeds /set-equals mismatches due to type"
+  ;      (core/match (matchers/set-embeds pred-seq) [1 3])
+  ;      => (just {::result/type   :mismatch
+  ;                ::result/value  (just {:actual   [1 3]
+  ;                                       :expected anything})
+  ;                ::result/weight 1})
+  ;      (core/match (matchers/set-equals pred-seq) [1 3])
+  ;      => (just {::result/type   :mismatch
+  ;                ::result/value  (just {:actual   [1 3]
+  ;                                       :expected anything})
+  ;                ::result/weight 1})
+  ;      (core/match (matchers/set-embeds 1) [1 3])
+  ;      => (just {::result/type   :mismatch
+  ;                ::result/value  (just {:expected-type-msg #"^set-embeds*"
+  ;                                       :provided          #"^provided: 1"})
+  ;                ::result/weight 1})
+  ;      (core/match (matchers/set-equals 1) [1 3])
+  ;      => (just {::result/type   :mismatch
+  ;                ::result/value  (just {:expected-type-msg #"^set-equals*"
+  ;                                       :provided          #"^provided: 1"})
+  ;                ::result/weight 1}))
 
-(fact "embeds /set-equals mismatches due to content"
-  (core/match (set-embeds pred-set) #{1 -2})
-  => (just {::result/type  :mismatch
-            ::result/value (just #{1 (just {:actual   -2
-                                            :expected anything})})
-            ::result/weight 1})
-
-  (core/match (set-embeds pred-seq) #{1 -2})
-  => (just {::result/type :mismatch
-            ::result/weight 1
-            ::result/value (just #{1 (just {:actual   -2
-                                            :expected anything})})})
-
-  (core/match (equals pred-set) #{1 -2})
-  => (just {::result/type :mismatch
-            ::result/weight 1
-            ::result/value (just #{1 (just {:actual   -2
-                                            :expected anything})})})
-
-  (core/match (set-equals pred-seq) #{1 -2})
-  => (just {::result/type :mismatch
-            ::result/weight 1
-            ::result/value (just #{1 (just {:actual   -2
-                                            :expected anything})})}))
+  ;(fact "embeds /set-equals mismatches due to content"
+  ;      (core/match (matchers/set-embeds pred-set) #{1 -2})
+  ;      => (just {::result/type   :mismatch
+  ;                ::result/value  (just #{1 (just {:actual   -2
+  ;                                                 :expected anything})})
+  ;                ::result/weight 1})
+  ;
+  ;      (core/match (matchers/set-embeds pred-seq) #{1 -2})
+  ;      => (just {::result/type   :mismatch
+  ;                ::result/weight 1
+  ;                ::result/value  (just #{1 (just {:actual   -2
+  ;                                                 :expected anything})})})
+  ;
+  ;      (core/match (matchers/equals pred-set) #{1 -2})
+  ;      => (just {::result/type   :mismatch
+  ;                ::result/weight 1
+  ;                ::result/value  (just #{1 (just {:actual   -2
+  ;                                                 :expected anything})})})
+  ;
+  ;      (core/match (matchers/set-equals pred-seq) #{1 -2})
+  ;      => (just {::result/type   :mismatch
+  ;                ::result/weight 1
+  ;                ::result/value  (just #{1 (just {:actual   -2
+  ;                                                 :expected anything})})}))
+)
 
 (def even-odd-set #{(pred-matcher #(and (odd? %) (pos? %)))
                     (pred-matcher even?)})
 (def even-odd-seq (into [] even-odd-set))
-(fact "Order agnostic checks show fine-grained mismatch details"
-  (core/match (equals even-odd-set) #{1 2 -3})
-  => (just {::result/type   :mismatch
+
+(deftest even-odd-test
+  (testing "Order agnostic checks show fine-grained mismatch details"
+    (is (= {::result/type   :mismatch
             ::result/value  #{1 2 (model/->Unexpected -3)}
-            ::result/weight 1})
+            ::result/weight 1}
+           (core/match (matchers/equals even-odd-set) #{1 2 -3})))
 
-  (core/match (in-any-order even-odd-seq) [1 2 -3])
-  => (just {::result/type   :mismatch
-            ::result/value  (just [1 2 (model/->Unexpected -3)]
-                                  :in-any-order)
-            ::result/weight 1})
+    ;(core/match (matchers/in-any-order even-odd-seq) [1 2 -3])
+    ;    => (just {::result/type   :mismatch
+    ;              ::result/value  (just [1 2 (model/->Unexpected -3)]
+    ;                                    :in-any-order)
+    ;              ::result/weight 1})
+    ;
+    ;    (core/match (matchers/in-any-order even-odd-seq) [1])
+    ;    => (just {::result/type   :mismatch
+    ;              ::result/value  (just [1 (just (model/->Missing anything))]
+    ;                                    :in-any-order)
+    ;              ::result/weight 1})
+    ;
+    ;    (core/match (matchers/equals even-odd-set) #{1})
+    ;    => (just {::result/type   :mismatch
+    ;              ::result/value  (just #{1 (just (model/->Missing anything))}
+    ;                                    :in-any-order)
+    ;              ::result/weight 1})
+))
 
-  (core/match (in-any-order even-odd-seq) [1])
-  => (just {::result/type   :mismatch
-            ::result/value  (just [1 (just (model/->Missing anything))]
-                                  :in-any-order)
-            ::result/weight 1})
+(deftest in-any-order-minimal-mismatch-test
+  (is (= {::result/type   :mismatch
+          ::result/value  [{:a "1" :x (model/->Mismatch "12" "12=")}]
+          ::result/weight 1}
+         (core/match (matchers/equals [(matchers/equals {:a (matchers/equals "1") :x (matchers/equals "12")})])
+           [{:a "1" :x "12="}])))
 
-  (core/match (equals even-odd-set) #{1})
-  => (just {::result/type   :mismatch
-            ::result/value  (just #{1 (just (model/->Missing anything))}
-                                  :in-any-order)
-            ::result/weight 1}))
-
-(fact "in-any-order minimal mismatch test"
-  (core/match (equals [(equals {:a (equals "1") :x (equals "12")})])
-    [{:a "1" :x "12="}])
-  => {::result/type   :mismatch
-      ::result/value  [{:a "1" :x (model/->Mismatch "12" "12=")}]
-      ::result/weight 1}
-
-  (core/match (in-any-order [(equals {:a (equals "2") :x (equals "14")})
-                             (equals {:a (equals "1") :x (equals "12")})])
-    [{:a "1" :x "12="} {:a "2" :x "14="}])
-  => (just {::result/type   :mismatch
-            ::result/value  (just [{:a "1" :x (model/->Mismatch "12" "12=")}
-                                   {:a "2" :x (model/->Mismatch "14" "14=")}]
-                                  :in-any-order)
-            ::result/weight 2})
-
-  (core/match (in-any-order [(equals {:a (equals "2") :x (equals "14")})
-                             (equals {:a (equals "1") :x (equals "12")})])
-    [{:a "1" :x "12="} {:a "2" :x "14="}])
-  => (just {::result/type   :mismatch
-            ::result/value  (just [{:a "2" :x (model/->Mismatch "14" "14=")}
-                                   {:a "1" :x (model/->Mismatch "12" "12=")}]
-                                  :in-any-order)
-            ::result/weight 2}))
+  ;(core/match (matchers/in-any-order [(matchers/equals {:a (matchers/equals "2") :x (matchers/equals "14")})
+  ;                           (matchers/equals {:a (matchers/equals "1") :x (matchers/equals "12")})])
+  ;  [{:a "1" :x "12="} {:a "2" :x "14="}])
+  ;=> (just {::result/type   :mismatch
+  ;          ::result/value  (just [{:a "1" :x (model/->Mismatch "12" "12=")}
+  ;                                 {:a "2" :x (model/->Mismatch "14" "14=")}]
+  ;                                :in-any-order)
+  ;          ::result/weight 2})
+  ;
+  ;(core/match (matchers/in-any-order [(matchers/equals {:a (matchers/equals "2") :x (matchers/equals "14")})
+  ;                           (matchers/equals {:a (matchers/equals "1") :x (matchers/equals "12")})])
+  ;  [{:a "1" :x "12="} {:a "2" :x "14="}])
+  ;=> (just {::result/type   :mismatch
+  ;          ::result/value  (just [{:a "2" :x (model/->Mismatch "14" "14=")}
+  ;                                 {:a "1" :x (model/->Mismatch "12" "12=")}]
+  ;                                :in-any-order)
+  ;          ::result/weight 2})
+)
 
 (spec.test/unstrument)

--- a/test/clj/matcher_combinators/core_test.clj
+++ b/test/clj/matcher_combinators/core_test.clj
@@ -19,16 +19,16 @@
 (defspec equals-matcher-matches-when-values-are-equal
   {:max-size 10}
   (prop/for-all [v gen/any-equatable]
-                (standalone/match? (matchers/equals v) v)))
+    (standalone/match? (matchers/equals v) v)))
 
 (defspec equals-matcher-mismatches-when-scalar-values-are-not-equal
   {:max-size 10}
   (prop/for-all [[a b] (gen/such-that (fn [[a b]] (not= a b))
                                       (gen/tuple gen/simple-type-equatable
                                                  gen/simple-type-equatable))]
-                (standalone/match?
-                 {::result/value (model/->Mismatch a b)}
-                 (core/match (matchers/equals a) b))))
+    (standalone/match?
+     {::result/value (model/->Mismatch a b)}
+     (core/match (matchers/equals a) b))))
 
 (deftest map-matchers-support-map-like-actual-values
   (let [map-like (reify Associative
@@ -53,57 +53,57 @@
   {:max-size 10}
   (prop/for-all [expected (gen/such-that not-empty (gen/map gen/keyword gen/small-integer))
                  m        (gen/elements [matchers/equals matchers/embeds])]
-                (let [k      (first (keys expected))
-                      actual (update expected k inc)
-                      res    (core/match (m expected) actual)]
-                  (standalone/match?
-                   {::result/type  :mismatch
-                    ::result/value (assoc actual k (model/->Mismatch (k expected) (k actual)))}
-                   res))))
+    (let [k      (first (keys expected))
+          actual (update expected k inc)
+          res    (core/match (m expected) actual)]
+      (standalone/match?
+       {::result/type  :mismatch
+        ::result/value (assoc actual k (model/->Mismatch (k expected) (k actual)))}
+       res))))
 
 (defspec map-matchers-mismatches-when-all-keys-have-a-mismatched-value
   {:max-size 10}
   (prop/for-all [expected (gen/such-that not-empty (gen/map gen/keyword gen/small-integer))
                  m        (gen/elements [matchers/equals matchers/embeds])]
-                (let [actual (reduce-kv (fn [m k v] (assoc m k (inc v))) {} expected)
-                      res    (core/match (m expected) actual)]
-                  (standalone/match?
-                   {::result/type :mismatch
-                    ::result/value
-                    (reduce (fn [m [k]]
-                              (assoc m k (model/->Mismatch (k expected) (k actual))))
-                            {}
-                            actual)}
-                   res))))
+    (let [actual (reduce-kv (fn [m k v] (assoc m k (inc v))) {} expected)
+          res    (core/match (m expected) actual)]
+      (standalone/match?
+       {::result/type :mismatch
+        ::result/value
+        (reduce (fn [m [k]]
+                  (assoc m k (model/->Mismatch (k expected) (k actual))))
+                {}
+                actual)}
+       res))))
 
 (defspec map-matchers-mismatch-when-expected-keys-are-missing
   {:max-size 10}
   (prop/for-all [expected (gen/such-that not-empty (gen/map gen/keyword gen/small-integer))
                  m        (gen/elements [matchers/equals matchers/embeds])]
-                (let [k      (first (keys expected))
-                      actual (dissoc expected k)
-                      res    (core/match (m expected) actual)]
-                  (standalone/match?
-                   {::result/type :mismatch
-                    ::result/value (assoc actual k (model/->Missing (get expected k)))}
-                   res))))
+    (let [k      (first (keys expected))
+          actual (dissoc expected k)
+          res    (core/match (m expected) actual)]
+      (standalone/match?
+       {::result/type :mismatch
+        ::result/value (assoc actual k (model/->Missing (get expected k)))}
+       res))))
 
 (defspec map-matchers-mismatch-any-non-map-value
   {:max-size 10}
   (prop/for-all [m        (gen/elements [matchers/equals matchers/embeds])
                  expected (gen/map gen/keyword gen/any-equatable)
                  actual   (gen/such-that (comp not map?) gen/any-equatable)]
-                (let [res (core/match (m expected) actual)]
-                  (standalone/match?
-                   {::result/type  :mismatch
-                    ::result/value (model/->Mismatch expected actual)}
-                   res))))
+    (let [res (core/match (m expected) actual)]
+      (standalone/match?
+       {::result/type  :mismatch
+        ::result/value (model/->Mismatch expected actual)}
+       res))))
 
 (defspec matcher-for-arities
   {:max-size 10}
   (prop/for-all [v gen/any]
-                (= (core/-matcher-for v)
-                   (core/-matcher-for v {}))))
+    (= (core/-matcher-for v)
+       (core/-matcher-for v {}))))
 
 (deftest matcher-for-with-overrides
   (is (= matchers/embeds
@@ -154,37 +154,37 @@
   (prop/for-all [v (gen/one-of [(gen/vector gen/any-equatable)
                                 (gen/list   gen/any-equatable)])
                  m (gen/elements [matchers/equals matchers/in-any-order])]
-                (core/indicates-match?
-                 (core/match (m v) v))))
+    (core/indicates-match?
+     (core/match (m v) v))))
 
 (defspec sequence-matchers-mismatch-missing-elements
   {:max-size 5}
   (prop/for-all [v (gen/one-of [(gen/vector gen/any-equatable)
                                 (gen/list   gen/any-equatable)])
                  m (gen/elements [matchers/equals matchers/in-any-order])]
-                (not
-                 (core/indicates-match?
-                  (core/match (m (concat v [:extra])) v)))))
+    (not
+     (core/indicates-match?
+      (core/match (m (concat v [:extra])) v)))))
 
 (defspec sequence-matchers-mismatch-extra-elements
   {:max-size 5}
   (prop/for-all [v (gen/one-of [(gen/vector gen/any-equatable)
                                 (gen/list   gen/any-equatable)])
                  m (gen/elements [matchers/equals matchers/in-any-order])]
-                (not
-                 (core/indicates-match?
-                  (core/match (m v) (concat v [:extra]))))))
+    (not
+     (core/indicates-match?
+      (core/match (m v) (concat v [:extra]))))))
 
 (defspec sequence-matchers-mismatch-incorrect-element
   {:max-size 5}
   (prop/for-all [nums      (gen/vector gen/small-integer 1 5)
                  coll-type (gen/elements [vector list])
                  m         (gen/elements [matchers/equals matchers/in-any-order])]
-                (let [expected (apply coll-type nums)
-                      actual   (apply coll-type (update nums 0 inc))]
-                  (not
-                   (core/indicates-match?
-                    (core/match (m expected) actual))))))
+    (let [expected (apply coll-type nums)
+          actual   (apply coll-type (update nums 0 inc))]
+      (not
+       (core/indicates-match?
+        (core/match (m expected) actual))))))
 
 (defspec sequence-matchers-mismatch-non-sequences
   {:max-size 5}
@@ -192,10 +192,10 @@
                                        (gen/list   gen/any-equatable)])
                  actual   gen/any-equatable
                  m (gen/elements [matchers/equals matchers/in-any-order])]
-                (or (sequential? actual)
-                    (not
-                     (core/indicates-match?
-                      (core/match (m expected) actual))))))
+    (or (sequential? actual)
+        (not
+         (core/indicates-match?
+          (core/match (m expected) actual))))))
 
 (deftest sequence-matchers
   (testing "on the equals matcher for sequences"
@@ -215,7 +215,7 @@
               ::result/value  [1 2 (model/->Mismatch 3 4)]
               ::result/weight 1}
              (core/match (matchers/equals [(matchers/equals 1) (matchers/equals 2) (matchers/equals 3)])
-               (list 1 2 4)))))
+                         (list 1 2 4)))))
 
     (testing "when there are more elements than expected matchers, mark each extra element as Unexpected"
       (is (= {::result/type   :mismatch
@@ -245,16 +245,16 @@
             ::result/value  [{:id 2 :x 2} {:id 1 :x 1}]
             ::result/weight 0}
            (core/match
-            (matchers/in-any-order [(matchers/equals {:id (matchers/equals 1) :x (matchers/equals 1)})
-                                    (matchers/equals {:id (matchers/equals 2) :x (matchers/equals 2)})])
+             (matchers/in-any-order [(matchers/equals {:id (matchers/equals 1) :x (matchers/equals 1)})
+                                     (matchers/equals {:id (matchers/equals 2) :x (matchers/equals 2)})])
              [{:id 2 :x 2} {:id 1 :x 1}])))
     (is (= {::result/type   :match
             ::result/value  [{:id 2 :x 2} {:id 1 :x 1} {:id 3 :x 3}]
             ::result/weight 0}
            (core/match
-            (matchers/in-any-order [(matchers/equals {:id (matchers/equals 1) :x (matchers/equals 1)})
-                                    (matchers/equals {:id (matchers/equals 2) :x (matchers/equals 2)})
-                                    (matchers/equals {:id (matchers/equals 3) :x (matchers/equals 3)})])
+             (matchers/in-any-order [(matchers/equals {:id (matchers/equals 1) :x (matchers/equals 1)})
+                                     (matchers/equals {:id (matchers/equals 2) :x (matchers/equals 2)})
+                                     (matchers/equals {:id (matchers/equals 3) :x (matchers/equals 3)})])
              [{:id 2 :x 2} {:id 1 :x 1} {:id 3 :x 3}]))))
 
   (testing "the 1-argument arity has a simple all-or-nothing behavior:"
@@ -281,21 +281,21 @@
             ::result/value  [[1 2] 20]
             ::result/weight 0}
            (core/match
-            (matchers/equals [(matchers/equals [(matchers/equals 1) (matchers/equals 2)]) (matchers/equals 20)])
+             (matchers/equals [(matchers/equals [(matchers/equals 1) (matchers/equals 2)]) (matchers/equals 20)])
              [[1 2] 20])))
 
     (is (= {::result/type   :mismatch
             ::result/value  [[1 (model/->Mismatch 2 5)] 20]
             ::result/weight 1}
            (core/match
-            (matchers/equals [(matchers/equals [(matchers/equals 1) (matchers/equals 2)]) (matchers/equals 20)])
+             (matchers/equals [(matchers/equals [(matchers/equals 1) (matchers/equals 2)]) (matchers/equals 20)])
              [[1 5] 20])))
 
     (is (= {::result/type   :mismatch
             ::result/value  [[1 (model/->Mismatch 2 5)] (model/->Mismatch 20 21)]
             ::result/weight 2}
            (core/match
-            (matchers/equals [(matchers/equals [(matchers/equals 1) (matchers/equals 2)]) (matchers/equals 20)])
+             (matchers/equals [(matchers/equals [(matchers/equals 1) (matchers/equals 2)]) (matchers/equals 20)])
              [[1 5] 21]))))
 
   (testing "sequence type is preserved in mismatch output"
@@ -312,8 +312,8 @@
             ::result/value  [{:id 1 :a 1} {:id 2 :a 2}]
             ::result/weight 0}
            (core/match
-            (matchers/in-any-order [(matchers/equals {:id (matchers/equals 1) :a (matchers/equals 1)})
-                                    (matchers/equals {:id (matchers/equals 2) :a (matchers/equals 2)})])
+             (matchers/in-any-order [(matchers/equals {:id (matchers/equals 1) :a (matchers/equals 1)})
+                                     (matchers/equals {:id (matchers/equals 2) :a (matchers/equals 2)})])
              [{:id 1 :a 1} {:id 2 :a 2}]))))
 
   (testing "nesting matchers/embeds  for maps"
@@ -321,7 +321,7 @@
             ::result/value  {:a 42 :m {:x "foo"}}
             ::result/weight 0}
            (core/match
-            (matchers/embeds  {:a (matchers/equals 42) :m (matchers/embeds  {:x (matchers/equals "foo")})})
+             (matchers/embeds  {:a (matchers/equals 42) :m (matchers/embeds  {:x (matchers/equals "foo")})})
              {:a 42 :m {:x "foo"}})))
 
     (is (= {::result/type   :mismatch
@@ -330,8 +330,8 @@
             ::result/weight 1}
            (core/match (matchers/embeds  {:a (matchers/equals 42)
                                           :m (matchers/embeds  {:x (matchers/equals "foo")})})
-             {:a 42
-              :m {:x "bar"}})))
+                       {:a 42
+                        :m {:x "bar"}})))
 
     (is (= {::result/type   :mismatch
             ::result/value  {:a (model/->Mismatch 42 43)
@@ -339,8 +339,8 @@
             ::result/weight 2}
            (core/match (matchers/embeds  {:a (matchers/equals 42)
                                           :m (matchers/embeds  {:x (matchers/equals "foo")})})
-             {:a 43
-              :m {:x "bar"}}))))
+                       {:a 43
+                        :m {:x "bar"}}))))
 
   (is (= {::result/type   :match
           ::result/value  [{:a 42 :b 1337} 20]
@@ -348,7 +348,7 @@
          (core/match (matchers/equals [(matchers/equals {:a (matchers/equals 42)
                                                          :b (matchers/equals 1337)})
                                        (matchers/equals 20)])
-           [{:a 42 :b 1337} 20])))
+                     [{:a 42 :b 1337} 20])))
 
   (is (= {::result/type   :mismatch
           ::result/value  [{:a (model/->Mismatch 42 43) :b 1337} 20]
@@ -356,7 +356,7 @@
          (core/match (matchers/equals [(matchers/equals {:a (matchers/equals 42)
                                                          :b (matchers/equals 1337)})
                                        (matchers/equals 20)])
-           [{:a 43 :b 1337} 20]))))
+                     [{:a 43 :b 1337} 20]))))
 
 ;; Since the parser namespace needs to be loaded to interpret functions as
 ;; matchers, and we don't want to load the parser namespace, we need to manually
@@ -421,7 +421,7 @@
           ::result/weight 0}
          (core/match (matchers/equals {:a (matchers/equals 42)
                                        :b matchers/absent})
-           {:a 42})))
+                     {:a 42})))
 
   (is (match? {::result/type   :mismatch
                ::result/value  {:a 42
@@ -429,8 +429,8 @@
                ::result/weight #(or (= 1 %) (= 2 %))}
               (core/match (matchers/embeds {:a (matchers/equals 42)
                                             :b matchers/absent})
-                {:a 42
-                 :b 43}))))
+                          {:a 42
+                           :b 43}))))
 
 (deftest absent-interaction-with-keys-pointing-to-nil-values
   (is (match? {::result/type   :mismatch
@@ -439,15 +439,15 @@
                ::result/weight 2}
               (core/match (matchers/equals {:a (matchers/equals 42)
                                             :b matchers/absent})
-                {:a 42
-                 :b nil}))))
+                          {:a 42
+                           :b nil}))))
 
 (deftest using-absent-incorrectly-outside-of-a-map
   (is (match? {::result/type   :mismatch
                ::result/value  [42 {:message "`absent` matcher should only be used as the value in a map"}]
                ::result/weight 1}
               (core/match (matchers/equals [(matchers/equals 42) matchers/absent])
-                [42]))))
+                          [42]))))
 
 (deftest let-us-think-of-a-name-later
   (are [?matcher]
@@ -601,7 +601,7 @@
           ::result/value  [{:a "1" :x (model/->Mismatch "12" "12=")}]
           ::result/weight 1}
          (core/match (matchers/equals [(matchers/equals {:a (matchers/equals "1") :x (matchers/equals "12")})])
-           [{:a "1" :x "12="}])))
+                     [{:a "1" :x "12="}])))
 
   (is (match? {::result/type   :mismatch
                ::result/value  (matchers/in-any-order [{:a "1" :x (model/->Mismatch "12" "12=")}
@@ -609,7 +609,7 @@
                ::result/weight 2}
               (core/match (matchers/in-any-order [(matchers/equals {:a (matchers/equals "2") :x (matchers/equals "14")})
                                                   (matchers/equals {:a (matchers/equals "1") :x (matchers/equals "12")})])
-                [{:a "1" :x "12="} {:a "2" :x "14="}])))
+                          [{:a "1" :x "12="} {:a "2" :x "14="}])))
 
   (is (match? {::result/type   :mismatch
                ::result/value  (matchers/in-any-order [{:a "2" :x (model/->Mismatch "14" "14=")}
@@ -617,4 +617,4 @@
                ::result/weight 2}
               (core/match (matchers/in-any-order [(matchers/equals {:a (matchers/equals "2") :x (matchers/equals "14")})
                                                   (matchers/equals {:a (matchers/equals "1") :x (matchers/equals "12")})])
-                [{:a "1" :x "12="} {:a "2" :x "14="}]))))
+                          [{:a "1" :x "12="} {:a "2" :x "14="}]))))

--- a/test/clj/matcher_combinators/core_test.clj
+++ b/test/clj/matcher_combinators/core_test.clj
@@ -1,11 +1,9 @@
 (ns matcher-combinators.core-test
-  (:require [midje.sweet :as sweet]
-            [clojure.test :refer [deftest testing is use-fixtures]]
+  (:require [clojure.test :refer [are deftest testing is use-fixtures]]
             [clojure.test.check.generators :as gen]
             [clojure.test.check.properties :as prop]
             [clojure.test.check.clojure-test :refer [defspec]]
             [clojure.string :as str]
-            [orchestra.spec.test :as spec.test]
             [matcher-combinators.core :as core]
             [matcher-combinators.matchers :as matchers]
             [matcher-combinators.model :as model]
@@ -199,8 +197,6 @@
                      (core/indicates-match?
                       (core/match (m expected) actual))))))
 
-(spec.test/instrument)
-
 (deftest sequence-matchers
   (testing "on the equals matcher for sequences"
     (testing "on element mismatches, marks each mismatch"
@@ -259,26 +255,25 @@
             (matchers/in-any-order [(matchers/equals {:id (matchers/equals 1) :x (matchers/equals 1)})
                                     (matchers/equals {:id (matchers/equals 2) :x (matchers/equals 2)})
                                     (matchers/equals {:id (matchers/equals 3) :x (matchers/equals 3)})])
-             [{:id 2 :x 2} {:id 1 :x 1} {:id 3 :x 3}])))       )
+             [{:id 2 :x 2} {:id 1 :x 1} {:id 3 :x 3}]))))
 
-    (testing "the 1-argument arity has a simple all-or-nothing behavior:"
-      (testing "in-any-order for list of same value/matchers"
-        (is (= {::result/type   :match
-                ::result/value  [2 2]
-                ::result/weight 0}
-               (core/match (matchers/in-any-order [(matchers/equals 2) (matchers/equals 2)]) [2 2]))))
+  (testing "the 1-argument arity has a simple all-or-nothing behavior:"
+    (testing "in-any-order for list of same value/matchers"
+      (is (= {::result/type   :match
+              ::result/value  [2 2]
+              ::result/weight 0}
+             (core/match (matchers/in-any-order [(matchers/equals 2) (matchers/equals 2)]) [2 2]))))
 
-      (testing "when there the matcher and list count differ, mark specific mismatches"
-        (is (match? {::result/type   :mismatch
-                     ::result/value  (matchers/in-any-order [1 2 (model/->Unexpected 3)]
-                                           )
-                     ::result/weight 1}
-                    (core/match (matchers/in-any-order [(matchers/equals 1) (matchers/equals 2)]) [1 2 3])))
+    (testing "when there the matcher and list count differ, mark specific mismatches"
+      (is (match? {::result/type   :mismatch
+                   ::result/value  (matchers/in-any-order [1 2 (model/->Unexpected 3)])
+                   ::result/weight 1}
+                  (core/match (matchers/in-any-order [(matchers/equals 1) (matchers/equals 2)]) [1 2 3])))
 
-        (is (match? {::result/type   :mismatch
-                     ::result/value  (matchers/in-any-order [2 1 (model/->Missing 3)])
-                     ::result/weight 1}
-                    (core/match (matchers/in-any-order [(matchers/equals 1) (matchers/equals 2) (matchers/equals 3)]) [1 2]))))))
+      (is (match? {::result/type   :mismatch
+                   ::result/value  (matchers/in-any-order [2 1 (model/->Missing 3)])
+                   ::result/weight 1}
+                  (core/match (matchers/in-any-order [(matchers/equals 1) (matchers/equals 2) (matchers/equals 3)]) [1 2]))))))
 
 (deftest nesting-multiple-matchers
   (testing "on nesting equals matchers for sequences"
@@ -318,7 +313,7 @@
             ::result/weight 0}
            (core/match
             (matchers/in-any-order [(matchers/equals {:id (matchers/equals 1) :a (matchers/equals 1)})
-                           (matchers/equals {:id (matchers/equals 2) :a (matchers/equals 2)})])
+                                    (matchers/equals {:id (matchers/equals 2) :a (matchers/equals 2)})])
              [{:id 1 :a 1} {:id 2 :a 2}]))))
 
   (testing "nesting matchers/embeds  for maps"
@@ -334,7 +329,7 @@
                              :m {:x (model/->Mismatch "foo" "bar")}}
             ::result/weight 1}
            (core/match (matchers/embeds  {:a (matchers/equals 42)
-                           :m (matchers/embeds  {:x (matchers/equals "foo")})})
+                                          :m (matchers/embeds  {:x (matchers/equals "foo")})})
              {:a 42
               :m {:x "bar"}})))
 
@@ -343,7 +338,7 @@
                              :m {:x (model/->Mismatch "foo" "bar")}}
             ::result/weight 2}
            (core/match (matchers/embeds  {:a (matchers/equals 42)
-                           :m (matchers/embeds  {:x (matchers/equals "foo")})})
+                                          :m (matchers/embeds  {:x (matchers/equals "foo")})})
              {:a 43
               :m {:x "bar"}}))))
 
@@ -351,16 +346,16 @@
           ::result/value  [{:a 42 :b 1337} 20]
           ::result/weight 0}
          (core/match (matchers/equals [(matchers/equals {:a (matchers/equals 42)
-                                  :b (matchers/equals 1337)})
-                         (matchers/equals 20)])
+                                                         :b (matchers/equals 1337)})
+                                       (matchers/equals 20)])
            [{:a 42 :b 1337} 20])))
 
   (is (= {::result/type   :mismatch
           ::result/value  [{:a (model/->Mismatch 42 43) :b 1337} 20]
           ::result/weight 1}
          (core/match (matchers/equals [(matchers/equals {:a (matchers/equals 42)
-                                  :b (matchers/equals 1337)})
-                         (matchers/equals 20)])
+                                                         :b (matchers/equals 1337)})
+                                       (matchers/equals 20)])
            [{:a 43 :b 1337} 20]))))
 
 ;; Since the parser namespace needs to be loaded to interpret functions as
@@ -379,96 +374,94 @@
   (is (match? {::result/type   :mismatch
                ::result/value  [1 any?]
                ::result/weight 1}
-              (core/match (matchers/equals [(pred-matcher odd?) (pred-matcher even?)]) [1])))
+              (core/match (matchers/equals [(pred-matcher odd?) (pred-matcher even?)]) [1]))) (let [matchers [(pred-matcher odd?) (pred-matcher even?)]]
+                                                                                                (testing "no matching when there are more matchers than elements"
+                                                                                                  (is (match? (matchers/embeds {:matched?  false
+                                                                                                                                :unmatched [any? any?]
+                                                                                                                                :matched   empty?})
+                                                                                                              (#'core/matches-in-any-order? matchers [] true [])))
+                                                                                                  (is (match? (matchers/embeds {:matched?  false
+                                                                                                                                :unmatched [any?]
+                                                                                                                                :matched   [any?]})
+                                                                                                              (#'core/matches-in-any-order? matchers [1] false [])))
+                                                                                                  (is (match? (matchers/embeds {:matched?  false
+                                                                                                                                :unmatched [any?]
+                                                                                                                                :matched   [any?]})
+                                                                                                              (#'core/matches-in-any-order? matchers [1] true []))))
 
+                                                                                                (testing "subset will recur on matchers"
+                                                                                                  (is (match? (matchers/embeds {:matched?  true
+                                                                                                                                :unmatched nil?
+                                                                                                                                :matched   [any? any?]})
+                                                                                                              (#'core/matches-in-any-order? matchers [5 4 1 2] true [])))
+                                                                                                  (is (match? (matchers/embeds {:matched?  true
+                                                                                                                                :unmatched nil?
+                                                                                                                                :matched   [any? any?]})
+                                                                                                              (#'core/matches-in-any-order? matchers [5 1 3 2] true []))))
 
-  (let [matchers [(pred-matcher odd?) (pred-matcher even?)]]
-    (testing "no matching when there are more matchers than elements"
-      (is (match? (matchers/embeds {:matched?  false
-                                    :unmatched [any? any?]
-                                    :matched   empty?})
-                  (#'core/matches-in-any-order? matchers [] true [])))
-      (is (match? (matchers/embeds {:matched?  false
-                                    :unmatched [any?]
-                                    :matched   [any?]})
-                  (#'core/matches-in-any-order? matchers [1] false [])))
-      (is (match? (matchers/embeds {:matched?  false
-                                    :unmatched [any?]
-                                    :matched   [any?]})
-                  (#'core/matches-in-any-order? matchers [1] true []))))
+                                                                                                (testing "works well with identical matchers"
+                                                                                                  (is (match? (matchers/embeds {:matched?  true
+                                                                                                                                :unmatched empty?
+                                                                                                                                :matched   [any? any?]})
+                                                                                                              (#'core/matches-in-any-order? [(matchers/equals 2) (matchers/equals 2)] [2 2] false []))))
 
-    (testing "subset will recur on matchers"
-      (is (match? (matchers/embeds {:matched?  true
-                                   :unmatched nil?
-                                   :matched   [any? any?]})
-                  (#'core/matches-in-any-order? matchers [5 4 1 2] true [])))
-      (is (match? (matchers/embeds {:matched?  true
-                                    :unmatched nil?
-                                    :matched   [any? any?]})
-                  (#'core/matches-in-any-order? matchers [5 1 3 2] true []))))
-
-    (testing "works well with identical matchers"
-      (is (match? (matchers/embeds {:matched?  true
-                                    :unmatched empty?
-                                    :matched   [any? any?]})
-                  (#'core/matches-in-any-order? [(matchers/equals 2) (matchers/equals 2)] [2 2] false []))))
-
-    (testing "mismatch if there are more matchers than actual elements"
-      (is (match? {::result/type  :mismatch
-                   ::result/value (matchers/in-any-order [(model/->Missing any?) 5])
-                   ::result/weight 1}
-                  (#'core/match-any-order matchers [5] false)))
-      (is (match? {::result/type   :mismatch
-                   ::result/value  (matchers/in-any-order [5 (model/->Missing any?)])
-                   ::result/weight 1}
-                  (#'core/match-any-order matchers [5] true))))))
+                                                                                                (testing "mismatch if there are more matchers than actual elements"
+                                                                                                  (is (match? {::result/type  :mismatch
+                                                                                                               ::result/value (matchers/in-any-order [(model/->Missing any?) 5])
+                                                                                                               ::result/weight 1}
+                                                                                                              (#'core/match-any-order matchers [5] false)))
+                                                                                                  (is (match? {::result/type   :mismatch
+                                                                                                               ::result/value  (matchers/in-any-order [5 (model/->Missing any?)])
+                                                                                                               ::result/weight 1}
+                                                                                                              (#'core/match-any-order matchers [5] true))))))
 
 (deftest matching-for-absence-in-map
-    (is (= {::result/type   :match
-            ::result/value  {:a 42}
-            ::result/weight 0}
-           (core/match (matchers/equals {:a (matchers/equals 42)
-                                  :b matchers/absent})
-                       {:a 42})))
-
-    (is (match? {::result/type   :mismatch
-                 ::result/value  {:a 42
-                                  :b {:actual 43}}
-                 ::result/weight #(or (= 1 %) (= 2 %))}
-                (core/match (matchers/embeds {:a (matchers/equals 42)
+  (is (= {::result/type   :match
+          ::result/value  {:a 42}
+          ::result/weight 0}
+         (core/match (matchers/equals {:a (matchers/equals 42)
                                        :b matchers/absent})
-                            {:a 42
-                             :b 43}))))
+           {:a 42})))
+
+  (is (match? {::result/type   :mismatch
+               ::result/value  {:a 42
+                                :b {:actual 43}}
+               ::result/weight #(or (= 1 %) (= 2 %))}
+              (core/match (matchers/embeds {:a (matchers/equals 42)
+                                            :b matchers/absent})
+                {:a 42
+                 :b 43}))))
 
 (deftest absent-interaction-with-keys-pointing-to-nil-values
   (is (match? {::result/type   :mismatch
                ::result/value  {:a 42
                                 :b {:actual nil}}
                ::result/weight 2}
-         (core/match (matchers/equals {:a (matchers/equals 42)
-                                       :b matchers/absent})
-                     {:a 42
-                      :b nil}))))
+              (core/match (matchers/equals {:a (matchers/equals 42)
+                                            :b matchers/absent})
+                {:a 42
+                 :b nil}))))
 
 (deftest using-absent-incorrectly-outside-of-a-map
   (is (match? {::result/type   :mismatch
                ::result/value  [42 {:message "`absent` matcher should only be used as the value in a map"}]
                ::result/weight 1}
               (core/match (matchers/equals [(matchers/equals 42) matchers/absent])
-                          [42]))))
+                [42]))))
 
-;(tabular
-;  (fact "Providing seq/map matcher with incorrect input leads to automatic mismatch"
-;    (core/match (?matcher 1) 1)
-;    => (just {::result/type   :mismatch
-;              ::result/value  (sweet/contains {:expected-type-msg
-;                                               #(str/starts-with? % (-> ?matcher var meta :name str))
-;                                               :provided
-;                                               "provided: 1"})
-;              ::result/weight number?}))
-;  ?matcher
-;  prefix
-;  embeds)
+(deftest let-us-think-of-a-name-later
+  (are [?matcher]
+       ;; expression - must return a truthy value to pass 
+       (match? {::result/type   :mismatch
+                ::result/value  {:expected-type-msg
+                                 #(str/starts-with? % (-> ?matcher var meta :name str))
+                                 :provided
+                                 "provided: 1"}
+                ::result/weight number?}
+               (core/match (?matcher 1) 1))
+    ;; values to be bound, one at a time, to ?matcher
+    matchers/prefix
+    matchers/embeds))
 
 (def pred-set #{(pred-matcher odd?) (pred-matcher pos?)})
 (def pred-seq [(pred-matcher odd?) (pred-matcher pos?)])
@@ -505,53 +498,53 @@
            (core/match (matchers/set-equals pred-seq) #{1 3}))))
 
   (testing "embeds /equals mismatches due to type"
-        (is (match? {::result/type   :mismatch
-                     ::result/value  {:actual   #{1 3}
-                                      :expected any?}
-                     ::result/weight 1}
-                    (core/match (matchers/equals pred-seq) #{1 3})))
-        (is (match? {::result/type   :mismatch
-                     ::result/value  {:actual   [1 3]
-                                      :expected any?}
-                     ::result/weight 1}
-                    (core/match (matchers/equals pred-set) [1 3])))
-        (is (match? {::result/type   :mismatch
-                     ::result/value  {:actual   #{1 3}
-                                      :expected any?}
-                     ::result/weight 1}
-                    (core/match (matchers/embeds pred-seq) #{1 3})))
-        (is (match? {::result/type   :mismatch
-                     ::result/value  {:actual   [1 3]
-                                      :expected any?}
-                     ::result/weight 1}
-                    (core/match (matchers/embeds pred-set) [1 3])))
-        (is (match? {::result/type   :mismatch
-                     ::result/value  {:expected-type-msg #"^embeds *"
-                                      :provided          #"^provided: 1"}
-                     ::result/weight 1}
-                    (core/match (matchers/embeds 1) [1]))))
+    (is (match? {::result/type   :mismatch
+                 ::result/value  {:actual   #{1 3}
+                                  :expected any?}
+                 ::result/weight 1}
+                (core/match (matchers/equals pred-seq) #{1 3})))
+    (is (match? {::result/type   :mismatch
+                 ::result/value  {:actual   [1 3]
+                                  :expected any?}
+                 ::result/weight 1}
+                (core/match (matchers/equals pred-set) [1 3])))
+    (is (match? {::result/type   :mismatch
+                 ::result/value  {:actual   #{1 3}
+                                  :expected any?}
+                 ::result/weight 1}
+                (core/match (matchers/embeds pred-seq) #{1 3})))
+    (is (match? {::result/type   :mismatch
+                 ::result/value  {:actual   [1 3]
+                                  :expected any?}
+                 ::result/weight 1}
+                (core/match (matchers/embeds pred-set) [1 3])))
+    (is (match? {::result/type   :mismatch
+                 ::result/value  {:expected-type-msg #"^embeds *"
+                                  :provided          #"^provided: 1"}
+                 ::result/weight 1}
+                (core/match (matchers/embeds 1) [1]))))
 
   (testing "embeds /set-equals mismatches due to type"
-        (is (match? {::result/type   :mismatch
-                     ::result/value  {:actual   [1 3]
-                                      :expected any?}
-                     ::result/weight 1}
-                    (core/match (matchers/set-embeds pred-seq) [1 3])))
-        (is (match? {::result/type   :mismatch
-                     ::result/value  {:actual   [1 3]
-                                      :expected any?}
-                     ::result/weight 1}
-                    (core/match (matchers/set-equals pred-seq) [1 3])))
-        (is (match? {::result/type   :mismatch
-                     ::result/value  {:expected-type-msg #"^set-embeds*"
-                                      :provided          #"^provided: 1"}
-                     ::result/weight 1}
-                    (core/match (matchers/set-embeds 1) [1 3])))
-        (is (match? {::result/type   :mismatch
-                     ::result/value  {:expected-type-msg #"^set-equals*"
-                                      :provided          #"^provided: 1"}
-                     ::result/weight 1}
-                    (core/match (matchers/set-equals 1) [1 3]))))
+    (is (match? {::result/type   :mismatch
+                 ::result/value  {:actual   [1 3]
+                                  :expected any?}
+                 ::result/weight 1}
+                (core/match (matchers/set-embeds pred-seq) [1 3])))
+    (is (match? {::result/type   :mismatch
+                 ::result/value  {:actual   [1 3]
+                                  :expected any?}
+                 ::result/weight 1}
+                (core/match (matchers/set-equals pred-seq) [1 3])))
+    (is (match? {::result/type   :mismatch
+                 ::result/value  {:expected-type-msg #"^set-embeds*"
+                                  :provided          #"^provided: 1"}
+                 ::result/weight 1}
+                (core/match (matchers/set-embeds 1) [1 3])))
+    (is (match? {::result/type   :mismatch
+                 ::result/value  {:expected-type-msg #"^set-equals*"
+                                  :provided          #"^provided: 1"}
+                 ::result/weight 1}
+                (core/match (matchers/set-equals 1) [1 3]))))
 
   (testing "embeds /set-equals mismatches due to content"
     (is (match? {::result/type   :mismatch
@@ -598,13 +591,10 @@
                  ::result/value  (matchers/in-any-order [1 (model/->Missing any?)])
                  ::result/weight 1}
                 (core/match (matchers/in-any-order even-odd-seq) [1])))
-
-    ;    (core/match (matchers/equals even-odd-set) #{1})
-    ;    => (just {::result/type   :mismatch
-    ;              ::result/value  (just #{1 (just (model/->Missing anything))}
-    ;                                    :in-any-order)
-    ;              ::result/weight 1})
-))
+    (is (match? {::result/type   :mismatch
+                 ::result/value  #{1 (model/->Missing any?)}
+                 ::result/weight 1}
+                (core/match (matchers/equals even-odd-set) #{1})))))
 
 (deftest in-any-order-minimal-mismatch-test
   (is (= {::result/type   :mismatch
@@ -615,18 +605,16 @@
 
   (is (match? {::result/type   :mismatch
                ::result/value  (matchers/in-any-order [{:a "1" :x (model/->Mismatch "12" "12=")}
-                                      {:a "2" :x (model/->Mismatch "14" "14=")}])
+                                                       {:a "2" :x (model/->Mismatch "14" "14=")}])
                ::result/weight 2}
               (core/match (matchers/in-any-order [(matchers/equals {:a (matchers/equals "2") :x (matchers/equals "14")})
                                                   (matchers/equals {:a (matchers/equals "1") :x (matchers/equals "12")})])
-                          [{:a "1" :x "12="} {:a "2" :x "14="}])))
+                [{:a "1" :x "12="} {:a "2" :x "14="}])))
 
   (is (match? {::result/type   :mismatch
                ::result/value  (matchers/in-any-order [{:a "2" :x (model/->Mismatch "14" "14=")}
-                                      {:a "1" :x (model/->Mismatch "12" "12=")}])
+                                                       {:a "1" :x (model/->Mismatch "12" "12=")}])
                ::result/weight 2}
               (core/match (matchers/in-any-order [(matchers/equals {:a (matchers/equals "2") :x (matchers/equals "14")})
                                                   (matchers/equals {:a (matchers/equals "1") :x (matchers/equals "12")})])
-                          [{:a "1" :x "12="} {:a "2" :x "14="}]))))
-
-(spec.test/unstrument)
+                [{:a "1" :x "12="} {:a "2" :x "14="}]))))

--- a/test/clj/matcher_combinators/core_test.clj
+++ b/test/clj/matcher_combinators/core_test.clj
@@ -191,11 +191,12 @@
   {:max-size 5}
   (prop/for-all [expected (gen/one-of [(gen/vector gen/any-equatable)
                                        (gen/list   gen/any-equatable)])
-                 actual   (gen/such-that (complement sequential?) gen/any-equatable)
+                 actual   gen/any-equatable
                  m (gen/elements [matchers/equals matchers/in-any-order])]
-                (not
-                 (core/indicates-match?
-                  (core/match (m expected) actual)))))
+                (or (sequential? actual)
+                    (not
+                     (core/indicates-match?
+                      (core/match (m expected) actual))))))
 
 (spec.test/instrument)
 

--- a/test/clj/matcher_combinators/matchers_test.clj
+++ b/test/clj/matcher_combinators/matchers_test.clj
@@ -1,14 +1,13 @@
 (ns matcher-combinators.matchers-test
-  (:require [clojure.test :refer [deftest testing is use-fixtures]]
+  (:require [clojure.math.combinatorics :as combo]
+            [clojure.test :refer [deftest is testing use-fixtures]]
+            [clojure.test.check.clojure-test :refer [defspec]]
             [clojure.test.check.generators :as gen]
             [clojure.test.check.properties :as prop]
-            [clojure.test.check.clojure-test :refer [defspec]]
-            [clojure.math.combinatorics :as combo]
-            [matcher-combinators.matchers :as m]
             [matcher-combinators.core :as c]
-            [matcher-combinators.test]
+            [matcher-combinators.matchers :as m]
             [matcher-combinators.result :as result]
-            [matcher-combinators.utils :as utils]
+            [matcher-combinators.test]
             [matcher-combinators.test-helpers :as test-helpers :refer [abs-value-matcher]])
   (:import [matcher_combinators.model Mismatch Missing InvalidMatcherType]))
 

--- a/test/clj/matcher_combinators/matchers_test.clj
+++ b/test/clj/matcher_combinators/matchers_test.clj
@@ -159,30 +159,30 @@
 
 (deftest equals-with-records
   (testing "matching"
-        (let [a (->Point 1 2)]
-          (is (match? {::result/type :match
-                       ::result/value a
-                       ::result/weight 0}
-                      (c/match (m/equals a) a)))))
+    (let [a (->Point 1 2)]
+      (is (match? {::result/type :match
+                   ::result/value a
+                   ::result/weight 0}
+                  (c/match (m/equals a) a)))))
 
   (testing "mismatching with same type and different values"
-        (let [a (->Point 1 2)
-              b (->Point 2 2)]
-          (is (match? {::result/type :mismatch
-                       ::result/value {:x {:actual 2
-                                           :expected 1}
-                                       :y 2}
-                       ::result/weight 1}
-                      (c/match (m/equals a) b)))))
+    (let [a (->Point 1 2)
+          b (->Point 2 2)]
+      (is (match? {::result/type :mismatch
+                   ::result/value {:x {:actual 2
+                                       :expected 1}
+                                   :y 2}
+                   ::result/weight 1}
+                  (c/match (m/equals a) b)))))
 
   (testing "mismatching with same values and different type"
-        (let [a (->Point 1 2)
-              b (->BluePoint 1 2)]
-          (is (match? {::result/type :mismatch
-                          ::result/value {:actual b
-                                          :expected a}
-                          ::result/weight 1}
-                      (c/match (m/equals a) b))))))
+    (let [a (->Point 1 2)
+          b (->BluePoint 1 2)]
+      (is (match? {::result/type :mismatch
+                   ::result/value {:actual b
+                                   :expected a}
+                   ::result/weight 1}
+                  (c/match (m/equals a) b))))))
 
 (deftest embeds-with-records
   (testing "matching"
@@ -228,9 +228,9 @@
                                  (not (instance? java.util.regex.Pattern v))
                                  (not (fn? v))))
                     gen/any)]
-                (= m/equals
-                   (m/matcher-for v)
-                   (m/matcher-for v {}))))
+    (= m/equals
+       (m/matcher-for v)
+       (m/matcher-for v {}))))
 
 (deftest matcher-for-special-cases
   (testing "matcher for a fn is pred"
@@ -353,10 +353,10 @@
                  expected (gen/one-of [gen/small-integer
                                        gen-processable-double
                                        gen-bigdec])]
-                (c/indicates-match?
-                 (c/match
-                  (m/within-delta delta expected)
-                  (+ expected delta)))))
+    (c/indicates-match?
+     (c/match
+       (m/within-delta delta expected)
+       (+ expected delta)))))
 
 (deftest within-delta-edge-cases
   (testing "+/-infinity and NaN return false (instead of throwing)"

--- a/test/clj/matcher_combinators/midje_test.clj
+++ b/test/clj/matcher_combinators/midje_test.clj
@@ -301,14 +301,12 @@
                          :f 5
                          :g 17}}}]
     (fact "nested maps inside of an `embeds` of a match-equals are treated as equals"
-          payload
-          =not=> (match-equals {:a {:b {:c 1}
-                                    :d (m/embeds {:e {:inner-e {:x 1}}})}})
-          payload
-          => (match-equals {:a {:b {:c 1}
-                                :d (m/embeds {:e {:inner-e {:x 1 :y 2}}})}}))))
-
-
+      payload
+      =not=> (match-equals {:a {:b {:c 1}
+                                :d (m/embeds {:e {:inner-e {:x 1}}})}})
+      payload
+      => (match-equals {:a {:b {:c 1}
+                            :d (m/embeds {:e {:inner-e {:x 1 :y 2}}})}}))))
 
 (facts "match-equals"
   (fact "normal loose matching passes"

--- a/test/clj/matcher_combinators/midje_test.clj
+++ b/test/clj/matcher_combinators/midje_test.clj
@@ -1,13 +1,14 @@
 (ns matcher-combinators.midje-test
-  (:require [midje.sweet :as midje :refer [fact facts => falsey]]
-            [matcher-combinators.core :as core]
+  (:require [matcher-combinators.core :as core]
             [matcher-combinators.matchers :as m]
-            [matcher-combinators.midje :refer [match throws-match match-with match-roughly match-equals]]
+            [matcher-combinators.midje :refer [match match-equals
+                                               match-roughly match-with throws-match]]
             [matcher-combinators.model :as model]
             [matcher-combinators.result :as result]
             [matcher-combinators.test-helpers :refer [abs-value-matcher]]
-            [orchestra.spec.test :as spec.test]
-            [midje.emission.api :as emission])
+            [midje.emission.api :as emission]
+            [midje.sweet :as midje :refer [=> fact facts falsey]]
+            [orchestra.spec.test :as spec.test])
   (:import [clojure.lang ExceptionInfo]))
 
 (spec.test/instrument)

--- a/test/clj/matcher_combinators/parser_test.clj
+++ b/test/clj/matcher_combinators/parser_test.clj
@@ -77,12 +77,12 @@
 (defspec test-scalars
   (testing "scalar values act as equals matchers"
     (prop/for-all [i gen-scalar]
-                  (= (core/match i i)
-                     (core/match (equals i) i)))
+      (= (core/match i i)
+         (core/match (equals i) i)))
 
     (prop/for-all [[i j] gen-scalar-pair]
-                  (= (core/match i j)
-                     (core/match (equals i) j)))))
+      (= (core/match i j)
+         (core/match (equals i) j)))))
 
 (deftest test-maps
   (testing "act as equals matcher"

--- a/test/clj/matcher_combinators/parser_test.clj
+++ b/test/clj/matcher_combinators/parser_test.clj
@@ -1,12 +1,11 @@
 (ns matcher-combinators.parser-test
-  (:require [clojure.test :as t :refer [deftest testing is]]
-            [matcher-combinators.parser :as parser]
-            [matcher-combinators.matchers :refer :all]
-            [matcher-combinators.core :as core]
+  (:require [clojure.test :as t :refer [deftest is testing]]
+            [clojure.test.check.clojure-test :refer [defspec]]
             [clojure.test.check.generators :as gen]
             [clojure.test.check.properties :as prop]
-            [clojure.test.check.clojure-test :refer [defspec]]
-            [matcher-combinators.model :as model])
+            [matcher-combinators.core :as core]
+            [matcher-combinators.matchers :refer :all]
+            [matcher-combinators.parser :as parser])
   (:import [java.net URI]))
 
 (def gen-big-decimal

--- a/test/clj/matcher_combinators/printer_test.clj
+++ b/test/clj/matcher_combinators/printer_test.clj
@@ -1,11 +1,11 @@
 (ns matcher-combinators.printer-test
-  (:require [midje.sweet :refer :all]
-            [midje.experimental :refer [for-all]]
-            [matcher-combinators.printer :as printer]
-            [matcher-combinators.model :as model]
+  (:require [clojure.pprint :as pprint]
             [clojure.test.check.generators :as gen]
             [colorize.core :as colorize]
-            [clojure.pprint :as pprint]))
+            [matcher-combinators.model :as model]
+            [matcher-combinators.printer :as printer]
+            [midje.experimental :refer [for-all]]
+            [midje.sweet :refer :all]))
 
 (def simple-double (gen/double* {:infinite? false
                                  :NaN?      false}))

--- a/test/clj/matcher_combinators/printer_test.clj
+++ b/test/clj/matcher_combinators/printer_test.clj
@@ -19,8 +19,8 @@
 (facts "on how we markup expressions that need special coloring"
   (fact "regular clojure expressions are not marked-up at all"
     (for-all [expression any]
-             {:num-tests 100}
-             (printer/markup-expression expression) => expression))
+      {:num-tests 100}
+      (printer/markup-expression expression) => expression))
 
   (fact "Mismatches are marked up in yellow and red"
     (printer/markup-expression (model/->Mismatch 1 2))
@@ -30,11 +30,11 @@
 
     (for-all [expected any
               actual   any]
-             {:num-tests 100}
-             (printer/markup-expression (model/->Mismatch expected actual))
-             => (list 'mismatch
-                      (list 'expected (printer/->ColorTag :yellow expected))
-                      (list 'actual (printer/->ColorTag :red actual)))))
+      {:num-tests 100}
+      (printer/markup-expression (model/->Mismatch expected actual))
+      => (list 'mismatch
+               (list 'expected (printer/->ColorTag :yellow expected))
+               (list 'actual (printer/->ColorTag :red actual)))))
 
   (fact "Missing values are marked up in red"
     (printer/markup-expression (model/->Missing 42))
@@ -42,10 +42,10 @@
              (printer/->ColorTag :red 42))
 
     (for-all [expected any]
-             {:num-tests 100}
-             (printer/markup-expression (model/->Missing expected))
-             => (list 'missing
-                      (printer/->ColorTag :red expected))))
+      {:num-tests 100}
+      (printer/markup-expression (model/->Missing expected))
+      => (list 'missing
+               (printer/->ColorTag :red expected))))
 
   (fact "Unexpected values are also marked up in red"
     (printer/markup-expression (model/->Unexpected 42))
@@ -53,10 +53,10 @@
              (printer/->ColorTag :red 42))
 
     (for-all [actual any]
-             {:num-tests 100}
-             (printer/markup-expression (model/->Unexpected actual))
-             => (list 'unexpected
-                      (printer/->ColorTag :red actual)))))
+      {:num-tests 100}
+      (printer/markup-expression (model/->Unexpected actual))
+      => (list 'unexpected
+               (printer/->ColorTag :red actual)))))
 
 (midje.config/with-augmented-config {:partial-prerequisites true}
   (facts "On printing"
@@ -73,5 +73,5 @@
       => "{:aaaaaaaaaaaa [100000000 100000000 100000000 100000000 100000000],\n :bbbbbbbbbbbb [200000000 200000000 200000000 200000000 200000000]}\n"
 
       (for-all [exp any]
-               {:num-tests 100}
-               (printer/as-string exp) => (with-out-str (pprint/pprint exp))))))
+        {:num-tests 100}
+        (printer/as-string exp) => (with-out-str (pprint/pprint exp))))))

--- a/test/clj/matcher_combinators/standalone_test.clj
+++ b/test/clj/matcher_combinators/standalone_test.clj
@@ -1,9 +1,8 @@
 (ns matcher-combinators.standalone-test
-  (:require [orchestra.spec.test :as spec.test]
-            [clojure.test :refer [deftest testing is use-fixtures]]
+  (:require [clojure.test :refer [deftest is testing use-fixtures]]
             [matcher-combinators.matchers :as m]
-            [matcher-combinators.result :as result]
-            [matcher-combinators.standalone :as standalone]))
+            [matcher-combinators.standalone :as standalone]
+            [orchestra.spec.test :as spec.test]))
 
 (use-fixtures :once
   (fn [f]

--- a/test/clj/matcher_combinators/test_test.clj
+++ b/test/clj/matcher_combinators/test_test.clj
@@ -1,8 +1,7 @@
 (ns matcher-combinators.test-test
-  (:require [clojure.test :refer [use-fixtures deftest testing is are]]
-            [matcher-combinators.test :refer :all]
-            [matcher-combinators.core :as core]
+  (:require [clojure.test :refer [are deftest is testing use-fixtures]]
             [matcher-combinators.matchers :as m]
+            [matcher-combinators.test :refer :all]
             [matcher-combinators.test-helpers :as test-helpers :refer [abs-value-matcher]])
   (:import [clojure.lang ExceptionInfo]))
 

--- a/test/cljc/matcher_combinators/test_helpers.cljc
+++ b/test/cljc/matcher_combinators/test_helpers.cljc
@@ -1,10 +1,7 @@
 (ns matcher-combinators.test-helpers
-  (:require [clojure.test.check.generators :as gen]
-            #?(:cljs [clojure.spec.test.alpha :as spec.test]
+  (:require #?(:cljs [clojure.spec.test.alpha :as spec.test]
                :clj  [orchestra.spec.test :as spec.test])
-            [matcher-combinators.core :as core]
-            [matcher-combinators.result :as result]
-            [matcher-combinators.model :as model]))
+            [matcher-combinators.core :as core]))
 
 (defn instrument
   "Test fixture to turn on clojure.spec instrumentation."


### PR DESCRIPTION
We're standardizing on clojure.test at NU. This PR updates some tests to clojure.test and also adds clojure-lsp to the project (hence all the reformatting). The meat of this PR is in core_test.clj