### PR TITLE
`Via` matcher

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,18 @@ All notable changes to this project will be documented in this file. This
 change log follows the conventions of
 [keepachangelog.com](http://keepachangelog.com/).
 
+## [3.6.0]
+- add `via` matcher, which transforms the `actual` data-structure before applying the
+  `expected` matcher.
+
+  For example, it allows one to match a nested string as an edn map:
+  ```
+  (is (match? {:payloads [(m/via read-string {:foo :bar})]}
+              {:payloads [\"{:foo :bar}\"]}))
+  ```
+
+  (additional context in [#148](https://github.com/nubank/matcher-combinators/issues/148) and [#175](https://github.com/nubank/matcher-combinators/issues/175))
+
 ## [3.5.1]
 - warn that in-any-order is expensive
 

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject nubank/matcher-combinators "3.5.1"
+(defproject nubank/matcher-combinators "3.6.0"
   :description "Library for creating matcher combinator to compare nested data structures"
   :url "https://github.com/nubank/matcher-combinators"
   :license {:name "Apache License, Version 2.0"}
@@ -8,13 +8,10 @@
                              :password :env/clojars_passwd
                              :sign-releases false}]]
 
-  :dependencies [[org.clojure/clojure "1.11.0"]
+  :dependencies [[org.clojure/clojure "1.11.1"]
                  [org.clojure/spec.alpha "0.3.218"]
                  [org.clojure/math.combinatorics "0.1.6"]
-                 [midje "1.10.5" :exclusions [org.clojure/clojure]]
-                 ;; override midje's dependency on an old version
-                 ;; of pretty
-                 [io.aviso/pretty "1.1.1"]]
+                 [midje "1.10.6" :exclusions [org.clojure/clojure]]]
 
   :source-paths ["src/clj" "src/cljc"]
   :test-paths   ["test/clj" "test/cljc"]

--- a/src/cljc/matcher_combinators/matchers.cljc
+++ b/src/cljc/matcher_combinators/matchers.cljc
@@ -1,8 +1,8 @@
 (ns matcher-combinators.matchers
-  (:require [clojure.string :as string]
+  (:require #?(:cljs [matcher-combinators.core :refer [Absent]])
+            [clojure.string :as string]
             [matcher-combinators.core :as core]
-            [matcher-combinators.utils :as utils]
-            #?(:cljs [matcher-combinators.core :refer [Absent]]))
+            [matcher-combinators.utils :as utils])
   #?(:clj (:import [matcher_combinators.core Absent])))
 
 (defn- non-internal-record? [v]
@@ -15,10 +15,10 @@
 
   When `expected` is:
    - A scalar or function: Value equality is used
-   - A composite data-structure (map, vector, etc): each element in `actual` must 
-  match a corresponding element in `expected`. Consistent with other matchers, 
-  equals is not recursively applied to sub-elements. This means that nested maps, 
-  for example, continue using their default matcher. If you want to do a deep  
+   - A composite data-structure (map, vector, etc): each element in `actual` must
+  match a corresponding element in `expected`. Consistent with other matchers,
+  equals is not recursively applied to sub-elements. This means that nested maps,
+  for example, continue using their default matcher. If you want to do a deep
   match, consider using `match-with` instead."
   [expected]
   (cond
@@ -65,7 +65,7 @@
 (defn in-any-order
   "Matcher that will match when the given a list that is the same as the
   `expected` list but with elements in a different order.
-  
+
   WARNING: in-any-order can match each expected element against every value
   in the actual sequence, which may be cost prohibitive for large sequences
   Consider sorting the expected and actual sequences and comparing those instead."
@@ -100,6 +100,19 @@
   leads to very unreadable match assertions"
   [expected]
   (core/->Mismatcher expected))
+
+(defn via
+  "A matcher that transforms the `actual` data-structure before applying the
+  `expected` matcher.
+
+  For example, it allows one to match a nested string as an edn map:
+  ```
+  (is (match? {:payloads [(m/via read-string {:foo :bar})]}
+              {:payloads [\"{:foo :bar}\"]}))
+  ```
+  "
+  [transform-actual-fn expected]
+  (core/->ViaMatcher transform-actual-fn expected))
 
 #?(:cljs (defn- cljs-uri [expected]
            (core/->CljsUriEquals expected)))


### PR DESCRIPTION
it which transforms the `actual` data-structure before applying the `expected` matcher.

For example, it allows one to match a nested string as an clojure map:
```
(is (match? {:payloads [(m/via read-string {:foo :bar})]}
            {:payloads [\"{:foo :bar}\"]}))
```

(additional context in [#148](https://github.com/nubank/matcher-combinators/issues/148) and [#175](https://github.com/nubank/matcher-combinators/issues/175))

also bump midje and remove now unneeded `io.aviso/pretty` version pinning