### PR TITLE
docs: add slack chat badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@ Library for making assertions about nested data structures.
 _current version:_
 
 [![Current Version](https://img.shields.io/clojars/v/nubank/matcher-combinators.svg)](https://clojars.org/nubank/matcher-combinators)
+[![join chat](https://img.shields.io/badge/slack-join_chat-brightgreen.svg)](https://clojurians.slack.com/archives/C04ABMF89D3)
 
 _docs:_
 [Found on cljdoc](https://cljdoc.xyz/d/nubank/matcher-combinators/)


### PR DESCRIPTION
Add slack chat badge for new #matcher-combinators channel on Clojurians Slack.