### PR TITLE
Make cljs version work with browser tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 /target
+/out
 /classes
 /checkouts
 pom.xml

--- a/README.md
+++ b/README.md
@@ -294,8 +294,16 @@ To run Clojure tests:
 lein midje
 ```
 
-To run Clojurescript tests:
+To run terminal-based Clojurescript tests:
 
 ```
 lein test-node
 ```
+
+To run browser-based Clojurescript tests:
+
+```
+clj -M:cljs-test watch browser-test
+```
+
+then navigate to `http://localhost:9158/`

--- a/deps.edn
+++ b/deps.edn
@@ -1,0 +1,16 @@
+{:paths ["src/clj" "src/cljc" "src/cljs"]
+ :deps {org.clojure/clojure {:mvn/version "1.11.1"}
+        org.clojure/spec.alpha {:mvn/version "0.3.218"}
+        org.clojure/math.combinatorics {:mvn/version "0.1.6"}}
+
+ :aliases
+ {:dev
+  {:extra-paths ["dev" "test/cljc" "test/cljs" "test/clj"]
+   :extra-deps {org.clojure/test.check {:mvn/version "1.1.1"}
+                orchestra/orchestra {:mvn/version "2021.01.01-1"}}}
+
+  :cljs-test
+  {:extra-paths ["test/cljc" "test/cljs"]
+   :main-opts ["-m" "shadow.cljs.devtools.cli"]
+   :extra-deps {org.clojure/test.check {:mvn/version "1.1.1"}
+                thheller/shadow-cljs {:mvn/version "2.18.0"}}}}}

--- a/shadow-cljs.edn
+++ b/shadow-cljs.edn
@@ -1,0 +1,9 @@
+{:deps   {}
+ :source-paths ["src/clj" "src/cljc" "src/cljs" "test"]
+ :builds {:browser-test {:target           :browser-test
+                         :test-dir         "web/public/js/test"
+                         :ns-regexp        "-test$"
+                         :compiler-options {:static-fns false}
+                         :devtools         {:http-port          9158
+                                            :http-resource-root "public"
+                                            :http-root          "web/public/js/test"}}}}

--- a/shadow-cljs.edn
+++ b/shadow-cljs.edn
@@ -1,9 +1,9 @@
 {:deps   {}
  :source-paths ["src/clj" "src/cljc" "src/cljs" "test"]
  :builds {:browser-test {:target           :browser-test
-                         :test-dir         "web/public/js/test"
+                         :test-dir         "out/public/js/test"
                          :ns-regexp        "-test$"
                          :compiler-options {:static-fns false}
                          :devtools         {:http-port          9158
                                             :http-resource-root "public"
-                                            :http-root          "web/public/js/test"}}}}
+                                            :http-root          "out/public/js/test"}}}}

--- a/test/cljs/matcher_combinators/cljs_example_test.cljs
+++ b/test/cljs/matcher_combinators/cljs_example_test.cljs
@@ -52,11 +52,18 @@
                      {:foo 1}
                      (bang!))))
 
+
+(deftest passing-match
+  (is (match? {:a 2} {:a 2 :b 1})))
+
 (comment
   (deftest match?-no-actual-arg
     (testing "fails with nice message when you don't provide an `actual` arg to `match?`"
       (is (match? 1)
           :in-wrong-place)))
+
+  (deftest failing-match
+    (is (match? 1 2)))
 
   (deftest thrown-match?-no-actual-arg
     (testing "fails with nice message when you don't provide an `actual` arg to `thrown-match?`"

--- a/test/cljs/matcher_combinators/cljs_example_test.cljs
+++ b/test/cljs/matcher_combinators/cljs_example_test.cljs
@@ -52,7 +52,6 @@
                      {:foo 1}
                      (bang!))))
 
-
 (deftest passing-match
   (is (match? {:a 2} {:a 2 :b 1})))
 


### PR DESCRIPTION
Should address https://github.com/nubank/matcher-combinators/issues/156 and https://github.com/nubank/matcher-combinators/issues/83, which @zampino and I ran into today ourselves.
The idea behind the fix is to apply the changes done in https://github.com/nubank/matcher-combinators/commit/7635d040fb81ad44b3587644d75bba8961269dc7 for clj clojure.test to the cljs branch of the code.

note that I still haven't figured out how to get ansi color escape codes to print well in the browser. If anyone has ideas please chime in. (EDIT: calling `(matcher-combinators.ansi-color/disable!)
` from https://github.com/nubank/matcher-combinators/pull/196 can do it)
![20221213_17h25m12s_grim](https://user-images.githubusercontent.com/94817/207388649-712283bf-704c-40a2-a2e5-a13c50e34116.png)

I'm adding a `deps.edn` file for ease of launching `shadow-cljs`. I imagine nubank will still do deploys using its `lein` based-infra (assuming a migration over to clj deps hasn't happened yet) but probably still nice to have `deps.edn` as mentioned also by @lread in https://github.com/nubank/matcher-combinators/issues/188
