### PR TITLE
Allow providing a description to pred matcher

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ change log follows the conventions of
 [keepachangelog.com](http://keepachangelog.com/).
 
 ## Unreleased
+- Add 2-arity `pred` matcher where the second argument is a description text.
+  Useful for mismatch messages when the pred is an anonymous function.
 - Allow globally configuring ANSI color emission via newly added `enable!` and
   `disable!` functions in `matcher-combinators.ansi-color`
 

--- a/src/cljc/matcher_combinators/matchers.cljc
+++ b/src/cljc/matcher_combinators/matchers.cljc
@@ -88,9 +88,9 @@
   (core/->Absent))
 
 (defn pred
-  "Matcher that will match when `pred` of the actual value returns true."
-  [pred]
-  (core/->PredMatcher pred `(~'pred ~pred)))
+  "Matcher that will match when `pred-fn` of the actual value returns true."
+  ([pred-fn] (pred pred-fn `(~'pred ~pred)))
+  ([pred-fn desc] (core/->PredMatcher pred-fn desc)))
 
 (defn mismatch
   "Negation matcher that takes in an `expected` matcher and passes when it

--- a/test/clj/matcher_combinators/matchers_test.clj
+++ b/test/clj/matcher_combinators/matchers_test.clj
@@ -9,7 +9,8 @@
             [matcher-combinators.result :as result]
             [matcher-combinators.test :refer [match?]]
             [matcher-combinators.test-helpers :as test-helpers :refer [abs-value-matcher]])
-  (:import [matcher_combinators.model Mismatch Missing InvalidMatcherType]))
+  (:import [matcher_combinators.model Mismatch Missing InvalidMatcherType]
+           [java.time Instant]))
 
 (use-fixtures :once test-helpers/instrument)
 
@@ -425,3 +426,17 @@
                  ::result/weight number?}
                 (c/match {:payloads [(m/via read-string {:foo :barz})]}
                          {:payloads [1]})))))
+
+(deftest pred-matcher
+  (testing "pred matcher without description argument gives mismatch info with the pred function's object representation"
+    (is (match? {::result/type   :mismatch
+                 ::result/value  {:payloads {:expected (list 'pred ifn?) :actual -1}}
+                 ::result/weight number?}
+                (c/match {:payloads (m/pred pos?)}
+                         {:payloads -1}))))
+  (testing "you can provide a description for clearer mismatch info"
+    (is (match? {::result/type   :mismatch
+                 ::result/value  {:payloads {:expected "positive numbers only please" :actual -1}}
+                 ::result/weight number?}
+                (c/match {:payloads (m/pred pos? "positive numbers only please")}
+                         {:payloads -1})))))


### PR DESCRIPTION
addresses https://github.com/nubank/matcher-combinators/issues/145

This is already possible in the PredMatcher defrecord. This change extends it to the `pred` matcher that calls to PredMatcher.

### without a description
```clojure
(is (match? {:payloads (m/pred pos?)}
            {:payloads -1}))

; FAIL
; expected: (match? {:payloads (m/pred pos?)} {:payloads -1})
;   actual: {:payloads
;  {:expected
;   (pred
;    #object[matcher_combinators.matchers$pred 0xbb81ab9 "matcher_combinators.matchers$pred@bb81ab9"])
;   :actual -1}}

```

### including a description

```clojure
(is (match? {:payloads (m/pred pos? "positive number")}
            {:payloads -1}))

; FAIL
; expected: (match? {:payloads (m/pred pos? "positive number")} {:payloads -1})
;   actual: {:payloads {:expected "positive number", :actual -1}}
```