### PR TITLE
Add `seq-of`, `all-of`, and `any-of` combinators

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,13 +4,9 @@ change log follows the conventions of
 [keepachangelog.com](http://keepachangelog.com/).
 
 ## Unreleased
-- Introduce `seq-of`, `any-of`, and `all-of` matchers combinators
-   * `seq-of` takes an expected matcher and creates a new matcher over a
-     sequence, where each element matches the provided expected matcher.
-   * `any-of` takes any number of matchers, successfully matching when at least
-     one matches.
-   * `all-of` takes any number of matchers, successfully matching when all
-     match.
+- Add `seq-of` matcher, which takes a matcher, successfully matching when each element matches the provided matcher.
+* Add `any-of` matcher, which takes any number of matchers, successfully matching when at least one matches.
+* Add `all-of` matcher, which takes any number of matchers, successfully matching when all match.
 
 - Add 2-arity `pred` matcher where the second argument is a description text.
   Useful for mismatch messages when the pred is an anonymous function.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@ change log follows the conventions of
 [keepachangelog.com](http://keepachangelog.com/).
 
 ## Unreleased
+- Introduce `seq-of`, `any-of`, and `all-of` matchers combinators
+   * `seq-of` takes an expected matcher and creates a new matcher over a
+     sequence, where each element matches the provided expected matcher.
+   * `any-of` takes any number of matchers, successfully matching when at least
+     one matches.
+   * `all-of` takes any number of matchers, successfully matching when all
+     match.
+
 - Add 2-arity `pred` matcher where the second argument is a description text.
   Useful for mismatch messages when the pred is an anonymous function.
 - Allow globally configuring ANSI color emission via newly added `enable!` and

--- a/README.md
+++ b/README.md
@@ -196,7 +196,9 @@ for a specific value, e.g.
 
 - `seq-of` takes an expected matcher and creates a new matcher over a sequence, where each element matches the provided expected matcher. Analogous to `clojure.core/every?`.
 
-- `either` given two matchers, successfully matches if one of them matches.
+- `any-of` given any number of matchers, successfully matches if at least one of them matches.
+
+- `all-of` given any number of matchers, successfully matches if all of them match.
 
 - `regex`: matches the `actual` value when provided an `expected-regex` using `(re-find expected-regex actual)`
 

--- a/README.md
+++ b/README.md
@@ -194,6 +194,8 @@ for a specific value, e.g.
 
 - `set-equals`/`set-embeds` similar behavior to `equals`/`embeds` for sets, but allows one to specify the matchers using a sequence so that duplicate matchers are not removed. For example, `(equals #{odd? odd?})` becomes `(equals #{odd})`, so to get arround this one should use `(set-equals [odd? odd])`.
 
+- `seq-of` takes an expected matcher and creates a new matcher over a sequence, where each element matches the provided expected matcher. Analogous to `clojure.core/every?`.
+
 - `regex`: matches the `actual` value when provided an `expected-regex` using `(re-find expected-regex actual)`
 
 - `match-with`: overrides default matchers for `expected` (scalar or arbitrarily deep stucture) (see Overriding default matchers, below)

--- a/README.md
+++ b/README.md
@@ -192,13 +192,15 @@ for a specific value, e.g.
 
   matches when the given a sequence that is the same as the `expected` sequence but with elements in a different order.  Similar to midje's `(just expected :in-any-order)`
 
-- `set-equals`/`set-embeds` similar behavior to `equals`/`embeds` for sets, but allows one to specify the matchers using a sequence so that duplicate matchers are not removed. For example, `(equals #{odd? odd?})` becomes `(equals #{odd})`, so to get arround this one should use `(set-equals [odd? odd])`.
+- `set-equals`/`set-embeds` similar behavior to `equals`/`embeds` for sets, but allows one to specify the matchers using a sequence so that duplicate matchers are not removed. For example, `(equals #{odd? odd?})` becomes `(equals #{odd})`, so to get around this one should use `(set-equals [odd? odd])`.
 
 - `seq-of` takes an expected matcher and creates a new matcher over a sequence, where each element matches the provided expected matcher. Analogous to `clojure.core/every?`.
 
+- `either` given two matchers, successfully matches if one of them matches.
+
 - `regex`: matches the `actual` value when provided an `expected-regex` using `(re-find expected-regex actual)`
 
-- `match-with`: overrides default matchers for `expected` (scalar or arbitrarily deep stucture) (see Overriding default matchers, below)
+- `match-with`: overrides default matchers for `expected` (scalar or arbitrarily deep structure) (see Overriding default matchers, below)
 
 - `within-delta`: matches numeric values that are within `expected` +/- `delta` (inclusive)
 

--- a/src/cljc/matcher_combinators/core.cljc
+++ b/src/cljc/matcher_combinators/core.cljc
@@ -513,6 +513,22 @@
        ::result/weight 1}))
   (-base-name [_] 'predicate))
 
+(defrecord Either [left right]
+  Matcher
+  (-matcher-for [this] this)
+  (-matcher-for [this _] this)
+  (-match [this actual]
+    (let [left-match-result (match left actual)]
+      (if (indicates-match? left-match-result)
+        left-match-result
+        (let [right-match-result (match right actual)]
+          (if (indicates-match? right-match-result)
+            right-match-result
+            {::result/type   :mismatch
+             ::result/value  (model/->Mismatch (list 'either left right) actual)
+             ::result/weight (max (::result/weight left-match-result) (::result/weight right-match-result))})))))
+  (-base-name [_] 'either))
+
 (defn- printable-matcher [matcher]
   (try
     (if-let [n (-base-name matcher)]

--- a/src/cljc/matcher_combinators/matchers.cljc
+++ b/src/cljc/matcher_combinators/matchers.cljc
@@ -28,6 +28,12 @@
     (map? expected)                 (core/->EqualsMap expected)
     :else                           (core/->Value expected)))
 
+(defn seq-of
+  "Matcher that will match when given a sequence where every element matches
+  the provided `expected` matcher"
+  [expected]
+  (core/->SeqOf expected))
+
 (defn set-equals
   "Matches a set in the way `(equals some-set)` would, but accepts sequences as
   the expected matcher argument, allowing one to use matchers with the same

--- a/src/cljc/matcher_combinators/matchers.cljc
+++ b/src/cljc/matcher_combinators/matchers.cljc
@@ -120,10 +120,15 @@
   [transform-actual-fn expected]
   (core/->ViaMatcher transform-actual-fn expected))
 
-(defn either
+(defn any-of
   "A matcher that successfully matches if one of the two provided matchers matches."
-  [left-expected right-expected]
-  (core/->Either left-expected right-expected))
+  [& matchers]
+  (core/->AnyOf matchers))
+
+(defn all-of
+  "A matcher that successfully matches if all provided matchers match."
+  [& matchers]
+  (core/->AllOf matchers))
 
 #?(:cljs (defn- cljs-uri [expected]
            (core/->CljsUriEquals expected)))

--- a/src/cljc/matcher_combinators/matchers.cljc
+++ b/src/cljc/matcher_combinators/matchers.cljc
@@ -120,6 +120,11 @@
   [transform-actual-fn expected]
   (core/->ViaMatcher transform-actual-fn expected))
 
+(defn either
+  "A matcher that successfully matches if one of the two provided matchers matches."
+  [left-expected right-expected]
+  (core/->Either left-expected right-expected))
+
 #?(:cljs (defn- cljs-uri [expected]
            (core/->CljsUriEquals expected)))
 

--- a/test/clj/matcher_combinators/matchers_test.clj
+++ b/test/clj/matcher_combinators/matchers_test.clj
@@ -436,25 +436,53 @@
               [{:name "Michael"
                 :id    #uuid "c70e35eb-9eb6-4e3d-b5da-1f7f80932db9"}])))
 
-(deftest either-matcher
-  (testing "top-level use of `either` gives poor mismatch info"
+(deftest any-of-matcher
+  (testing "simple any-of match"
+    (is (match? {::result/type  :match
+                 ::result/value {:a 3}}
+                (c/match (m/any-of {:a 1} {:a 3}) {:a 3}))))
+  (testing "top-level use of `any-of` gives poor mismatch info"
     (is (match? {::result/type  :mismatch
-                 ::result/value {:expected (list 'either {:a 1} {:a 2})
+                 ::result/value {:expected (list 'any-of {:a 1} {:a 2})
                                  :actual {:a 3}}}
-                (c/match (m/either {:a 1} {:a 2}) {:a 3}))))
-  (testing "low-level use of `either` gives better mismatch info"
+                (c/match (m/any-of {:a 1} {:a 2}) {:a 3}))))
+  (testing "low-level use of `any-of` gives better mismatch info"
     (is (match? {::result/type  :mismatch
-                 ::result/value {:a {:expected (list 'either 1 2)
+                 ::result/value {:a {:expected (list 'any-of 1 2)
                                      :actual 3}}}
-                (c/match {:a (m/either 1 2)} {:a 3}))))
+                (c/match {:a (m/any-of 1 2)} {:a 3}))))
 
-  (testing "`either` + `seq-of` works great"
+  (testing "`any-of` + `seq-of` works great"
     (is (match? {::result/type :mismatch
                  ::result/value [1 "2" mismatch? 4 "5" mismatch?]}
-          (c/match (m/seq-of (m/either string? int?))
+          (c/match (m/seq-of (m/any-of string? int?))
                    [1 "2" :3 4 "5" :6])))
-    (is (match? (m/seq-of (m/either string? int?))
+    (is (match? (m/seq-of (m/any-of string? int?))
                 [1 "2" 3 "4"]))))
+
+(deftest all-of-matcher
+  (testing "simple all-of match"
+    (is (match? {::result/type  :match
+                 ::result/value {:a 3}}
+                (c/match (m/all-of {:a odd?} {:a 3}) {:a 3}))))
+  (testing "top-level use of `all-of` gives poor mismatch info"
+    (is (match? {::result/type  :mismatch
+                 ::result/value {:expected (list 'all-of {:a 3} {:a 2})
+                                 :actual {:a 3}}}
+                (c/match (m/all-of {:a 3} {:a 2}) {:a 3}))))
+  (testing "low-level use of `all-of` gives better mismatch info"
+    (is (match? {::result/type  :mismatch
+                 ::result/value {:a {:expected (list 'all-of (m/equals int?) (m/equals odd?) any?)
+                                     :actual 3}}}
+                (c/match {:a (m/all-of int? odd? #(> % 5))} {:a 3}))))
+
+  (testing "`all-of` + `seq-of` works great"
+    (is (match? {::result/type :mismatch
+                 ::result/value [1 mismatch? mismatch? mismatch? mismatch? mismatch?]}
+          (c/match (m/seq-of (m/all-of int? odd?))
+                   [1 "2" :3 4 "5" :6])))
+    (is (match? (m/seq-of (m/all-of int? odd?))
+                [1 -1 3 -3]))))
 
 (deftest pred-matcher
   (testing "pred matcher without description argument gives mismatch info with the pred function's object representation"

--- a/test/clj/matcher_combinators/matchers_test.clj
+++ b/test/clj/matcher_combinators/matchers_test.clj
@@ -434,3 +434,23 @@
   (is (match? (m/seq-of {:name string? :id uuid?})
               [{:name "Michael"
                 :id    #uuid "c70e35eb-9eb6-4e3d-b5da-1f7f80932db9"}])))
+
+(deftest either-matcher
+  (testing "top-level use of `either` gives poor mismatch info"
+    (is (match? {::result/type  :mismatch
+                 ::result/value {:expected (list 'either {:a 1} {:a 2})
+                                 :actual {:a 3}}}
+                (c/match (m/either {:a 1} {:a 2}) {:a 3}))))
+  (testing "low-level use of `either` gives better mismatch info"
+    (is (match? {::result/type  :mismatch
+                 ::result/value {:a {:expected (list 'either 1 2)
+                                     :actual 3}}}
+                (c/match {:a (m/either 1 2)} {:a 3}))))
+
+  (testing "`either` + `seq-of` works great"
+    (is (match? {::result/type :mismatch
+                 ::result/value [1 "2" mismatch? 4 "5" mismatch?]}
+          (c/match (m/seq-of (m/either string? int?))
+                   [1 "2" :3 4 "5" :6])))
+    (is (match? (m/seq-of (m/either string? int?))
+                [1 "2" 3 "4"]))))

--- a/test/clj/matcher_combinators/matchers_test.clj
+++ b/test/clj/matcher_combinators/matchers_test.clj
@@ -425,3 +425,12 @@
                  ::result/weight number?}
                 (c/match {:payloads [(m/via read-string {:foo :barz})]}
                          {:payloads [1]})))))
+
+(deftest seq-of-matcher
+  (is (match? {::result/type   :mismatch
+               ::result/value  {:expected "seq-of expects a non-empty sequence" :actual []}
+               ::result/weight number?}
+        (c/match (m/seq-of int?) [])))
+  (is (match? (m/seq-of {:name string? :id uuid?})
+              [{:name "Michael"
+                :id    #uuid "c70e35eb-9eb6-4e3d-b5da-1f7f80932db9"}])))


### PR DESCRIPTION
addresses https://github.com/nubank/matcher-combinators/issues/149

an example of the difference between the new `seq-of` matcher and @dchelimsky 's temporary workaround `(defn seq-of [matcher] (fn [coll] (and (seq coll) (every? (partial matcher-combinators.standalone/match? matcher) coll))))`
![20221214_13h57m17s_grim](https://user-images.githubusercontent.com/94817/207608318-e3a1c6ce-8b52-438b-bcc7-b22f02713236.png)


not sure if this additional expressiveness is opening a can of worms in terms of the complexity available to users. It has been asked for before though in https://github.com/nubank/matcher-combinators/issues/18 and https://github.com/nubank/matcher-combinators/issues/149 and a few times during in-person chats