### PR TITLE
WIP: fix match-with for cljs

### DIFF
--- a/bb.edn
+++ b/bb.edn
@@ -12,6 +12,10 @@
   {:doc "Starts a nREPL"
    :task (apply clojure "-Adev -Sdeps '{:deps {cider/cider-nrepl {:mvn/version \"0.29.0\"}}}' -m nrepl.cmdline --middleware \"[cider.nrepl/cider-middleware]\"" *command-line-args*)}
 
+  dev:cljs
+  {:doc "Starts a ClojureScript nREPL"
+   :task (apply clojure "-M:cljs-test node-repl" *command-line-args*)}
+
   test:clj
   {:doc "run Clojure clojure.test tests"
    :task (apply clojure "-A:dev:clj-test:test-runner" *command-line-args*)}

--- a/src/cljc/matcher_combinators/matchers.cljc
+++ b/src/cljc/matcher_combinators/matchers.cljc
@@ -130,7 +130,7 @@
   [& matchers]
   (core/->AllOf matchers))
 
-#?(:cljs (defn- cljs-uri [expected]
+#?(:cljs (defn cljs-uri [expected]
            (core/->CljsUriEquals expected)))
 
 (defn matcher-for

--- a/src/cljc/matcher_combinators/parser.cljc
+++ b/src/cljc/matcher_combinators/parser.cljc
@@ -13,56 +13,95 @@
   function
   (-match [this actual]
     (core/match (matchers/pred this) actual))
+  (-matcher-for
+    ([this] (matchers/pred this))
+    ([this _t->m] (matchers/pred this)))
 
   ;; equals base types
   nil
   (-match [this actual]
     (core/match (matchers/equals this) actual))
+  (-matcher-for
+    ([_this] matchers/equals)
+    ([this t->m] (matchers/lookup-matcher this t->m)))
 
   number
   (-match [this actual]
     (core/match (matchers/equals this) actual))
+  (-matcher-for
+    ([_this] matchers/equals)
+    ([this t->m] (matchers/lookup-matcher this t->m)))
 
   string
   (-match [this actual]
     (core/match (matchers/equals this) actual))
+  (-matcher-for
+    ([_this] matchers/equals)
+    ([this t->m] (matchers/lookup-matcher this t->m)))
 
   boolean
   (-match [this actual]
     (core/match (matchers/equals this) actual))
+  (-matcher-for
+    ([_this] matchers/equals)
+    ([this t->m] (matchers/lookup-matcher this t->m)))
 
   Keyword
   (-match [this actual]
     (core/match (matchers/equals this) actual))
+  (-matcher-for
+    ([_this] matchers/equals)
+    ([this t->m] (matchers/lookup-matcher this t->m)))
 
   Symbol
   (-match [this actual]
     (core/match (matchers/equals this) actual))
+  (-matcher-for
+    ([_this] matchers/equals)
+    ([this t->m] (matchers/lookup-matcher this t->m)))
 
   UUID
   (-match [this actual]
     (core/match (matchers/equals this) actual))
+  (-matcher-for
+    ([_this] matchers/equals)
+    ([this t->m] (matchers/lookup-matcher this t->m)))
 
   goog.Uri
   (-match [this actual]
     (core/match (matchers/cljs-uri this) actual))
+  (-matcher-for
+    ([_this] matchers/cljs-uri)
+    ([this t->m] (matchers/lookup-matcher this t->m)))
 
   js/Date
   (-match [this actual]
     (core/match (matchers/equals this) actual))
+  (-matcher-for
+    ([_this] matchers/equals)
+    ([this t->m] (matchers/lookup-matcher this t->m)))
 
   Var
   (-match [this actual]
     (core/match (matchers/equals this) actual))
+  (-matcher-for
+    ([_this] matchers/equals)
+    ([this t->m] (matchers/lookup-matcher this t->m)))
 
   ;; equals nested types
   Cons
   (-match [this actual]
     (core/match (matchers/equals this) actual))
+  (-matcher-for
+    ([_this] matchers/equals)
+    ([this t->m] (matchers/lookup-matcher this t->m)))
 
   Repeat
   (-match [this actual]
     (core/match (matchers/equals this) actual))
+  (-matcher-for
+    ([_this] matchers/equals)
+    ([this t->m] (matchers/lookup-matcher this t->m)))
 
   default
   (-match [this actual]
@@ -73,10 +112,18 @@
       (or (satisfies? ISet this)
           (satisfies? ISequential this))
       (core/match (matchers/equals this) actual)))
+  (-matcher-for
+    ([this] (if (satisfies? IMap this)
+              matchers/embeds
+              matchers/equals))
+    ([this t->m] (matchers/lookup-matcher this t->m)))
 
   js/RegExp
   (-match [this actual]
-    (core/match (matchers/regex this) actual))))
+    (core/match (matchers/regex this) actual))
+  (-matcher-for
+    ([_this] matchers/equals)
+    ([this t->m] (matchers/lookup-matcher this t->m)))))
 
 #?(:clj (do
 (defmacro mimic-matcher [matcher t]
@@ -105,6 +152,6 @@
   core/Matcher
   (-matcher-for
     ([this] (matchers/pred this))
-    ([this t->m] (matchers/pred this)))
+    ([this _t->m] (matchers/pred this)))
   (-match [this actual]
     (core/match (matchers/pred this) actual)))))

--- a/src/cljc/matcher_combinators/parser.cljc
+++ b/src/cljc/matcher_combinators/parser.cljc
@@ -152,6 +152,6 @@
   core/Matcher
   (-matcher-for
     ([this] (matchers/pred this))
-    ([this _t->m] (matchers/pred this)))
+    ([this t->m] (matchers/lookup-matcher this t->m)))
   (-match [this actual]
     (core/match (matchers/pred this) actual)))))

--- a/test/clj/matcher_combinators/matchers_test.clj
+++ b/test/clj/matcher_combinators/matchers_test.clj
@@ -9,7 +9,7 @@
             [matcher-combinators.matchers :as m]
             [matcher-combinators.result :as result]
             [matcher-combinators.test :refer [match?]]
-            [matcher-combinators.test-helpers :as test-helpers :refer [abs-value-matcher]])
+            [matcher-combinators.test-helpers :as test-helpers :refer [no-match? abs-value-matcher]])
   (:import [matcher_combinators.model Mismatch Missing InvalidMatcherType]))
 
 (defn any? [_x] true)
@@ -242,9 +242,6 @@
   (testing "matcher for a regex"
     (is (= m/regex
            (m/matcher-for #"abc")))))
-
-(defn no-match? [expected actual]
-  (not (c/indicates-match? (c/match expected actual))))
 
 (deftest match-with-matcher
   (testing "processes overrides in order"

--- a/test/clj/matcher_combinators/matchers_test.clj
+++ b/test/clj/matcher_combinators/matchers_test.clj
@@ -293,6 +293,10 @@
            #{1 2}))
 
       (is (match?
+            (m/match-with [set? m/embeds]
+                          #{(m/pred odd?)})
+            #{1 2}))
+      (is (match?
            (m/match-with [set? m/embeds]
                          #{odd?})
            #{1 2}))))

--- a/test/clj/matcher_combinators/standalone_test.clj
+++ b/test/clj/matcher_combinators/standalone_test.clj
@@ -1,5 +1,5 @@
 (ns matcher-combinators.standalone-test
-  (:require [clojure.test :refer [deftest is testing use-fixtures]]
+  (:require [clojure.test :refer [deftest is testing]]
             [matcher-combinators.matchers :as m]
             [matcher-combinators.standalone :as standalone]))
 

--- a/test/cljc/matcher_combinators/test_helpers.cljc
+++ b/test/cljc/matcher_combinators/test_helpers.cljc
@@ -6,3 +6,6 @@
    (fn [actual] (= (Math/abs expected)
                    (Math/abs actual)))
    (str "equal to abs value of " expected)))
+
+(defn no-match? [expected actual]
+  (not (core/indicates-match? (core/match expected actual))))

--- a/test/cljs/matcher_combinators/cljs_example_test.cljs
+++ b/test/cljs/matcher_combinators/cljs_example_test.cljs
@@ -59,6 +59,12 @@
 (deftest passing-match
   (is (match? {:a 2} {:a 2 :b 1})))
 
+(deftest pred-match
+  (is (match? #{odd?}
+              #{1}))
+  (is (match? #{(m/pred odd?)}
+              #{1})))
+
 (comment
   (deftest match?-no-actual-arg
     (testing "fails with nice message when you don't provide an `actual` arg to `match?`"
@@ -104,19 +110,25 @@
                   {:b :c}))))
 
   (testing "sets"
-    (testing "passing cases"
-      (is (match?
-            (m/match-with [set? m/embeds]
-                          #{1})
-            #{1 2}))
+    (is (match?
+          (m/match-with [set? m/embeds]
+                        #{1})
+          #{1 2}))
 
-      (is (match?
-            (m/match-with [set? m/embeds]
-                          #{(m/pred odd?)})
-            #{1 2}))))
+    (is (match?
+          (m/match-with [set? m/embeds]
+                        #{(m/pred odd?)})
+          #{1 2})))
 
   (let [matcher (m/match-with [pos? abs-value-matcher
                                integer? m/equals]
                               5)]
     (is (match? matcher 5))
     (is (match? matcher -5))))
+
+(comment
+(ifn? odd?)
+(fn? odd?)
+(ifn? (m/pred odd?))
+(fn? (m/pred odd?))
+)

--- a/test/cljs/matcher_combinators/cljs_example_test.cljs
+++ b/test/cljs/matcher_combinators/cljs_example_test.cljs
@@ -1,14 +1,13 @@
 (ns matcher-combinators.cljs-example-test
-  (:require [clojure.test :refer [deftest testing is are]]
+  (:require [clojure.test :refer [deftest testing is]]
             [clojure.test.check.generators :as gen]
             [clojure.test.check.properties :as prop]
             [clojure.test.check.clojure-test :refer [defspec]]
             [matcher-combinators.standalone :as standalone]
             [matcher-combinators.parser]
             [matcher-combinators.matchers :as m]
-            [matcher-combinators.core :as c]
-            [matcher-combinators.test]
-            [matcher-combinators.test-helpers :as helpers])
+            [matcher-combinators.test :refer [match? thrown-match?]]
+            [matcher-combinators.test-helpers :refer [abs-value-matcher no-match?]])
   (:import [goog.Uri]))
 
 (def gen-any-equatable
@@ -45,7 +44,12 @@
                            [2 3 1])))
   (testing "`(sort 2)` throws and causes a mismatch"
     (is (not (standalone/match? (m/via sort 2)
-                                2)))))
+                                2))))
+  (testing "via + match-with allows pre-processing `actual` before applying matching"
+    (is (match? (m/match-with
+                  [vector? (fn [expected] (m/via sort expected))]
+                  {:payloads [1 2 3]})
+                {:payloads (shuffle [3 2 1])}))))
 
 (deftest exception-matching
   (is (thrown-match? ExceptionInfo
@@ -68,3 +72,51 @@
     (testing "fails with nice message when you don't provide an `actual` arg to `thrown-match?`"
       (is (thrown-match? ExceptionInfo {:a 1})
           :in-wrong-place))))
+
+(deftest match-with-test
+  (testing "Example numeric test-case"
+    (is (match? (m/match-with [number? (m/within-delta 0.05)] 1) 0.99)))
+
+  (testing "maps"
+    (testing "passing case with equals override"
+      (is (match? (m/match-with [map? m/equals]
+                                {:a :b})
+                  {:a :b})))
+    (testing "failing case with equals override"
+      (is (no-match? (m/match-with [map? m/equals]
+                                   {:a :b})
+                     {:a :b :d :e})))
+    (testing "passing case multiple scopes"
+      (is (match?
+            {:o (m/match-with [map? m/equals]
+                              {:a
+                               (m/match-with [map? m/embeds]
+                                             {:b :c})})}
+            {:o {:a {:b :c :d :e}}
+             :p :q})))
+    (testing "using `absent` matcher"
+      (is (match? (m/match-with [map? m/equals]
+                                {:a m/absent
+                                 :b :c})
+                  {:b :c}))
+      (is (match? (m/match-with [map? m/embeds]
+                                {:a m/absent})
+                  {:b :c}))))
+
+  (testing "sets"
+    (testing "passing cases"
+      (is (match?
+            (m/match-with [set? m/embeds]
+                          #{1})
+            #{1 2}))
+
+      (is (match?
+            (m/match-with [set? m/embeds]
+                          #{(m/pred odd?)})
+            #{1 2}))))
+
+  (let [matcher (m/match-with [pos? abs-value-matcher
+                               integer? m/equals]
+                              5)]
+    (is (match? matcher 5))
+    (is (match? matcher -5))))


### PR DESCRIPTION
addresses https://github.com/nubank/matcher-combinators/issues/202

it uncovered an issue with `pred` when used in `match-with` that I still need to figure out (tests are currently failing because of this)