### PR TITLE
Configure clj-kondo for ClojureScript as well

### DIFF
--- a/resources/clj-kondo.exports/nubank/matcher-combinators/config.edn
+++ b/resources/clj-kondo.exports/nubank/matcher-combinators/config.edn
@@ -1,3 +1,4 @@
 {:linters
  {:unresolved-symbol
-  {:exclude [(clojure.test/is [match? thrown-match?])]}}}
+  {:exclude [(cljs.test/is [match? thrown-match?])
+             (clojure.test/is [match? thrown-match?])]}}}


### PR DESCRIPTION
The exported clj-kondo configuration currently only considers Clojure's `clojure.test`, but not ClojureScript's `cljs.test`. Therefore you'll get linter errors when using `match?` in ClojureScript tests.