### PR TITLE
Extra info for seq-of

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,7 +176,7 @@ for a specific value, e.g.
 
 - `set-equals`/`set-embeds` similar behavior to `equals`/`embeds` for sets, but allows one to specify the matchers using a sequence so that duplicate matchers are not removed. For example, `(equals #{odd? odd?})` becomes `(equals #{odd})`, so to get around this one should use `(set-equals [odd? odd])`.
 
-- `seq-of` takes an expected matcher and creates a new matcher over a sequence, where each element matches the provided expected matcher. Analogous to `clojure.core/every?`.
+- `seq-of` takes an expected matcher and creates a new matcher over a sequence, where each element matches the provided expected matcher. Analogous to `clojure.core/every?`, although seq-of expects a non-empty sequence.
 
 - `any-of` given any number of matchers, successfully matches if at least one of them matches.
 

--- a/src/cljc/matcher_combinators/matchers.cljc
+++ b/src/cljc/matcher_combinators/matchers.cljc
@@ -30,7 +30,7 @@
 
 (defn seq-of
   "Matcher that will match when given a sequence where every element matches
-  the provided `expected` matcher"
+  the provided `expected` matcher. It expects a non-empty sequence."
   [expected]
   (core/->SeqOf expected))
 


### PR DESCRIPTION
Matcher `seq-of` expects a non-empty sequence, but it wasn't clear from the docs.