### PR TITLE
Redact fully-matched data-structures from output

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,5 @@ pom.xml.asc
 .hg/
 .clj-kondo/*
 .shadow-cljs/*
+.cpcache/*
+.lsp/*

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@ All notable changes to this project will be documented in this file. This
 change log follows the conventions of
 [keepachangelog.com](http://keepachangelog.com/).
 
+## 3.8.7 / 2023-08-31
+- [Experimental] add experimental feature to not print the entire actual data-structure on
+  mismatch, but only the mismatches.
+
 ## 3.8.6 / 2023-07-18
 - fix issue when using non-composite matchers (`m/regex`, `m/pred`, etc)
   inside `match-with`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,8 +4,11 @@ change log follows the conventions of
 [keepachangelog.com](http://keepachangelog.com/).
 
 ## 3.8.7 / 2023-09-01
-- [Experimental] add experimental feature to not print the entire actual data-structure on
-  mismatch, but only the mismatches.
+- introduce `matcher-combinators.config` namespace to toggle use of ansi color
+  codes and the new output abbreviation mode.
+- [Experimental] add `(matcher-combinators.config/enable-abbreviation!)`, an
+  experimental feature to print only the mismatched parts of a data-structure
+  while elliding the matched parts.
 - fix more issues when using non-composite matchers (`m/regex`, `m/pred`, etc)
   inside `match-with`.
 

--- a/src/clj/matcher_combinators/clj_test.clj
+++ b/src/clj/matcher_combinators/clj_test.clj
@@ -204,6 +204,7 @@
              :actual   '~form}))))))
 
 (defmethod clojure.test/assert-expr 'match-equals? [msg form]
+  ;; DEPRECATED
   (build-match-assert 'match-equals?
                       {clojure.lang.IPersistentMap matchers/equals}
                       msg
@@ -212,6 +213,7 @@
                            "                    Use (match? (matchers/match-with [map? matchers/equals] <expected>) <actual>) instead.")))
 
 (defmethod clojure.test/assert-expr 'match-roughly? [msg form]
+  ;; DEPRECATED
   (let [directive (first form)
         delta     (second form)
         the-rest  (rest (rest form))

--- a/src/cljc/matcher_combinators/ansi_color.cljc
+++ b/src/cljc/matcher_combinators/ansi_color.cljc
@@ -7,19 +7,20 @@
   *use-color*
   true)
 
-(defn- set-use-color! [v]
-  #?(:clj (alter-var-root #'*use-color* (constantly v))
-     :cljs (set! *use-color* v)))
-
-(defn enable!
-  "Thread-global way to enable the usage of ANSI color codes in matcher-combinator output."
+(defn
+  ^{:deprecated true
+    :doc "DEPRECATED! Use matcher-combinators.config/enable-ansi-color!"}
+  enable!
   []
-  (set-use-color! true))
+  #?(:clj (alter-var-root #'*use-color* (constantly true))
+     :cljs (set! *use-color* true)))
 
 (defn disable!
-  "Thread-global way to disable the usage of ANSI color codes in matcher-combinator output."
+  ^{:deprecated true
+    :doc "DEPRECATED! Use matcher-combinators.config/disable-ansi-color!"}
   []
-  (set-use-color! false))
+  #?(:clj (alter-var-root #'*use-color* (constantly false))
+     :cljs (set! *use-color* false)))
 
 (def ANSI-CODES
   {:reset              "[0m"

--- a/src/cljc/matcher_combinators/config.cljc
+++ b/src/cljc/matcher_combinators/config.cljc
@@ -17,12 +17,14 @@
      :cljs (set! *use-redaction* v)))
 
 (defn enable-redaction!
-  "Thread-global way to enable the redaction of fully-matched data-structures in matcher-combinator output."
+  "**Experimental, subject to change**
+  Thread-global way to enable the redaction of fully-matched data-structures in matcher-combinator output."
   []
   (set-use-redaction! true))
 
 (defn disable-redaction!
-  "Thread-global way to disable the redaction of fully-matched data-structures in matcher-combinator output."
+  "**Experimental, subject to change**
+  Thread-global way to disable the redaction of fully-matched data-structures in matcher-combinator output."
   []
   (set-use-redaction! false))
 

--- a/src/cljc/matcher_combinators/config.cljc
+++ b/src/cljc/matcher_combinators/config.cljc
@@ -2,31 +2,31 @@
   "Global output behavior configurations"
   (:require [matcher-combinators.ansi-color :as ansi-color]))
 
-;; Redacting fully-matched data-structures from output
-;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;; Abbreviating match results to only include mismatched data in the output
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 (def ^{:dynamic true
-       :doc "thread-local way to control, via `binding`, the redacting of fully-matched data-structures in the matcher-combinator output"}
-  *use-redaction*
+       :doc "thread-local way to control, via `binding`, the abbreviation of fully-matched data-structures in the matcher-combinator output"}
+  *use-abbreviation*
   false)
 
-(defn- set-use-redaction!
-  "internal function, use matcher-combinators.config/enable-redaction!"
+(defn- set-use-abbreviation!
+  "internal function, use matcher-combinators.config/{enable|disable}-abbreviation!"
   [v]
-  #?(:clj (alter-var-root #'*use-redaction* (constantly v))
-     :cljs (set! *use-redaction* v)))
+  #?(:clj (alter-var-root #'*use-abbreviation* (constantly v))
+     :cljs (set! *use-abbreviation* v)))
 
-(defn enable-redaction!
+(defn enable-abbreviation!
   "**Experimental, subject to change**
-  Thread-global way to enable the redaction of fully-matched data-structures in matcher-combinator output."
+  Thread-global way to enable the abbreviation of fully-matched data-structures in matcher-combinator output."
   []
-  (set-use-redaction! true))
+  (set-use-abbreviation! true))
 
-(defn disable-redaction!
+(defn disable-abbreviation!
   "**Experimental, subject to change**
-  Thread-global way to disable the redaction of fully-matched data-structures in matcher-combinator output."
+  Thread-global way to disable the abbreviation of fully-matched data-structures in matcher-combinator output."
   []
-  (set-use-redaction! false))
+  (set-use-abbreviation! false))
 
 
 ;; Disable special ANSI color characters in output

--- a/src/cljc/matcher_combinators/config.cljc
+++ b/src/cljc/matcher_combinators/config.cljc
@@ -1,0 +1,45 @@
+(ns matcher-combinators.config
+  "Global output behavior configurations"
+  (:require [matcher-combinators.ansi-color :as ansi-color]))
+
+;; Redacting fully-matched data-structures from output
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+(def ^{:dynamic true
+       :doc "thread-local way to control, via `binding`, the redacting of fully-matched data-structures in the matcher-combinator output"}
+  *use-redaction*
+  false)
+
+(defn- set-use-redaction!
+  "internal function, use matcher-combinators.config/enable-redaction!"
+  [v]
+  #?(:clj (alter-var-root #'*use-redaction* (constantly v))
+     :cljs (set! *use-redaction* v)))
+
+(defn enable-redaction!
+  "Thread-global way to enable the redaction of fully-matched data-structures in matcher-combinator output."
+  []
+  (set-use-redaction! true))
+
+(defn disable-redaction!
+  "Thread-global way to disable the redaction of fully-matched data-structures in matcher-combinator output."
+  []
+  (set-use-redaction! false))
+
+
+;; Disable special ANSI color characters in output
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+(defn- set-use-color! [v]
+  #?(:clj (alter-var-root #'ansi-color/*use-color* (constantly v))
+     :cljs (set! ansi-color/*use-color* v)))
+
+(defn enable-ansi-color!
+  "Thread-global way to enable the usage of ANSI color codes in matcher-combinator output."
+  []
+  (set-use-color! true))
+
+(defn disable-ansi-color!
+  "Thread-global way to disable the usage of ANSI color codes in matcher-combinator output."
+  []
+  (set-use-color! false))

--- a/src/cljc/matcher_combinators/core.cljc
+++ b/src/cljc/matcher_combinators/core.cljc
@@ -172,7 +172,10 @@
 (defn- with-mismatch-meta
   "Tags element with data that allows to redact matched data-structures from test output when desired"
   [elem mismatch-meta]
-  (with-meta elem {:mismatch mismatch-meta}))
+  (if #?(:clj (instance? clojure.lang.IMeta elem)
+         :cljs (satisfies? IMeta elem))
+    (with-meta elem {:mismatch mismatch-meta})
+    elem))
 
 (defn- compare-maps [expected actual unexpected-handler allow-unexpected?]
   (let [entry-results      (->> expected

--- a/src/cljc/matcher_combinators/core.cljc
+++ b/src/cljc/matcher_combinators/core.cljc
@@ -191,7 +191,7 @@
                                (reduce (fn [acc-weight result] (+ acc-weight (::result/weight result)))
                                        (if allow-unexpected? 0 (count unexpected-entries))))]
         {::result/type   :mismatch
-         ::result/value  mismatch-val
+         ::result/value  (with-meta mismatch-val {:mismatch :mismatch-map})
          ::result/weight weight}))))
 
 (def ^:private map-like?
@@ -288,7 +288,8 @@
         match-results  (take match-size match-results')]
     (if (some (complement indicates-match?) match-results)
       {::result/type   :mismatch
-       ::result/value  (type-preserving-mismatch (empty actual) (map ::result/value match-results))
+       ::result/value  (with-meta (type-preserving-mismatch (empty actual) (map ::result/value match-results))
+                                  {:mismatch :mismatch-sequence})
        ::result/weight (->> match-results
                             (map ::result/weight)
                             (reduce + 0))}

--- a/src/cljc/matcher_combinators/core.cljc
+++ b/src/cljc/matcher_combinators/core.cljc
@@ -171,7 +171,8 @@
     [key (match matcher (get actual key ::missing))]))
 
 (defn- with-mismatch-meta
-  "Tags element with data that allows to redact matched data-structures from test output when desired"
+  "Tags element with data that allows abbreviation of matched data-structures
+  in test output when desired"
   [elem mismatch-meta]
   (if #?(:clj (instance? clojure.lang.IMeta elem)
          :cljs (satisfies? IMeta elem))

--- a/src/cljc/matcher_combinators/core.cljc
+++ b/src/cljc/matcher_combinators/core.cljc
@@ -1,6 +1,7 @@
 (ns matcher-combinators.core
   (:require [clojure.math.combinatorics :as combo]
             [clojure.pprint]
+            [clojure.string :as string]
             [matcher-combinators.model :as model]
             [matcher-combinators.result :as result]
             [matcher-combinators.utils :as utils]))
@@ -598,3 +599,7 @@
       (value-match (.toString expected)
                    (.toString actual))))
   (-base-name [_] 'equals))
+
+(defn non-internal-record? [v]
+  (and (record? v)
+       (not (string/starts-with? (-> v type str) "class matcher_combinators.core"))))

--- a/src/cljc/matcher_combinators/matchers.cljc
+++ b/src/cljc/matcher_combinators/matchers.cljc
@@ -1,13 +1,8 @@
 (ns matcher-combinators.matchers
   (:require #?(:cljs [matcher-combinators.core :as core :refer [Matcher Regex Value Absent PredMatcher]]
                :clj [matcher-combinators.core :as core])
-            [clojure.string :as string]
             [matcher-combinators.utils :as utils])
   #?(:clj (:import [matcher_combinators.core Matcher])))
-
-(defn- non-internal-record? [v]
-  (and (record? v)
-       (not (string/starts-with? (-> v type str) "class matcher_combinators.core"))))
 
 (defn equals
   "Matcher that will match when the given value is exactly the same as the
@@ -21,12 +16,20 @@
   for example, continue using their default matcher. If you want to do a deep
   match, consider using `match-with` instead."
   [expected]
-  (cond
-    (sequential? expected)          (core/->EqualsSeq expected)
-    (set? expected)                 (core/->SetEquals expected false)
-    (non-internal-record? expected) (core/->EqualsRecord expected)
-    (map? expected)                 (core/->EqualsMap expected)
-    :else                           (core/->Value expected)))
+  (cond (sequential? expected)
+        (core/->EqualsSeq expected)
+
+        (set? expected)
+        (core/->SetEquals expected false)
+
+        (core/non-internal-record? expected)
+        (core/->EqualsRecord expected)
+
+        (map? expected)
+        (core/->EqualsMap expected)
+
+        :else
+        (core/->Value expected)))
 
 (defn seq-of
   "Matcher that will match when given a sequence where every element matches
@@ -54,12 +57,20 @@
               matched with an element in the provided set. There may be more
               elements in the provided set than there are matchers."
   [expected]
-  (cond
-    (sequential? expected)          (core/->EmbedsSeq expected)
-    (set? expected)                 (core/->SetEmbeds expected false)
-    (non-internal-record? expected) (core/->EqualsRecord expected)
-    (map? expected)                 (core/->EmbedsMap expected)
-    :else                           (core/->InvalidType expected "embeds" "seq, set, map")))
+  (cond (sequential? expected)
+        (core/->EmbedsSeq expected)
+
+        (set? expected)
+        (core/->SetEmbeds expected false)
+
+        (core/non-internal-record? expected)
+        (core/->EqualsRecord expected)
+
+        (map? expected)
+        (core/->EmbedsMap expected)
+
+        :else
+        (core/->InvalidType expected "embeds" "seq, set, map")))
 
 (defn set-embeds
   "Matches a set in the way `(embeds some-set)` would, but accepts sequences

--- a/src/cljc/matcher_combinators/printer.cljc
+++ b/src/cljc/matcher_combinators/printer.cljc
@@ -75,8 +75,8 @@
 (def ellision-marker (EllisionMarker.))
 
 (defn with-ellision-marker
-  "Include `...` in mismatch data-structure to show that match output redaction
-  is enabled"
+  "Include `...` in mismatch data-structure to show that the match output has
+  been abbreviated"
   [expr]
   (cond (or (sequential? expr)
             (set? expr))
@@ -102,7 +102,7 @@
       (= :mismatch-map (:mismatch (meta x)))
       (= :mismatch-sequence (:mismatch (meta x)))))
 
-(defn redacted [expr]
+(defn abbreviated [expr]
   (walk/prewalk (fn [x]
                   (cond (mismatch? x)
                         x
@@ -122,8 +122,8 @@
 (defn pretty-print [expr]
   (pprint/with-pprint-dispatch
     print-diff-dispatch
-    (pprint/pprint (if config/*use-redaction*
-                     ((comp redacted with-ellision-marker) expr)
+    (pprint/pprint (if config/*use-abbreviation*
+                     ((comp abbreviated with-ellision-marker) expr)
                      expr))))
 
 (defn as-string [value]

--- a/src/cljc/matcher_combinators/printer.cljc
+++ b/src/cljc/matcher_combinators/printer.cljc
@@ -70,9 +70,12 @@
       (pprint/simple-dispatch markup))))
 
 (defrecord EllisionMarker [])
-(defmethod markup-expression EllisionMarker [_]
-  '...)
+(defmethod markup-expression EllisionMarker [_] '...)
 (def ellision-marker (EllisionMarker.))
+
+(defrecord EmptyMarker [])
+(defmethod markup-expression EmptyMarker [_] (symbol ""))
+(def empty-marker (EmptyMarker.))
 
 (defn with-ellision-marker
   "Include `...` in mismatch data-structure to show that the match output has
@@ -83,13 +86,14 @@
         (conj expr ellision-marker)
 
         (and (map? expr) (not (core/non-internal-record? expr)))
-        (assoc expr ellision-marker ellision-marker)
+        (assoc expr ellision-marker empty-marker)
 
         :else
         expr))
 
 (defn- mismatch? [expr]
   (or (instance? EllisionMarker expr)
+      (instance? EmptyMarker expr)
       (instance? Mismatch expr)
       (instance? Missing expr)
       (instance? Unexpected expr)

--- a/src/cljc/matcher_combinators/printer.cljc
+++ b/src/cljc/matcher_combinators/printer.cljc
@@ -1,6 +1,7 @@
 (ns matcher-combinators.printer
   (:refer-clojure :exclude [print])
   (:require [clojure.pprint :as pprint]
+            [matcher-combinators.config :as config]
             [matcher-combinators.core :as core]
             #?(:clj  [matcher-combinators.model]
                :cljs [matcher-combinators.model :refer [ExpectedMismatch
@@ -96,30 +97,11 @@
                         x))
                 expr))
 
-(def ^{:dynamic true
-       :doc "thread-local way to control, via `binding`, the redacting of fully-matched data-structures in the matcher-combinator output"}
-  *use-redaction*
-  false)
-
-(defn- set-use-redaction! [v]
-  #?(:clj (alter-var-root #'*use-redaction* (constantly v))
-     :cljs (set! *use-redaction* v)))
-
-(defn enable-redaction!
-  "Thread-global way to enable the redaction of fully-matched data-structures in matcher-combinator output."
-  []
-  (set-use-redaction! true))
-
-(defn disable-redaction!
-  "Thread-global way to disable the redaction of fully-matched data-structures in matcher-combinator output."
-  []
-  (set-use-redaction! false))
-
 (defn pretty-print [expr]
   (pprint/with-pprint-dispatch
     print-diff-dispatch
     (pprint/pprint (cond-> expr
-                     *use-redaction*
+                     config/*use-redaction*
                      redacted))))
 
 (defn as-string [value]

--- a/test/clj/matcher_combinators/config_test.clj
+++ b/test/clj/matcher_combinators/config_test.clj
@@ -1,0 +1,32 @@
+(ns matcher-combinators.config-test
+  (:require [clojure.test :refer [deftest is testing]]
+            [colorize.core :as colorize]
+            [matcher-combinators.config :as config]
+            [matcher-combinators.core :as c]
+            [matcher-combinators.printer :as printer]))
+
+(deftest ansi-color-test
+  (testing "with color"
+    (config/enable-ansi-color!)
+    (is (= (str "(unexpected " (colorize/red 1) ")\n")
+           (printer/as-string (list 'unexpected (printer/->ColorTag :red 1))))))
+  (testing "disable coloring"
+    (config/disable-ansi-color!)
+    (is (= (str "(unexpected 1)\n")
+           (printer/as-string (list 'unexpected (printer/->ColorTag :red 1))))))
+    (config/enable-ansi-color!))
+
+(deftest redact-matched-output-test
+  (matcher-combinators.config/disable-redaction!)
+  (is (= (str "[1\n 2\n {:a 2,\n  :b [4 (mismatch (expected " (colorize/yellow 5) ") (actual " (colorize/red 6) "))],\n  :c [2 [3 4]]}]\n")
+         (printer/as-string
+           (:matcher-combinators.result/value
+             (c/match [1 2 {:a 2 :b [4 5] :c [2 [3 4]]}]
+                      [1 2 {:a 2 :b [4 6] :c [2 [3 4]]}])))))
+
+  (matcher-combinators.config/enable-redaction!)
+  (is (= (str "[{:b [(mismatch (expected " (colorize/yellow 5) ") (actual " (colorize/red 6) "))]}]\n")
+         (printer/as-string
+           (:matcher-combinators.result/value
+             (c/match [1 2 {:a 2 :b [4 5] :c [2 [3 4]]}]
+                      [1 2 {:a 2 :b [4 6] :c [2 [3 4]]}]))))))

--- a/test/clj/matcher_combinators/config_test.clj
+++ b/test/clj/matcher_combinators/config_test.clj
@@ -3,7 +3,8 @@
             [colorize.core :as colorize]
             [matcher-combinators.config :as config]
             [matcher-combinators.core :as c]
-            [matcher-combinators.printer :as printer]))
+            [matcher-combinators.printer :as printer]
+            matcher-combinators.test))
 
 (defn set-config-defaults! []
   (config/enable-ansi-color!)
@@ -32,7 +33,7 @@
                       [1 2 {:a 2 :b [4 6] :c [2 [3 4]]}])))))
 
   (config/enable-abbreviation!)
-  (is (= (str "{:stuff [{:b [(mismatch (expected " (colorize/yellow 5) ") (actual " (colorize/red 6) "))]}],\n ... ...}\n")
+  (is (= (str "{:stuff [{:b [(mismatch (expected " (colorize/yellow 5) ") (actual " (colorize/red 6) "))]}],\n ... }\n")
          (printer/as-string
            (:matcher-combinators.result/value
              (c/match {:stuff [1 2 {:a 2 :b [4 5] :c [2 [3 4]]}]}

--- a/test/clj/matcher_combinators/config_test.clj
+++ b/test/clj/matcher_combinators/config_test.clj
@@ -7,7 +7,7 @@
 
 (defn set-config-defaults! []
   (config/enable-ansi-color!)
-  (config/disable-redaction!))
+  (config/disable-abbreviation!))
 
 (use-fixtures :each
               (fn [t]
@@ -24,14 +24,14 @@
     (is (= (str "(unexpected 1)\n")
            (printer/as-string (list 'unexpected (printer/->ColorTag :red 1)))))))
 
-(deftest redact-matched-output-test
+(deftest abbreviated-matched-output-test
   (is (= (str "[1\n 2\n {:a 2,\n  :b [4 (mismatch (expected " (colorize/yellow 5) ") (actual " (colorize/red 6) "))],\n  :c [2 [3 4]]}]\n")
          (printer/as-string
            (:matcher-combinators.result/value
              (c/match [1 2 {:a 2 :b [4 5] :c [2 [3 4]]}]
                       [1 2 {:a 2 :b [4 6] :c [2 [3 4]]}])))))
 
-  (config/enable-redaction!)
+  (config/enable-abbreviation!)
   (is (= (str "{:stuff [{:b [(mismatch (expected " (colorize/yellow 5) ") (actual " (colorize/red 6) "))]}],\n ... ...}\n")
          (printer/as-string
            (:matcher-combinators.result/value

--- a/test/clj/matcher_combinators/config_test.clj
+++ b/test/clj/matcher_combinators/config_test.clj
@@ -1,31 +1,44 @@
 (ns matcher-combinators.config-test
-  (:require [clojure.test :refer [deftest is testing]]
+  (:require [clojure.test :refer [deftest is testing use-fixtures]]
             [colorize.core :as colorize]
             [matcher-combinators.config :as config]
             [matcher-combinators.core :as c]
             [matcher-combinators.printer :as printer]))
 
+(defn set-config-defaults! []
+  (config/enable-ansi-color!)
+  (config/disable-redaction!))
+
+(use-fixtures :each
+              (fn [t]
+                (set-config-defaults!)
+                (t)
+                (set-config-defaults!)))
+
 (deftest ansi-color-test
   (testing "with color"
-    (config/enable-ansi-color!)
     (is (= (str "(unexpected " (colorize/red 1) ")\n")
            (printer/as-string (list 'unexpected (printer/->ColorTag :red 1))))))
   (testing "disable coloring"
     (config/disable-ansi-color!)
     (is (= (str "(unexpected 1)\n")
-           (printer/as-string (list 'unexpected (printer/->ColorTag :red 1))))))
-    (config/enable-ansi-color!))
+           (printer/as-string (list 'unexpected (printer/->ColorTag :red 1)))))))
 
 (deftest redact-matched-output-test
-  (matcher-combinators.config/disable-redaction!)
   (is (= (str "[1\n 2\n {:a 2,\n  :b [4 (mismatch (expected " (colorize/yellow 5) ") (actual " (colorize/red 6) "))],\n  :c [2 [3 4]]}]\n")
          (printer/as-string
            (:matcher-combinators.result/value
              (c/match [1 2 {:a 2 :b [4 5] :c [2 [3 4]]}]
                       [1 2 {:a 2 :b [4 6] :c [2 [3 4]]}])))))
 
-  (matcher-combinators.config/enable-redaction!)
-  (is (= (str "[{:b [(mismatch (expected " (colorize/yellow 5) ") (actual " (colorize/red 6) "))]}]\n")
+  (config/enable-redaction!)
+  (is (= (str "{:stuff [{:b [(mismatch (expected " (colorize/yellow 5) ") (actual " (colorize/red 6) "))]}],\n ... ...}\n")
+         (printer/as-string
+           (:matcher-combinators.result/value
+             (c/match {:stuff [1 2 {:a 2 :b [4 5] :c [2 [3 4]]}]}
+                      {:stuff [1 2 {:a 2 :b [4 6] :c [2 [3 4]]}]})))))
+
+  (is (= (str "[{:b [(mismatch (expected " (colorize/yellow 5) ") (actual " (colorize/red 6) "))]} ...]\n")
          (printer/as-string
            (:matcher-combinators.result/value
              (c/match [1 2 {:a 2 :b [4 5] :c [2 [3 4]]}]

--- a/version.edn
+++ b/version.edn
@@ -1,4 +1,4 @@
 {:major 3
  :minor 8
- :release 6
+ :release 7
 #_#_ :qualifier :alpha}


### PR DESCRIPTION
addresses https://github.com/nubank/matcher-combinators/issues/159 by allowing user to manually turn on output redaction, which removes all fully-matched data-structures from the output. When output is redacted a `'...` entry is added to the top level mismatching data-structure. This helps keep the context that what you are seeing isn't the actual full form.

### For maps
```clojure
(matcher-combinators.config/disable-abbreviation!)
(is (match? {:a [1 2 {:a 2 :b [4 5] :c [2 [3 4]]}]}
            {:a [1 2 {:a 2 :b [4 6] :c [2 [3 4]]}]})
    "this is standard output")

(matcher-combinators.config/enable-abbreviation!)
(is (match? {:a [1 2 {:a 2 :b [4 5] :c [2 [3 4]]}]}
            {:a [1 2 {:a 2 :b [4 6] :c [2 [3 4]]}]})
    "this is abbreviated")
```
we get:
![20230901_13h25m55s_grim](https://github.com/nubank/matcher-combinators/assets/94817/1e5e298a-3247-42ca-8d00-77e5b31ba003)

### for sequences

```clojure
(matcher-combinators.config/disable-abbreviation!)
(is (match? [1 2 {:a 2 :b [4 5] :c [2 [3 4]]}]
            [1 2 {:a 2 :b [4 6] :c [2 [3 4]]}])
    "this is standard output")

(matcher-combinators.config/enable-abbreviation!)
(is (match? [1 2 {:a 2 :b [4 5] :c [2 [3 4]]}]
            [1 2 {:a 2 :b [4 6] :c [2 [3 4]]}])
    "this is abbreviated output")
```

![20230901_13h25m34s_grim](https://github.com/nubank/matcher-combinators/assets/94817/bfd37080-2204-4e51-9103-2acb88dd16c4)
