### PR TITLE
Fix more issues when using non-composite matchers (`m/regex`, `m/pred`, etc)   inside `match-with`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@ All notable changes to this project will be documented in this file. This
 change log follows the conventions of
 [keepachangelog.com](http://keepachangelog.com/).
 
+## 3.8.7 / 2023-08-31
+- fix more issues when using non-composite matchers (`m/regex`, `m/pred`, etc)
+  inside `match-with`.
+
 ## 3.8.6 / 2023-07-18
 - fix issue when using non-composite matchers (`m/regex`, `m/pred`, etc)
   inside `match-with`.

--- a/bb.edn
+++ b/bb.edn
@@ -26,7 +26,8 @@
 
   test:node
   {:doc "run ClojureScript tests via node"
-   :task (apply clojure "-M:cljs-test compile cli-test" *command-line-args*)}
+   :task (do (apply clojure "-M:cljs-test compile cli-test" *command-line-args*)
+             (shell "node ./out/node-tests.js"))}
 
   test:browser
   {:doc "run ClojureScript tests in browser at `http://localhost:9158/`"

--- a/shadow-cljs.edn
+++ b/shadow-cljs.edn
@@ -2,8 +2,7 @@
  :source-paths ["src/clj" "src/cljc" "src/cljs" "test"]
  :builds {:cli-test {:target    :node-test
                      :output-to "out/node-tests.js"
-                     :ns-regexp "-test$"
-                     :autorun   true}
+                     :ns-regexp "-test$"}
           :browser-test {:target           :browser-test
                          :test-dir         "out/public/js/test"
                          :ns-regexp        "-test$"

--- a/src/cljc/matcher_combinators/matchers.cljc
+++ b/src/cljc/matcher_combinators/matchers.cljc
@@ -1,5 +1,5 @@
 (ns matcher-combinators.matchers
-  (:require #?(:cljs [matcher-combinators.core :as core :refer [Matcher]]
+  (:require #?(:cljs [matcher-combinators.core :as core :refer [Matcher Regex Value Absent PredMatcher]]
                :clj [matcher-combinators.core :as core])
             [clojure.string :as string]
             [matcher-combinators.utils :as utils])
@@ -224,7 +224,10 @@
          (update value :expected match-with-elements overrides)
 
          ;; non-nested matcher like `(m/equals 1)` or `(m/regex #"hi")`
-         (instance? Matcher value)
+         #?(:clj (instance? Matcher value)
+            ;; TODO: how do you do this in a comprehensive way?
+            ;; `(satisfies? Matcher value)` doesn't seem to work
+            :cljs (#{Absent PredMatcher Regex Value} (type value)))
          value
 
          (map? value)

--- a/version.edn
+++ b/version.edn
@@ -1,4 +1,4 @@
 {:major 3
  :minor 8
- :release 6
+ :release 7
 #_#_ :qualifier :alpha}


### PR DESCRIPTION
follow-up to https://github.com/nubank/matcher-combinators/pull/213/ because it left some of the CLJS tests failing (I guess they don't fail CI; will need to look into that)