### PR TITLE
Adapt abbreviation algorithm to not visit complete mismatch structures

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,11 @@ All notable changes to this project will be documented in this file. This
 change log follows the conventions of
 [keepachangelog.com](http://keepachangelog.com/).
 
+## 3.8.8 / 2023-09-04
+- refine abbreviation logic to not descend into fully mismatched data, because
+  there is nothing to filter out in such sub-elements and it can cause issues
+  with datomic entities
+
 ## 3.8.7 / 2023-09-01
 - introduce `matcher-combinators.config` namespace to toggle use of ansi color
   codes and the new output abbreviation mode.

--- a/src/cljc/matcher_combinators/printer.cljc
+++ b/src/cljc/matcher_combinators/printer.cljc
@@ -108,7 +108,7 @@
 
 (defn- prewalk-with-skip
   "A specialization of clojure.prewalk that adds a predicate that stops
-  recurssion when satisfied"
+  recursion when satisfied."
   [f skip? form]
   (cond (skip? form)
         form

--- a/src/cljc/matcher_combinators/printer.cljc
+++ b/src/cljc/matcher_combinators/printer.cljc
@@ -91,10 +91,9 @@
         :else
         expr))
 
-(defn- mismatch? [expr]
+(defn- complete-mismatch? [expr]
   (or (instance? EllisionMarker expr)
       (instance? EmptyMarker expr)
-      (instance? Mismatch expr)
       (instance? Missing expr)
       (instance? Unexpected expr)
       (instance? InvalidMatcherType expr)
@@ -102,26 +101,53 @@
       (instance? TypeMismatch expr)))
 
 (defn- mismatch+? [x]
-  (or (mismatch? x)
+  (or (complete-mismatch? x)
+      (instance? Mismatch x)
       (= :mismatch-map (:mismatch (meta x)))
       (= :mismatch-sequence (:mismatch (meta x)))))
 
+(defn- prewalk-with-skip
+  "A specialization of clojure.prewalk that adds a predicate that stops
+  recurssion when satisfied"
+  [f skip? form]
+  (cond (skip? form)
+        form
+
+        (list? form)
+        (apply list (map f form))
+
+        #?(:clj (instance? clojure.lang.IMapEntry form)
+           :cljs (map-entry? form))
+        #?(:clj (vec (map f form))
+           :cljs (MapEntry. (f (key form)) (f (val form)) nil))
+
+        (seq? form)
+        (doall (map f form))
+
+        #?(:clj (instance? clojure.lang.IRecord form)
+           :cljs (record? form))
+        (reduce (fn [r x] (conj r (f x))) form form)
+
+        (coll? form)
+        (into (empty form) (map f form))
+
+        :else
+        form))
+
+(defn abbreviate-expr [expr]
+  (cond (= :mismatch-map (:mismatch (meta expr)))
+        ;; keep only mismatched data from the mismatched map
+        (into {} (filter (fn [[_k v]] (mismatch+? v))) expr)
+
+        (= :mismatch-sequence (:mismatch (meta expr)))
+        ;; keep only mismatched data from the sequence
+        (#'core/type-preserving-mismatch (empty expr) (filter mismatch+? expr))
+
+        :else
+        expr))
+
 (defn abbreviated [expr]
-  (walk/prewalk (fn [x]
-                  (cond (mismatch? x)
-                        x
-
-                        (= :mismatch-map (:mismatch (meta x)))
-                        ;; keep only mismatched data from the mismatched map
-                        (into {} (filter (fn [[_k v]] (mismatch+? v))) x)
-
-                        (= :mismatch-sequence (:mismatch (meta x)))
-                        ;; keep only mismatched data from the sequence
-                        (#'core/type-preserving-mismatch (empty x) (filter mismatch+? x))
-
-                        :else
-                        x))
-                expr))
+  (prewalk-with-skip abbreviated complete-mismatch? (abbreviate-expr expr)))
 
 (defn pretty-print [expr]
   (pprint/with-pprint-dispatch

--- a/test/clj/matcher_combinators/printer_test.clj
+++ b/test/clj/matcher_combinators/printer_test.clj
@@ -59,3 +59,33 @@
       (is (= "{:aaaaaaaaaaaa [100000000 100000000 100000000 100000000 100000000],\n :bbbbbbbbbbbb [200000000 200000000 200000000 200000000 200000000]}\n"
              (printer/as-string {:aaaaaaaaaaaa [100000000 100000000 100000000 100000000 100000000]
                                  :bbbbbbbbbbbb [200000000 200000000 200000000 200000000 200000000]}))))))
+
+(deftype ExampleEntityMap [attrs]
+  clojure.lang.Associative
+  (containsKey [_ k] (.containsKey attrs k))
+  (entryAt [_ k]      (when (.containsKey attrs k)
+                           (clojure.lang.MapEntry/create k (.get attrs k))))
+  #_(assoc [_this k v])
+
+    clojure.lang.ILookup
+    (valAt [_ k]         (when (.containsKey attrs k)
+                                  (.get attrs k)))
+
+    (valAt [_ k _] (cond (.containsKey attrs k)
+                                  (.get attrs k)))
+
+
+    clojure.lang.Counted
+    (count [_] (.count attrs))
+
+    clojure.lang.IPersistentCollection
+    #_(cons  [this o] )
+    (empty [this]  this) ;; mimic empty from datomic EntityMap; this is what messes with clojure.walk
+    (equiv [this o] (.equals this o))
+
+    clojure.lang.Seqable
+    (seq [_] (seq attrs)))
+
+(deftest abbreviation-test
+  (testing "Abbreviation doesn't descend into complete mismatch data (doing so would result in an exception)"
+    (is (printer/abbreviated (model/->Missing (->ExampleEntityMap {:a 1}))))))

--- a/test/clj/matcher_combinators/printer_test.clj
+++ b/test/clj/matcher_combinators/printer_test.clj
@@ -63,28 +63,30 @@
 (deftype ExampleEntityMap [attrs]
   clojure.lang.Associative
   (containsKey [_ k] (.containsKey attrs k))
-  (entryAt [_ k]      (when (.containsKey attrs k)
-                           (clojure.lang.MapEntry/create k (.get attrs k))))
+  (entryAt [_ k] (when (.containsKey attrs k)
+                   (clojure.lang.MapEntry/create k (.get attrs k))))
   #_(assoc [_this k v])
 
-    clojure.lang.ILookup
-    (valAt [_ k]         (when (.containsKey attrs k)
-                                  (.get attrs k)))
+  clojure.lang.ILookup
+  (valAt [_ k] (when (.containsKey attrs k)
+                 (.get attrs k)))
 
-    (valAt [_ k _] (cond (.containsKey attrs k)
-                                  (.get attrs k)))
+  (valAt [_ k _] (cond (.containsKey attrs k)
+                       (.get attrs k)))
 
+  clojure.lang.Counted
+  (count [_] (.count attrs))
 
-    clojure.lang.Counted
-    (count [_] (.count attrs))
+  clojure.lang.IPersistentCollection
+  #_(cons  [this o])
 
-    clojure.lang.IPersistentCollection
-    #_(cons  [this o] )
-    (empty [this]  this) ;; mimic empty from datomic EntityMap; this is what messes with clojure.walk
-    (equiv [this o] (.equals this o))
+  ;; sorta mimic empty from datomic EntityMap
+  ;; this + no cons/assoc impl is messes with clojure.walk:
+  (empty [this] this)
+  (equiv [this o] (.equals this o))
 
-    clojure.lang.Seqable
-    (seq [_] (seq attrs)))
+  clojure.lang.Seqable
+  (seq [_] (seq attrs)))
 
 (deftest abbreviation-test
   (testing "Abbreviation doesn't descend into complete mismatch data (doing so would result in an exception)"

--- a/version.edn
+++ b/version.edn
@@ -1,4 +1,4 @@
 {:major 3
  :minor 8
- :release 7
+ :release 8
 #_#_ :qualifier :alpha}


### PR DESCRIPTION
I was testing the [experimental abbreviation feature](https://github.com/nubank/matcher-combinators/pull/214) on a list of datomic entities and noticed some new exceptions.
Datomic entities are tricky to work with in the presence of `clojure.walk` functions because you can't assoc/cons onto them. Generally matcher-combinators doesn't work too well on them but because of this. 

In this particular case, I realized that it was because the walk was descending into missing/unexpected data, which shouldn't be abbreviated at all. If that data is a datomic entity, it raises an exception. So to avoid such exceptions, and data traversal, I added a patched version of prewalk that allows not descending into elements that satisfy a predicate.