### PR TITLE
Create nested-equals matcher

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@ All notable changes to this project will be documented in this file. This
 change log follows the conventions of
 [keepachangelog.com](http://keepachangelog.com/).
 
+## 3.9.0 / 2024-01-26
+- Add `strictly-equals` matcher, which always uses `equals` matcher at every level of nesting.
+
 ## 3.8.8 / 2023-09-04
 - refine abbreviation logic to not descend into fully mismatched data, because
   there is nothing to filter out in such sub-elements and it can cause issues

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,8 +3,8 @@ All notable changes to this project will be documented in this file. This
 change log follows the conventions of
 [keepachangelog.com](http://keepachangelog.com/).
 
-## 3.9.0 / 2024-01-26
-- Add `strictly-equals` matcher, which always uses `equals` matcher at every level of nesting.
+## 3.9.0 / 2024-02-01
+- Add `nested-equals` matcher, which always uses `equals` matcher at every level of nesting.
 
 ## 3.8.8 / 2023-09-04
 - refine abbreviation logic to not descend into fully mismatched data, because

--- a/README.md
+++ b/README.md
@@ -163,6 +163,7 @@ for a specific value, e.g.
          - Note: Given that the default matcher for maps is `embeds`, nested maps continue being matched with embeds (instead of also being matched with `equals`). Check out 'Overriding default matchers' below for instructions on how to match nested maps with equals too.
   - sequence: matches when the `expected` sequences's matchers match the given sequence. Similar to midje's `(just expected)`
   - set: matches when all the elements in the given set can be matched with a matcher in `expected` set and each matcher is used exactly once.
+- `strictly equals`: overrides map's default matchers to `equals`, using it for nested structures (see Overriding default matchers, below)
 - `embeds` operates over maps, sequences, and sets
   - map: matches when the map contains some of the same key/values as the `expected` map.
   - sequence: order-agnostic matcher that will match when provided a subset of the `expected` sequence. Similar to midje's `(contains expected :in-any-order :gaps-ok)`
@@ -264,11 +265,11 @@ For example, if you want to do exact map matching you need to use a log of `m/eq
               {:a {:b {:c 1 :extra-c 0} :extra-b 0} :extra-a 0})))
 ```
 
-This verbosity can be avoided by redefining the matcher data-type defaults using the `match-with` matcher:
+For convenience we've also added the built-in matcher `strictly-equals` to reduce this verbosity:
 
 ``` clojure
 (deftest exact-map-matching-with-match-with
-  (is (match? (m/match-with [map? m/equals] {:a {:b {:c odd?}}}))
+  (is (match? (m/strictly-equals {:a {:b {:c odd?}}}))
               {:a {:b {:c 1}}}))
 ```
 

--- a/README.md
+++ b/README.md
@@ -163,7 +163,7 @@ for a specific value, e.g.
          - Note: Given that the default matcher for maps is `embeds`, nested maps continue being matched with embeds (instead of also being matched with `equals`). Check out 'Overriding default matchers' below for instructions on how to match nested maps with equals too.
   - sequence: matches when the `expected` sequences's matchers match the given sequence. Similar to midje's `(just expected)`
   - set: matches when all the elements in the given set can be matched with a matcher in `expected` set and each matcher is used exactly once.
-- `strictly equals`: overrides map's default matchers to `equals`, using it for nested structures (see Overriding default matchers, below)
+- `nested-equals`: overrides map's default matchers to `equals`, using it for nested structures (see Overriding default matchers, below)
 - `embeds` operates over maps, sequences, and sets
   - map: matches when the map contains some of the same key/values as the `expected` map.
   - sequence: order-agnostic matcher that will match when provided a subset of the `expected` sequence. Similar to midje's `(contains expected :in-any-order :gaps-ok)`
@@ -265,11 +265,11 @@ For example, if you want to do exact map matching you need to use a log of `m/eq
               {:a {:b {:c 1 :extra-c 0} :extra-b 0} :extra-a 0})))
 ```
 
-For convenience we've also added the built-in matcher `strictly-equals` to reduce this verbosity:
+For convenience we've also added the built-in matcher `nested-equals` to reduce this verbosity:
 
 ``` clojure
 (deftest exact-map-matching-with-match-with
-  (is (match? (m/strictly-equals {:a {:b {:c odd?}}}))
+  (is (match? (m/nested-equals {:a {:b {:c odd?}}}))
               {:a {:b {:c 1}}}))
 ```
 

--- a/src/cljc/matcher_combinators/matchers.cljc
+++ b/src/cljc/matcher_combinators/matchers.cljc
@@ -34,13 +34,17 @@
 (declare match-with)
 
 (defn strictly-equals
-  "Return a matcher for the expected value which matches nested maps with `equals`.
-  This solves a common need of matching nested maps with strict equality.
-  See also: `match-with`.
+  "A matcher that always uses the `equals` matcher at every level of nesting.
 
-  Usage:
-    (is (match? (strictly-equals {:a :b})
-                {:a :b :c :d}))"
+  Useful given that matchers usually only change the first level of the data
+  they are applied to, leaving nested data to use the default matcher of that
+  type of data. For instance, this can be used to assert that any nested map
+  has exactly the same keys and matching values as provided in the `expected`,
+  and no more.
+
+  Note: this excludes functions, which continue to be invoked
+  as predicates, and regex, which continue to be invoked with `regex`,
+  instead of being compared via the `equals` matcher."
   [expected]
   (match-with [map? equals] expected))
 

--- a/src/cljc/matcher_combinators/matchers.cljc
+++ b/src/cljc/matcher_combinators/matchers.cljc
@@ -31,6 +31,19 @@
         :else
         (core/->Value expected)))
 
+(declare match-with)
+
+(defn deep-equals
+  "Return a matcher for the expected value which matches nested maps with `equals`.
+  This solves a common need of matching nested maps with strict equality.
+  See also: `match-with`.
+
+  Usage:
+    (is (match? (deep-equals {:a :b})
+                {:a :b :c :d}))"
+  [expected]
+  (match-with [map? equals] expected))
+
 (defn seq-of
   "Matcher that will match when given a sequence where every element matches
   the provided `expected` matcher. It expects a non-empty sequence."
@@ -183,8 +196,6 @@
            first
            last)
       (matcher-for value)))
-
-(declare match-with)
 
 (defn- match-with-values [m overrides]
   (reduce-kv (fn [m* k v] (assoc m* k (match-with overrides v)))

--- a/src/cljc/matcher_combinators/matchers.cljc
+++ b/src/cljc/matcher_combinators/matchers.cljc
@@ -33,7 +33,7 @@
 
 (declare match-with)
 
-(defn strictly-equals
+(defn nested-equals
   "A matcher that always uses the `equals` matcher at every level of nesting.
 
   Useful given that matchers usually only change the first level of the data

--- a/src/cljc/matcher_combinators/matchers.cljc
+++ b/src/cljc/matcher_combinators/matchers.cljc
@@ -33,13 +33,13 @@
 
 (declare match-with)
 
-(defn deep-equals
+(defn strictly-equals
   "Return a matcher for the expected value which matches nested maps with `equals`.
   This solves a common need of matching nested maps with strict equality.
   See also: `match-with`.
 
   Usage:
-    (is (match? (deep-equals {:a :b})
+    (is (match? (strictly-equals {:a :b})
                 {:a :b :c :d}))"
   [expected]
   (match-with [map? equals] expected))

--- a/test/clj/matcher_combinators/matchers_test.clj
+++ b/test/clj/matcher_combinators/matchers_test.clj
@@ -361,6 +361,23 @@
                               :d (m/embeds {:e {:inner-e {:x 1 :y 2}}})}})
            actual)))))
 
+(deftest strictly-equals-matcher
+  (testing "passing case with one level map"
+    (is (match? (m/strictly-equals {:a :b})
+                {:a :b})))
+
+  (testing "passing case with multi level map"
+    (is (match? (m/strictly-equals {:a :b :c {:d {:e :f}}})
+                {:a :b :c {:d {:e :f}}})))
+
+  (testing "failing case with one level map"
+    (is (no-match? (m/strictly-equals {:a :b})
+                   {:a :b :c :d})))
+
+  (testing "failing case with multi level map"
+    (is (no-match? (m/strictly-equals {:a :b :c {:d {:e :f}}})
+                   {:a :b :c {:d :e}}))))
+
 (def gen-processable-double
   (gen/double* {:infinite? false :NaN? false}))
 

--- a/test/clj/matcher_combinators/matchers_test.clj
+++ b/test/clj/matcher_combinators/matchers_test.clj
@@ -398,11 +398,11 @@
 
   (testing "regex"
     (testing "`strictly-equals` does not apply `equals` to regex"
-      (is (match? (m/strictly-equals {:x #"\s+"})
+      (is (match? (m/strictly-equals {:x (m/regex #"\w+")})
                   {:x "abc"})))
 
     (testing "`equals` should be aplied directly to the regex to fail"
-      (is (no-match? (m/equals {:x (m/equals #"\s+")})
+      (is (no-match? (m/equals {:x (m/equals (m/regex #"\w+"))})
                      {:x "abc"})))))
 
 (def gen-processable-double

--- a/test/clj/matcher_combinators/matchers_test.clj
+++ b/test/clj/matcher_combinators/matchers_test.clj
@@ -9,8 +9,8 @@
             [matcher-combinators.matchers :as m]
             [matcher-combinators.result :as result]
             [matcher-combinators.test :refer [match?]]
-            [matcher-combinators.test-helpers :as test-helpers :refer [no-match? abs-value-matcher]])
-  (:import [matcher_combinators.model Mismatch Missing InvalidMatcherContext InvalidMatcherType]))
+            [matcher-combinators.test-helpers :refer [abs-value-matcher no-match?]])
+  (:import [matcher_combinators.model InvalidMatcherContext InvalidMatcherType Mismatch Missing]))
 
 (defn any? [_x] true)
 
@@ -362,21 +362,48 @@
            actual)))))
 
 (deftest strictly-equals-matcher
-  (testing "passing case with one level map"
-    (is (match? (m/strictly-equals {:a :b})
-                {:a :b})))
+  (testing "nested maps"
+    (testing "passing case"
+      (is (match? (m/strictly-equals {:user1 {:id 5 :name "hennix"}
+                                      :user2 {:id 3 :name "flynt"}})
+                  {:user1 {:id 5 :name "hennix"}
+                   :user2 {:id 3 :name "flynt"}})))
 
-  (testing "passing case with multi level map"
-    (is (match? (m/strictly-equals {:a :b :c {:d {:e :f}}})
-                {:a :b :c {:d {:e :f}}})))
+    (testing "`strictly-equals` fails when nested maps have extra keys"
+      (is (no-match? (m/strictly-equals {:user1 {:id 5}
+                                         :user2 {:id 3}})
+                     {:user1 {:id 5 :name "hennix"}
+                      :user2 {:id 3 :name "flynt"}})))
 
-  (testing "failing case with one level map"
-    (is (no-match? (m/strictly-equals {:a :b})
-                   {:a :b :c :d})))
+    (testing "`equals` still matchs when nested maps have extra keys"
+      (is (match? (m/equals {:user1 {:id 5}
+                             :user2 {:id 3}})
+                  {:user1 {:id 5 :name "hennix"}
+                   :user2 {:id 3 :name "flynt"}})))
 
-  (testing "failing case with multi level map"
-    (is (no-match? (m/strictly-equals {:a :b :c {:d {:e :f}}})
-                   {:a :b :c {:d :e}}))))
+    (testing "`strictly-equals` is similar to using `equals` in each map"
+      (is (no-match? (m/equals {:user1 (m/equals {:id 5})
+                                :user2 (m/equals {:id 3})})
+                     {:user1 {:id 5 :name "hennix"}
+                      :user2 {:id 3 :name "flynt"}}))))
+
+  (testing "functions"
+    (testing "`strictly-equals` does not apply `equals` to functions"
+      (is (match? (m/strictly-equals {:x odd?})
+                  {:x 1})))
+
+    (testing "`equals` should be aplied directly to the function to fail"
+      (is (no-match? (m/equals {:x (m/equals odd?)})
+                     {:x 1}))))
+
+  (testing "regex"
+    (testing "`strictly-equals` does not apply `equals` to regex"
+      (is (match? (m/strictly-equals {:x #"\s+"})
+                  {:x "abc"})))
+
+    (testing "`equals` should be aplied directly to the regex to fail"
+      (is (no-match? (m/equals {:x (m/equals #"\s+")})
+                     {:x "abc"})))))
 
 (def gen-processable-double
   (gen/double* {:infinite? false :NaN? false}))

--- a/test/clj/matcher_combinators/matchers_test.clj
+++ b/test/clj/matcher_combinators/matchers_test.clj
@@ -361,16 +361,16 @@
                               :d (m/embeds {:e {:inner-e {:x 1 :y 2}}})}})
            actual)))))
 
-(deftest strictly-equals-matcher
+(deftest nested-equals-matcher
   (testing "nested maps"
     (testing "passing case"
-      (is (match? (m/strictly-equals {:user1 {:id 5 :name "hennix"}
+      (is (match? (m/nested-equals {:user1 {:id 5 :name "hennix"}
                                       :user2 {:id 3 :name "flynt"}})
                   {:user1 {:id 5 :name "hennix"}
                    :user2 {:id 3 :name "flynt"}})))
 
-    (testing "`strictly-equals` fails when nested maps have extra keys"
-      (is (no-match? (m/strictly-equals {:user1 {:id 5}
+    (testing "`nested-equals` fails when nested maps have extra keys"
+      (is (no-match? (m/nested-equals {:user1 {:id 5}
                                          :user2 {:id 3}})
                      {:user1 {:id 5 :name "hennix"}
                       :user2 {:id 3 :name "flynt"}})))
@@ -381,15 +381,15 @@
                   {:user1 {:id 5 :name "hennix"}
                    :user2 {:id 3 :name "flynt"}})))
 
-    (testing "`strictly-equals` is similar to using `equals` in each map"
+    (testing "`nested-equals` is similar to using `equals` in each map"
       (is (no-match? (m/equals {:user1 (m/equals {:id 5})
                                 :user2 (m/equals {:id 3})})
                      {:user1 {:id 5 :name "hennix"}
                       :user2 {:id 3 :name "flynt"}}))))
 
   (testing "functions"
-    (testing "`strictly-equals` does not apply `equals` to functions"
-      (is (match? (m/strictly-equals {:x odd?})
+    (testing "`nested-equals` does not apply `equals` to functions"
+      (is (match? (m/nested-equals {:x odd?})
                   {:x 1})))
 
     (testing "`equals` should be aplied directly to the function to fail"
@@ -397,8 +397,8 @@
                      {:x 1}))))
 
   (testing "regex"
-    (testing "`strictly-equals` does not apply `equals` to regex"
-      (is (match? (m/strictly-equals {:x (m/regex #"\w+")})
+    (testing "`nested-equals` does not apply `equals` to regex"
+      (is (match? (m/nested-equals {:x (m/regex #"\w+")})
                   {:x "abc"})))
 
     (testing "`equals` should be aplied directly to the regex to fail"

--- a/version.edn
+++ b/version.edn
@@ -1,4 +1,4 @@
 {:major 3
- :minor 8
- :release 8
+ :minor 9
+ :release 0
 #_#_ :qualifier :alpha}


### PR DESCRIPTION
Create `nested-equals` function to match nested maps with `equals` and providing a documentation closer to the code about the nested behavior for matchers.

See https://github.com/nubank/matcher-combinators/issues/217