### PR TITLE
Bump clojure tools versions

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -36,6 +36,6 @@
 
   :build
   {:extra-deps {slipset/deps-deploy {:mvn/version "0.2.0"}
-                io.github.clojure/tools.build {:git/sha "fe6b1405ba888720c813c7488c03880be73bbe20"}}
+                io.github.clojure/tools.build {:mvn/version "0.9.6"}}
    :extra-paths ["src" "bb"]
    :ns-default build}}}


### PR DESCRIPTION
Even after [adding the license](https://github.com/nubank/matcher-combinators/pull/219) to the POM file, we still [can not deploy to clojars](https://github.com/nubank/matcher-combinators/actions/runs/7820320633/job/21334888472).

After some analysis, I discovered the problem was related to the `tools.deps` version (`0.16.1264`) being used that does not support the usage of the `:pom-data`. 

So I'm bumping the `tools.build` version to generate the correct POM file. I could verify that everything was correct by executing `bb jar` and checking the file on `target/classes/META-INF/maven/nubank/matcher-combinators/pom.xml`