### PR TITLE
Include reporting functions in standalone match result

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,15 @@ All notable changes to this project will be documented in this file. This
 change log follows the conventions of
 [keepachangelog.com](http://keepachangelog.com/).
 
+## 3.10.0 / 2026-01-22
+- include reporting functions in standalone match result
+
+  ```
+  (def result (match {:name "Quercus suber"} {:name "Quercus lusitanica"}))
+  (print! result)
+  (report-clojure-test! result)
+  ```
+
 ## 3.9.2 / 2025-08-20
 - Fix set mismatch info when experimental elision feature is enabled
 

--- a/src/cljc/matcher_combinators/standalone.cljc
+++ b/src/cljc/matcher_combinators/standalone.cljc
@@ -1,6 +1,10 @@
 (ns matcher-combinators.standalone
   "An API for using matcher-combinators outside the context of a test framework"
   (:require [matcher-combinators.core :as core]
+            #?(:cljs [matcher-combinators.cljs-test :as internal.clj-test]
+               :clj  [matcher-combinators.clj-test :as internal.clj-test])
+            #?(:cljs [cljs.test :as t]
+               :clj  [clojure.test :as t])
             [matcher-combinators.parser]))
 
 (defn match
@@ -10,15 +14,45 @@
 
   Return map includes the following keys:
 
-  - :match/result    - either :match or :mismatch
-  - :mismatch/detail - the actual value with mismatch annotations. Only present when :match/result is :mismatch"
+  - :match/result          - either :match or :mismatch
+  - :mismatch/detail       - the actual value with mismatch annotations.
+  - ::pretty-print!        - function that pretty prints the mismatch
+  - ::report-clojure-test! - function that reports failure to clojure.test"
   [matcher actual]
   (let [{:keys [matcher-combinators.result/type
-                matcher-combinators.result/value]}
-        (core/match matcher actual)]
-    (cond-> {:match/result type}
+                matcher-combinators.result/value]
+         :as match-data}
+        (core/match matcher actual)
+        printable-match-data (internal.clj-test/tagged-for-pretty-printing
+                              nil
+                              match-data)]
+    (cond-> {:match/result type
+             ::report-clojure-test! #(t/do-report
+                                       (if (= :mismatch type)
+                                         {:type     :fail
+                                          :expected matcher
+                                          :actual   printable-match-data}
+                                         {:type     :pass
+                                          :expected matcher
+                                          :actual   (list 'match? matcher actual)}))}
       (= :mismatch type)
-      (assoc :mismatch/detail value))))
+      (assoc :mismatch/detail value
+             ::pretty-print! #(print printable-match-data)))))
+
+(defn report-clojure-test!
+  "Given a `match`, report the result to clojure.test"
+  [{report! ::report-clojure-test! :as _match-result}]
+  (report!))
+
+(defn print!
+  "Given a `match`, pretty-print the mismatch data-structure"
+  [{::keys [pretty-print!] :as _match-result}]
+  (pretty-print!))
+
+(comment
+  (def result (match {:name "Quercus suber"} {:name "Quercus lusitanica"}))
+  (print! result)
+  (report-clojure-test! result))
 
 (defn match?
   "Given a `matcher` and `actual`, returns `true` if

--- a/src/cljc/matcher_combinators/standalone.cljc
+++ b/src/cljc/matcher_combinators/standalone.cljc
@@ -46,7 +46,7 @@
 
 (defn print!
   "Given a `match`, pretty-print the mismatch data-structure"
-  [{::keys [pretty-print!] :as _match-result}]
+  [{pretty-print! ::pretty-print! :as _match-result}]
   (pretty-print!))
 
 (comment

--- a/version.edn
+++ b/version.edn
@@ -1,4 +1,4 @@
 {:major 3
- :minor 9
- :release 2
+ :minor 10
+ :release 0
 #_#_ :qualifier :alpha}


### PR DESCRIPTION
Sometimes when using the standalone matching logic it would be nice to have the option to pretty print the mismatch result. For instance could come in handy when doing more repl-driven interactions with the library.


```
(def result (match {:name "Quercus suber"} {:name "Quercus lusitanica"}))
(print! result)
(report-clojure-test! result)
```