### PR TITLE
Don't error on mismatches when `actual` value is a Datomic EntityMap

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@ All notable changes to this project will be documented in this file. This
 change log follows the conventions of
 [keepachangelog.com](http://keepachangelog.com/).
 
+## 3.9.3 / 2026-01-22
+- Don't error on mismatches when `actual` value is a Datomic EntityMap.
+
 ## 3.9.2 / 2025-08-20
 - Fix set mismatch info when experimental elision feature is enabled
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@ All notable changes to this project will be documented in this file. This
 change log follows the conventions of
 [keepachangelog.com](http://keepachangelog.com/).
 
-## 3.9.3 / 2026-01-22
+## 3.10.0 / 2026-01-27
 - Don't error on mismatches when `actual` value is a Datomic EntityMap.
 
 ## 3.9.2 / 2025-08-20

--- a/src/cljc/matcher_combinators/core.cljc
+++ b/src/cljc/matcher_combinators/core.cljc
@@ -192,10 +192,14 @@
       {::result/type   :match
        ::result/value  actual
        ::result/weight 0}
-      (let [mismatch-val (->> entry-results
+      (let [mismatches (->> entry-results
                               (map (fn [[key match-result]] [key (::result/value match-result)]))
-                              (concat unexpected-entries)
-                              (into actual))
+                              (concat unexpected-entries))
+            mismatch-val (try (into actual mismatches)
+                              (catch #?(:clj AbstractMethodError :cljs js/Error) _ame
+                                ;; converts things like Datomic EntityMaps into
+                                ;; maps, so assoc'ing can happen
+                                (into (into {} actual) mismatches)))
             weight        (->> entry-results
                                (map second)
                                (reduce (fn [acc-weight result] (+ acc-weight (::result/weight result)))

--- a/test/clj/matcher_combinators/core_test.clj
+++ b/test/clj/matcher_combinators/core_test.clj
@@ -30,24 +30,26 @@
      {::result/value (model/->Mismatch a b)}
      (core/match (matchers/equals a) b))))
 
+(def map-like
+  (reify Associative
+    (seq [_] (map identity {:a 1}))
+    (valAt [_ k] (get {:a 1} k))
+    (valAt [_ k _] (get {:a 1} k))
+    (equiv [_ _] false)
+    (cons [_ _])))
+
 (deftest map-matchers-support-map-like-actual-values
-  (let [map-like (reify Associative
-                   (seq [_] (map identity {:a 1}))
-                   (valAt [_ k] (get {:a 1} k))
-                   (valAt [_ k _] (get {:a 1} k))
-                   (equiv [_ _] false)
-                   (cons [_ _]))]
-    (testing "map-like test value associative, but not a map or sequential"
-      (is (associative? map-like))
-      (is (not (map? map-like)))
-      (is (not (sequential? map-like))))
-    (testing "embeds"
-      (is (core/indicates-match?
-           (core/match (matchers/embeds {:a 1}) map-like)))
-      (is (not (core/indicates-match?
-                (core/match (matchers/embeds {:a 2}) map-like))))
-      (is (not (core/indicates-match?
-                (core/match (matchers/embeds {:b 1}) map-like)))))))
+  (testing "map-like test value associative, but not a map or sequential"
+    (is (associative? map-like))
+    (is (not (map? map-like)))
+    (is (not (sequential? map-like))))
+  (testing "embeds"
+    (is (core/indicates-match?
+          (core/match (matchers/embeds {:a 1}) map-like)))
+    (is (not (core/indicates-match?
+               (core/match (matchers/embeds {:a 2}) map-like))))
+    (is (not (core/indicates-match?
+               (core/match (matchers/embeds {:b 1}) map-like))))))
 
 (defspec map-matchers-mismatches-when-one-key-has-a-mismatched-value
   {:max-size 10}

--- a/version.edn
+++ b/version.edn
@@ -1,4 +1,4 @@
 {:major 3
  :minor 9
- :release 2
+ :release 3
 #_#_ :qualifier :alpha}

--- a/version.edn
+++ b/version.edn
@@ -1,4 +1,4 @@
 {:major 3
- :minor 9
- :release 3
+ :minor 10
+ :release 0
 #_#_ :qualifier :alpha}


### PR DESCRIPTION
When trying to match for Datomic EntityMap values (or other values that only partially implement `clojure.lang.Associative`), mismatches will result in errors:

```clojure
(is (match? {:x 1} some-datomic-entity-map))
;; Receiver class datomic.api.EntityMap does not define or inherit an implementation of the resolved method 'abstract clojure.lang.IPersistentCollection cons(java.lang.Object)' of interface clojure.lang.IPersistentCollection.
```

This change gets around this by first converting the `actual` to a map so assoc'ing mismatch info is possible.

Note: this change will mean that in specific cases the data-structure returned by the library will not have the exact same type as the provided `actual` value. The chances that this causes confusion are minimal (probably only if you interact with data coming back from the library instead of just test report output).