### PR TITLE
memoize match usages in in-any-order for some speed ups

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@ All notable changes to this project will be documented in this file. This
 change log follows the conventions of
 [keepachangelog.com](http://keepachangelog.com/).
 
+## 3.9.3 / 2026-01-22
+- Improve performance of in-any-order via memoization
+
 ## 3.9.2 / 2025-08-20
 - Fix set mismatch info when experimental elision feature is enabled
 

--- a/src/cljc/matcher_combinators/core.cljc
+++ b/src/cljc/matcher_combinators/core.cljc
@@ -338,10 +338,16 @@
   (or (and subset? (empty? unmatched))
       (and (not subset?) (empty? unmatched) (empty? elements))))
 
+(def ^:private memo-match
+  "Memoized version of match for use in `in-any-order`. Helpful because in the
+  case of a mismatch, `in-any-order` can call match several times on the same
+  input (to compute weight or minimal mismatch details)."
+  (memoize match))
+
 (defn- residual-matching-weight [matchers elements]
   (reduce (fn [w result] (+ w (::result/weight result)))
           0
-          (map match matchers elements)))
+          (map memo-match matchers elements)))
 
 (defn- matches-in-any-order? [unmatched elements subset? matching]
   (if (or (empty? unmatched) (empty? elements))
@@ -352,7 +358,7 @@
        :elements  (concat (map second matching) elements)
        :matched   (map first matching)})
     (let [[matcher & unmatched-rest] unmatched
-          matching-elem              (utils/find-first #(indicates-match? (match matcher %))
+          matching-elem              (utils/find-first #(indicates-match? (memo-match matcher %))
                                                        elements)]
       (if (nil? matching-elem)
         {:matched?  false

--- a/version.edn
+++ b/version.edn
@@ -1,4 +1,4 @@
 {:major 3
  :minor 9
- :release 2
+ :release 3
 #_#_ :qualifier :alpha}


### PR DESCRIPTION
looking for some performance wins for `in-any-order` (see https://github.com/nubank/matcher-combinators/issues/106)

With memoization I'm seeing a 2x speed up for code like this:

```clojure
(require '[matcher-combinators.standalone :refer [match]])

(defn rand-set [size]
  (into #{} (repeatedly size #(rand-int Integer/MAX_VALUE))))

(time
 (run!
  (fn [_]
    (match
      (set [(rand-set 8) (rand-set 8) (rand-set 8)])
      (set [(rand-set 8) (rand-set 8) (rand-set 8)])))
  (range 5)))
```

but then a 2x slowdown for code like this:
```clojure
 (run! (fn [i]
        (println (str "set size: " i))
        (time
         (run!
          (fn [_] (match (rand-set (inc i)) (rand-set i)))
          (range 5))))
      (range 9))
```

I think this is because in the first case, the nesting of sets means that the duplication of `match` calls compounds, so memoization helps a lot. In the second case, the flatness of the sets being matched means that duplicate match calls don't cause a cascade of nested match calls. In this case the memoization overhead of storing and looking up args probably bits us.

I think I'll continue to look into this but see if I can pass state around in the code to reduce duplicate invocations to `match` instead of using memoization