### PR TITLE
fix: allow abbreviation on sorted mismatch maps

### DIFF
--- a/src/cljc/matcher_combinators/printer.cljc
+++ b/src/cljc/matcher_combinators/printer.cljc
@@ -86,7 +86,12 @@
         (conj expr ellision-marker)
 
         (and (map? expr) (not (core/non-internal-record? expr)))
-        (assoc expr ellision-marker empty-marker)
+        ;; Sorted maps require Comparable keys; EllisionMarker is not
+        ;; Comparable, so convert to a plain hash-map before assoc.
+        ;; See https://github.com/nubank/matcher-combinators/issues/234
+        (assoc (if (sorted? expr) (into {} expr) expr)
+               ellision-marker
+               empty-marker)
 
         :else
         expr))

--- a/test/clj/matcher_combinators/printer_test.clj
+++ b/test/clj/matcher_combinators/printer_test.clj
@@ -91,3 +91,11 @@
 (deftest abbreviation-test
   (testing "Abbreviation doesn't descend into complete mismatch data (doing so would result in an exception)"
     (is (printer/abbreviated (model/->Missing (->ExampleEntityMap {:a 1}))))))
+
+(deftest with-ellision-marker-sorted-map
+  (testing "sorted maps can be abbreviated without ClassCastException on non-Comparable keys"
+    (let [result (printer/with-ellision-marker (sorted-map :a 1 :b 2))]
+      (is (map? result))
+      (is (not (sorted? result))
+          "abbreviation should use a hash-map so EllisionMarker keys are legal")
+      (is (contains? result printer/ellision-marker)))))


### PR DESCRIPTION
## Summary
- Convert sorted maps to hash-maps before associating `EllisionMarker` keys during abbreviation.
- Add a unit test that previously would `ClassCastException` on `PersistentTreeMap`.

## Why
`with-ellision-marker` used `assoc` with a non-`Comparable` marker key. Sorted mismatch maps require comparable keys, which surfaces as `ClassCastException` when `*use-abbreviation*` is enabled (issue #234).

Fixes #234

## Test plan
- [x] `matcher-combinators.printer-test/with-ellision-marker-sorted-map`
- [ ] Run printer / full test suite in CI

---

— Felipe Fernandes · Systems & Agentic AI Engineer
https://github.com/felipeofdev-ai · https://felipeofdev-ai.github.io/