### PR TITLE
fix: allow absent inside any-of for missing map keys

### DIFF
--- a/src/cljc/matcher_combinators/core.cljc
+++ b/src/cljc/matcher_combinators/core.cljc
@@ -131,13 +131,19 @@
   Matcher
   (-matcher-for [this] this)
   (-matcher-for [this _] this)
-  (-match [_this _actual]
-    ;; `Absent` should never be matched against directly. That happening means
-    ;; it wasn't used in the context of a map
-    {::result/type  :mismatch
-     ::result/value (model/->InvalidMatcherContext
-                      "`absent` matcher should only be used as the value in a map")
-     ::result/weight 1})
+  (-match [_this actual]
+    ;; Map matching special-cases bare `absent` via `match-kv`. When `absent`
+    ;; is nested (e.g. inside `any-of`), map matching passes `::missing` for a
+    ;; missing key — treat that as a successful absence match (#211).
+    (if (= actual ::missing)
+      {::result/type   :match
+       ::result/value  actual
+       ::result/weight 0}
+      ;; Any other direct use means `absent` wasn't applied as a map value.
+      {::result/type  :mismatch
+       ::result/value (model/->InvalidMatcherContext
+                        "`absent` matcher should only be used as the value in a map")
+       ::result/weight 1}))
   (-base-name [_] 'absent))
 
 (defmethod clojure.pprint/simple-dispatch Absent [absent]

--- a/test/clj/matcher_combinators/matchers_test.clj
+++ b/test/clj/matcher_combinators/matchers_test.clj
@@ -602,6 +602,22 @@
                                      :actual 3}}}
                 (c/match {:a (m/any-of 1 2)} {:a 3}))))
 
+  (testing "`any-of` + `absent` matches when the key is missing (#211)"
+    (is (match? {::result/type  :match
+                 ::result/value {:c 'd}}
+                (c/match {:a (m/any-of 'b m/absent)} {:c 'd})))
+    (is (c/indicates-match?
+         (c/match {:a (m/any-of 'b m/absent)} {:c 'd}))))
+
+  (testing "`any-of` + `absent` still matches when the alternate value is present"
+    (is (match? {::result/type  :match
+                 ::result/value {:a 'b}}
+                (c/match {:a (m/any-of 'b m/absent)} {:a 'b}))))
+
+  (testing "`any-of` + `absent` mismatches when the key has a different value"
+    (is (match? {::result/type :mismatch}
+                (c/match {:a (m/any-of 'b m/absent)} {:a 'c}))))
+
   (testing "`any-of` + `seq-of` works great"
     (is (match? {::result/type :mismatch
                  ::result/value [1 "2" mismatch? 4 "5" mismatch?]}


### PR DESCRIPTION
## Summary
- Teach `Absent` to match the map-matching `::missing` sentinel so `any-of` + `absent` works for missing keys.
- Add regression tests for missing key, present alternate, and mismatched present value.

## Why
Bare `absent` is special-cased in `match-kv`, but nested `absent` (e.g. inside `any-of`) went through `-match`, which always failed — so `{:a (any-of 'b absent)}` never matched a map without `:a`.

Fixes #211

## Test plan
- [x] `clojure -A:dev:clj-test:test-runner -n matcher-combinators.matchers-test` (0 failures)
- [ ] Full CI suite


---

— Felipe Fernandes · Systems & Agentic AI Engineer
https://github.com/felipeofdev-ai · https://felipeofdev-ai.github.io/

Made with [Cursor](https://cursor.com)