### PR TITLE
feat: add entry-embeds matcher for predicate map keys (#132)

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,7 +101,11 @@ For example:
   (is (match? {:name/first "Alfredo"}
               {:name/first  "Alfredo"
                :name/last   "da Rocha Viana"
-               :name/suffix "Jr."}))))
+               :name/suffix "Jr."}))
+
+  ;; Predicate keys are not supported by default map matching; use entry-embeds
+  (is (not (match? {keyword? :b} {:a :b})))
+  (is (match? (m/entry-embeds [[keyword? :b]]) {:a :b})))
 
 (deftest test-matching-nested-datastructures
   ;; Maps, sequences, and sets follow the same semantics whether at
@@ -179,6 +183,8 @@ for a specific value, e.g.
   An alternative to `in-any-order` for cases when inputs are sortable and `in-any-order` has poor performance, such as with large sequences.
 
 - `set-equals`/`set-embeds` similar behavior to `equals`/`embeds` for sets, but allows one to specify the matchers using a sequence so that duplicate matchers are not removed. For example, `(equals #{odd? odd?})` becomes `(equals #{odd})`, so to get around this one should use `(set-equals [odd? odd])`.
+
+- `entry-embeds` opt-in matcher for maps when keys and/or values should be matched with predicates or submatchers. Provide a sequential collection of `[key-matcher value-matcher]` pairs; extra entries in the actual map are ignored. Default map matching uses literal keys only — `(match? {keyword? :b} {:a :b})` does **not** match; use `(match? (m/entry-embeds [[keyword? :b]]) {:a :b})` instead. See [issue #132](https://github.com/nubank/matcher-combinators/issues/132). Like `embeds`/`in-any-order`, avoid large maps.
 
 - `seq-of` takes an expected matcher and creates a new matcher over a sequence, where each element matches the provided expected matcher. Analogous to `clojure.core/every?`, although seq-of expects a non-empty sequence.
 

--- a/src/cljc/matcher_combinators/core.cljc
+++ b/src/cljc/matcher_combinators/core.cljc
@@ -502,6 +502,21 @@
               ::result/value set)))
   (-base-name [_] (if accept-seq? 'set-embeds 'embeds)))
 
+(defn- map->entry-vectors [m]
+  (mapv (fn [[k v]] [k v]) m))
+
+(defrecord EntryEmbeds [expected]
+  Matcher
+  (-matcher-for [this] this)
+  (-matcher-for [this _] this)
+  (-match [this actual]
+    (if-let [issue (validate-input expected actual map? map-like? (-base-name this) "map")]
+      issue
+      (let [entry-matchers (vec expected)
+            actual-entries (map->entry-vectors actual)]
+        (match-any-order entry-matchers actual-entries true))))
+  (-base-name [_] 'entry-embeds))
+
 (defrecord PredMatcher [pred desc]
   Matcher
   (-matcher-for [this] this)

--- a/src/cljc/matcher_combinators/matchers.cljc
+++ b/src/cljc/matcher_combinators/matchers.cljc
@@ -96,6 +96,29 @@
   [expected]
   (core/->SetEmbeds expected true))
 
+(defn entry-embeds
+  "Opt-in matcher for maps whose keys and/or values should be matched with
+  predicates or submatchers instead of literal equality.
+
+  `expected` is a sequential collection of `[key-matcher value-matcher]`
+  pairs. Each pair is matched against some `[key value]` entry in the actual
+  map; extra entries in the actual map are ignored (embeds semantics).
+
+  Default map matching uses literal keys only — predicates in map key
+  position are not supported. Use `entry-embeds` when you need that
+  behaviour, e.g. matching any keyword key:
+
+  ```clojure
+  (is (match? (m/entry-embeds [[keyword? odd?] [:x pos?]])
+              {:a 1 :x -1 :whatever \"foo\"}))
+  ```
+
+  WARNING: like `embeds` and `in-any-order`, this matcher may compare every
+  expected entry with every actual entry to find a best pairing. Avoid large
+  maps."
+  [expected]
+  (core/->EntryEmbeds expected))
+
 (defn in-any-order
   "Matcher that will match when the given a list that is the same as the
   `expected` list but with elements in a different order.

--- a/test/clj/matcher_combinators/core_test.clj
+++ b/test/clj/matcher_combinators/core_test.clj
@@ -598,7 +598,46 @@
                  ::result/weight 1}
                 (core/match (matchers/equals even-odd-set) #{1})))))
 
-(deftest in-any-order-minimal-mismatch-test
+(deftest entry-embeds-test
+  (testing "matches map entries with predicate keys (issue #132)"
+    (is (= {::result/type   :match
+            ::result/value  {:a :b}
+            ::result/weight 0}
+           (core/match (matchers/entry-embeds [[keyword? :b]])
+                       {:a :b})))
+    (is (= {::result/type   :mismatch
+            ::result/weight pos-int?
+            ::result/value  map?}
+           (core/match (matchers/entry-embeds [[keyword? :b]])
+                       {:a :c}))))
+
+  (testing "default map matcher does not match predicate keys"
+    (is (= {::result/type   :mismatch
+            ::result/weight pos-int?
+            ::result/value  map?}
+           (core/match {keyword? :b} {:a :b}))))
+
+  (testing "philomates-style multi-entry matching with extra keys"
+    (is (= {::result/type   :match
+            ::result/value  {:a 1 :x -1 :whatever "foo"}
+            ::result/weight 0}
+           (core/match (matchers/entry-embeds [[keyword? odd?] [:x pos?]])
+                       {:a 1 :x -1 :whatever "foo"}))))
+
+  (testing "duplicate key matchers via entry pairs (symbols)"
+    (is (= {::result/type   :match
+            ::result/value  {'x 1 'y 2}
+            ::result/weight 0}
+           (core/match (matchers/entry-embeds [[symbol? 2] [symbol? 1]])
+                       {'x 1 'y 2}))))
+
+  (testing "mismatches when type is not a map"
+    (is (match? {::result/type   :mismatch
+                 ::result/value  {:expected-type-msg #"^entry-embeds *"
+                                  :actual-type     sequential?
+                                  :provided        "provided: sequential"}
+                 ::result/weight 1}
+                (core/match (matchers/entry-embeds [[keyword? odd?]]) [1 2 3])))))
   (is (= {::result/type   :mismatch
           ::result/value  [{:a "1" :x (model/->Mismatch "12" "12=")}]
           ::result/weight 1}

--- a/test/clj/matcher_combinators/matchers_test.clj
+++ b/test/clj/matcher_combinators/matchers_test.clj
@@ -634,6 +634,15 @@
     (is (match? (m/seq-of (m/all-of integer? odd?))
                 [1 -1 3 -3]))))
 
+(deftest entry-embeds-matcher
+  (testing "clojure.test match? integration"
+    (is (match? (m/entry-embeds [[keyword? odd?] [:x pos?]])
+                {:a 1 :x -1 :whatever "foo"}))
+    (is (match? (m/entry-embeds [[keyword? :b]])
+                {:a :b}))
+    (is (not (match? (m/entry-embeds [[keyword? :b]])
+                     {:a :c})))))
+
 (deftest pred-matcher
   (testing "pred matcher without description argument gives mismatch info with the pred function's object representation"
     (is (match? {::result/type   :mismatch


### PR DESCRIPTION
## Summary

Implements philomates' opt-in approach from #132: a new **`entry-embeds`** matcher for maps whose keys and/or values should be matched with predicates or submatchers.

Default map matching is **unchanged** — literal keys only. Predicate keys like `{keyword? :b}` still do not match `{:a :b}` unless wrapped in `entry-embeds`.

Fixes #132 (opt-in path; documents limitation for default maps)

## Design

Following [philomates' suggestion](https://github.com/nubank/matcher-combinators/issues/132#issuecomment-644965378), map matching with predicate keys is recast as order-agnostic matching over `[key-matcher value-matcher]` entry pairs:

```clojure
(is (match? (m/entry-embeds [[keyword? odd?] [:x pos?]])
            {:a 1 :x -1 :whatever "foo"}))

;; Duplicate key matchers (impossible in literal maps):
(is (match? (m/entry-embeds [[symbol? 2] [symbol? 1]])
            {'x 1 'y 2}))
```

Extra entries in the actual map are ignored (embeds semantics). Runtime is the same class as `embeds` / `in-any-order` — documented warning for large maps.

## Changes

- `EntryEmbeds` record + `entry-embeds` public matcher
- Regression tests covering #132 REPL examples + philomates multi-entry case
- README: documents `entry-embeds` and notes default map behaviour

## Test plan

- [x] New unit tests in `core_test.clj` and `matchers_test.clj`
- [ ] Maintainer CI (Nu workflows)

---

— Felipe Fernandes · Systems & Agentic AI Engineer  
https://github.com/felipeofdev-ai · https://felipeofdev-ai.github.io/
