### PR TITLE
fix: structured standalone detail for missing map keys (#107)

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,6 +135,23 @@ We've deprecated support for [Midje](https://github.com/marick/midje) in `matche
 
 The `matcher-combinators.standalone` namespace provides an API for using matcher-combinators outside the context of a test framework.
 
+When a map mismatch includes missing keys, `:mismatch/detail` is a plain map with explicit keys:
+
+```clojure
+(require '[matcher-combinators.standalone :as standalone]
+         '[matcher-combinators.matchers :as m])
+
+(standalone/match (m/equals {:a 1}) {:b 2})
+;;=> {:match/result :mismatch,
+;;     :mismatch/detail {:value {:b 2}
+;;                       :missing-keys [:a]
+;;                       :missing {:a 1}
+;;                       :unexpected-keys [:b]}
+;;     ...}
+```
+
+`:missing` holds the expected values for keys absent from the actual map. Value mismatches on present keys keep the previous annotated-map shape.
+
 ## Matchers
 
 ### Default matchers

--- a/src/cljc/matcher_combinators/standalone.cljc
+++ b/src/cljc/matcher_combinators/standalone.cljc
@@ -5,7 +5,41 @@
                :clj  [matcher-combinators.clj-test :as internal.clj-test])
             #?(:cljs [cljs.test :as t]
                :clj  [clojure.test :as t])
-            [matcher-combinators.parser]))
+            #?(:clj  [matcher-combinators.model]
+               :cljs [matcher-combinators.model :refer [Missing Unexpected]])
+            [matcher-combinators.parser])
+  #?(:clj
+     (:import [matcher_combinators.model Missing Unexpected])))
+
+(defn- missing? [v] (instance? Missing v))
+(defn- unexpected? [v] (instance? Unexpected v))
+
+(defn- map-mismatch? [value]
+  (and (map? value)
+       (= :mismatch-map (:mismatch (meta value)))))
+
+(defn- structured-map-detail [value]
+  (let [missing-entries     (filter (fn [[_ v]] (missing? v)) value)
+        missing-keys        (vec (map first missing-entries))
+        missing             (into {} (map (fn [[k v]] [k (:expected v)]) missing-entries))
+        unexpected-entries  (filter (fn [[_ v]] (unexpected? v)) value)
+        unexpected-keys     (vec (map first unexpected-entries))
+        mismatch-entries    (remove (fn [[_ v]] (or (missing? v) (unexpected? v))) value)
+        clean-value         (into {}
+                                    (concat
+                                     (map (fn [[k v]] [k (:actual v)]) unexpected-entries)
+                                     mismatch-entries))]
+    (cond-> {}
+      (seq clean-value)     (assoc :value clean-value)
+      (seq missing-keys)    (assoc :missing-keys missing-keys
+                                     :missing missing)
+      (seq unexpected-keys) (assoc :unexpected-keys unexpected-keys))))
+
+(defn- format-mismatch-detail [value]
+  (if (and (map-mismatch? value)
+           (some (fn [[_ v]] (missing? v)) value))
+    (structured-map-detail value)
+    value))
 
 (defn match
   "Returns a map indicating whether the `actual` value matches `expected`.
@@ -15,7 +49,11 @@
   Return map includes the following keys:
 
   - :match/result          - either :match or :mismatch
-  - :mismatch/detail       - the actual value with mismatch annotations.
+  - :mismatch/detail       - mismatch annotations. For map mismatches with
+                              missing keys, a structured map with `:value`,
+                              `:missing-keys`, and `:missing` (expected values
+                              for absent keys). Other map mismatches and
+                              non-map mismatches keep the previous shape.
   - ::pretty-print!        - function that pretty prints the mismatch
   - ::report-clojure-test! - function that reports failure to clojure.test"
   [matcher actual]
@@ -36,7 +74,7 @@
                                           :expected matcher
                                           :actual   (list 'match? matcher actual)}))}
       (= :mismatch type)
-      (assoc :mismatch/detail value
+      (assoc :mismatch/detail (format-mismatch-detail value)
              ::pretty-print! #(print printable-match-data)))))
 
 (defn report-clojure-test!

--- a/test/clj/matcher_combinators/standalone_test.clj
+++ b/test/clj/matcher_combinators/standalone_test.clj
@@ -23,7 +23,21 @@
 
   ;; TODO (dchelimsky,2020-03-11): consider making it a plain datastructure
   (testing ":match/detail binds to a Mismatch object"
-    (is (instance? matcher_combinators.model.Mismatch (:mismatch/detail (standalone/match 37 42))))))
+    (is (instance? matcher_combinators.model.Mismatch (:mismatch/detail (standalone/match 37 42)))))
+
+  (testing ":mismatch/detail surfaces missing map keys explicitly (fixes #107)"
+    (let [detail (:mismatch/detail (standalone/match (m/equals {:a 1}) {:b 2}))]
+      (is (= {:value {:b 2} :missing-keys [:a] :missing {:a 1} :unexpected-keys [:b]} detail)))
+    (let [detail (:mismatch/detail (standalone/match (m/equals {:a 1}) {}))]
+      (is (= {:missing-keys [:a] :missing {:a 1}} detail)))
+    (let [detail (:mismatch/detail (standalone/match (m/equals {:a 1 :c 3}) {:b 2}))]
+      (is (= #{:a :c} (set (:missing-keys detail))))
+      (is (= {:a 1 :c 3} (:missing detail)))
+      (is (= #{:b} (set (:unexpected-keys detail)))))
+    (testing "value mismatches without missing keys keep prior shape"
+      (let [detail (:mismatch/detail (standalone/match (m/equals {:a 1}) {:a 2}))]
+        (is (map? detail))
+        (is (instance? matcher_combinators.model.Mismatch (:a detail)))))))
 
 (deftest test-match?
   (testing "parser defaults"


### PR DESCRIPTION
## Summary
- Restructure `matcher-combinators.standalone/match` `:mismatch/detail` when map mismatches include missing keys.
- Surface `:missing-keys`, `:missing` (expected values), and `:unexpected-keys` instead of embedding `Missing` records that read like partial mismatches.
- Add regression tests and README standalone docs.

## Why
When an expected map key is absent, the standalone API returned entries like `:a #Missing{:expected 1}` inside the detail map. That reads like a value mismatch missing an `:actual` field rather than an absent key — exactly the ambiguity @dchelimsky described in #107 and the TODO in `standalone_test.clj`.

Example before:
```clojure
(standalone/match (m/equals {:a 1}) {:b 2})
;; :mismatch/detail {:b #Unexpected{:actual 2}, :a #Missing{:expected 1}}
```

After:
```clojure
(standalone/match (m/equals {:a 1}) {:b 2})
;; :mismatch/detail {:value {:b 2}
;;                   :missing-keys [:a]
;;                   :missing {:a 1}
;;                   :unexpected-keys [:b]}
```

Core `match` results and pretty-print output are unchanged; only the standalone `:mismatch/detail` shape changes when missing keys are present. Value mismatches on present keys keep the prior annotated-map shape.

Fixes #107

## Test plan
- [x] `clojure -M:dev:clj-test:test-runner` (78 tests, 0 failures)
- [x] `clojure -M:dev:clj-test:test-runner -n matcher-combinators.standalone-test`
- [ ] Full CI (`bb test` — cljs + midje)

---

— Felipe Oliveira Fernandes · Systems & Agentic AI Engineer
https://github.com/felipeofdev-ai · https://felipeofdev-ai.github.io/

Made with [Cursor](https://cursor.com)
